### PR TITLE
add tablesort to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/theresaanna/openfec-web-app/issues"
   },
   "dependencies": {
-    "handlebars": "^2.0.0"
+    "handlebars": "^2.0.0",
+    "tablesort": "^2.2.3"
   }
 }


### PR DESCRIPTION
I ran `npm run build` (and `watch`) for the first time, and was notified that the `tablesort` package was missing.

```sh
npm install --save tablesort
```

et voilà!