### PR TITLE
Hardcoded in https over protocol-relative links.

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -5,9 +5,9 @@
     <title>Open FEC Beta</title>
     <link href="styles/styles.css" rel="stylesheet" type="text/css"/>
     <link href="js/vendor/chosen/chosen.min.css" rel="stylesheet" type="text/css"/>
-    <link href='//fonts.googleapis.com/css?family=Raleway:300,400,600,700|Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Raleway:300,400,600,700|Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Protocol-relative links are a neat trick, but really more of an anti-pattern when pulling in resources that are certain to be available over SSL.

One version of the resource means caching will work whether the main page is accessed through http or https.
