### PR TITLE
add --cached flag to cache API requests

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,8 @@ from flask import Flask, render_template, request
 from openfecwebapp.views import (render_search_results, render_table,
     render_page)
 from openfecwebapp.api_caller import (load_search_results,
-    load_single_type, load_totals, load_single_type_summary)
+    load_single_type, load_totals, load_single_type_summary,
+    install_cache)
 
 app = Flask(__name__)
 
@@ -56,4 +57,7 @@ def server_error(e):
     return render_template('500.html'), 500
 
 if __name__ == '__main__':
+    import sys
+    if '--cached' in sys.argv:
+        install_cache()
     app.run(host=host, port=int(port), debug=debug)

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -54,3 +54,7 @@ def load_totals(committee_ids):
     }
 
     return _call_api(url, params)
+
+def install_cache():
+    import requests_cache
+    requests_cache.install_cache()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Werkzeug==0.9.6
 itsdangerous==0.24
 nose==1.3.4
 requests==2.5.1
+requests-cache==0.4.9


### PR DESCRIPTION
This PR adds support for a `--cached` flag that enables caching of API calls, facilitating a much faster frontend development workflow. You can run it like so:

```sh
python __init__.py --cached
```

I *almost* put the cache installation code in `__init__.py`, but ended up moving it to `api_caller.py` so that all of the request-specific stuff lived there, which makes it simpler to modify how caching is enabled if we were to ever move away from using `requests` for some reason. Happy to entertain another way of doing this, or to use `argparse` instead of just sniffing `sys.argv`.