### PR TITLE
Populating candidate['office'] with the correct info

### DIFF
--- a/openfecwebapp/data_prep/candidates.py
+++ b/openfecwebapp/data_prep/candidates.py
@@ -30,11 +30,11 @@ def map_candidate_page_values(c):
         candidate['party'] = c_e.get('party_affiliation', '')
         candidate['incumbent_challenge'] = c_e.get(
             'incumbent_challenge_full', '')
+        candidate['office'] = c_e['office_full']
+
         if c_e.get('primary_committee'):
             candidate['primary_committee'] = _map_committee_values(
                 c_e['primary_committee'])
-            candidate['office'] = c_e['primary_committee'].get(
-                'type_full', '')
             candidate['related_committees'] = True
 
         # affiliated committees = committee_type_map, 

--- a/openfecwebapp/tests/mock_data.py
+++ b/openfecwebapp/tests/mock_data.py
@@ -6,7 +6,7 @@ candidate = {
         'party_affiliation': 'Cool People',
         'state': 'TN',
         'election_year': '2012',
-        'office_sought_full': 'Supreme Ruler',
+        'office_full': 'Supreme Ruler',
         'district': '11',
         'incumbent_challenge_full': 'challenger',
         'primary_committee': {


### PR DESCRIPTION
Grabbing the office title from the candidate's object instead of the primary committee's type.

Won’t work until #444 is merged