### PR TITLE
Fix state mapping

### DIFF
--- a/openfecwebapp/data_mappings.py
+++ b/openfecwebapp/data_mappings.py
@@ -163,7 +163,7 @@ def map_candidate_page_values(c):
     """
     candidate = {}
     candidate['name'] = c['name']['full_name']
-    candidate['state'] = c['mailing_addresses'][0].get('state', '')
+    candidate['state'] = c['elections'][0].get('state', '')
 
     if c.get('elections'):
         c_e = c['elections'][0]

--- a/openfecwebapp/tests/data_mappings_test.py
+++ b/openfecwebapp/tests/data_mappings_test.py
@@ -93,7 +93,7 @@ class TestDataMappings(TestCase):
         vals = map_candidate_page_values(self.candidate)
 
         self.assertTrue(vals['related_committees'])
-        self.assertEqual(vals['state'], 'CA')
+        self.assertEqual(vals['state'], 'TN')
         self.assertEqual(vals['name'], 'Person McPersonson')
         self.assertEqual('challenger', vals['incumbent_challenge'])
         self.assertEqual('D1234', vals['primary_committee']['id'])


### PR DESCRIPTION
Candidates need to be associated with the state of the office they are running for and not where their office is located.