### PR TITLE
Fixes `npm run sass-build` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "watch": "watchify static/js/init.js -o static/js/app.js --debug --verbose",
     "build": "browserify static/js/init.js > static/js/app.js",
     "sass-watch": "sass --watch static/styles/:static/styles/",
-    "sass-build": "sass static/styles/sass/:static/styles/",
+    "sass-build": "sass static/styles/styles.scss:static/styles/styles.css",
     "watch-all": "npm run watch & npm run sass-watch"
   },
   "repository": {


### PR DESCRIPTION
When running `npm run sass-build` was getting the error:
```
> openfec-web-app@0.0.0 sass-build /Users/msegreto/Developement/openFEC-web-app
> sass static/styles/sass/:static/styles/

Errno::ENOENT: No such file or directory @ rb_sysopen - static/styles/sass/
  Use --trace for backtrace.

npm ERR! openfec-web-app@0.0.0 sass-build: `sass static/styles/sass/:static/styles/`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the openfec-web-app@0.0.0 sass-build script.
npm ERR! This is most likely a problem with the openfec-web-app package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     sass static/styles/sass/:static/styles/
npm ERR! You can get their info via:
npm ERR!     npm owner ls openfec-web-app
npm ERR! There is likely additional logging output above.
npm ERR! System Darwin 13.4.0
npm ERR! command "node" "/usr/local/bin/npm" "run" "sass-build"
npm ERR! cwd /Users/msegreto/Developement/openFEC-web-app
npm ERR! node -v v0.10.32
npm ERR! npm -v 1.4.28
npm ERR! code ELIFECYCLE
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/msegreto/Developement/openFEC-web-app/npm-debug.log
npm ERR! not ok code 0
```

This fixes the error.