### PR TITLE
Miscellaneous updates for Selenium tests.

### DIFF
--- a/openfecwebapp/tests/selenium/base_test_class.py
+++ b/openfecwebapp/tests/selenium/base_test_class.py
@@ -1,7 +1,16 @@
+import os
+import unittest
+
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
-import unittest
 from nose.plugins.attrib import attr
+
+
+drivers = {
+    'phantomjs': lambda: webdriver.PhantomJS(service_args=['--ignore-ssl-errors=true']),
+    'firefox': lambda: webdriver.Firefox(),
+    'chrome': lambda: webdriver.Chrome(),
+}
 
 
 @attr('selenium')
@@ -9,7 +18,7 @@ class BaseTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.driver = webdriver.PhantomJS()
+        cls.driver = drivers[os.getenv('FEC_SELENIUM_DRIVER', 'phantomjs')]()
         cls.driver.set_window_size(2000, 2000)
         cls.base_url = 'http://localhost:3000'
 

--- a/openfecwebapp/tests/selenium/candidates_list_page_test.py
+++ b/openfecwebapp/tests/selenium/candidates_list_page_test.py
@@ -1,8 +1,5 @@
 from .base_test_class import BaseTest
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
 import time
 
 
@@ -41,7 +38,7 @@ class CandidatesPageTests(BaseTest):
         self.assertEqual(
             div.get_attribute('class'),
             'field active')
-        div.find_element_by_tag_name('input').send_keys(Keys.ENTER)
+        self.driver.find_element_by_id('category-filters').submit()
         results = (self.driver.find_elements_by_tag_name('tr'))
         col = [y.find_elements_by_tag_name('td')[index]
                 .text for y in results[1:]]

--- a/openfecwebapp/tests/selenium/committees_list_page_test.py
+++ b/openfecwebapp/tests/selenium/committees_list_page_test.py
@@ -23,7 +23,6 @@ class CommitteesPageTests(BaseTest):
         self.driver.get(self.url)
         self.openFilters()
         cycle = self.getFilterDivByName(name)
-        time.sleep(1)
         cycle.find_element_by_xpath('./div/a/div/b').click()
         self.assertEqual(
             cycle.find_element_by_xpath('./div').get_attribute('class'),
@@ -38,7 +37,7 @@ class CommitteesPageTests(BaseTest):
         self.assertEqual(
             cycle.get_attribute('class'),
             'field active')
-        cycle.find_element_by_tag_name('input').send_keys(Keys.ENTER)
+        self.driver.find_element_by_id('category-filters').submit()
         results = (self.driver.find_elements_by_tag_name('tr'))
         col = [y.find_elements_by_tag_name('td')[index]
                 .text for y in results[1:]]

--- a/openfecwebapp/tests/selenium/error_page_test.py
+++ b/openfecwebapp/tests/selenium/error_page_test.py
@@ -10,7 +10,7 @@ class ErrorPageTests(BaseTest):
         self.driver.get(self.url)
         self.assertEqual(
             self.driver.find_element_by_tag_name('h1').text,
-            'Not Found')
+            'Oops!')
 
     def testErrorPageSearch(self):
         self.driver.get(self.url)


### PR DESCRIPTION
Miscellaneous small changes to make Selenium tests pass in Chrome / Firefox.

* Submit forms using `form.submit()` rather than `input.send_keys(ENTER)`
    * Better cross-browser behavior (i.e. doesn't break Firefox)
* Remove `time.sleep` calls
    * If waits needed, prefer using Selenium explicit wait
* Ignore SSL errors when using PhantomJS
* Allow user to select Selenium webdriver via FEC_SELENIUM_DRIVER
* Fix a failing test