### PR TITLE
Use python3.4 in CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
-python: "3.4"
+language: python
+
+python:
+  - "3.4"
+
+# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
 before_script:
     - cd openfecwebapp
 install:
-    - sudo pip install -r requirements.txt
+    - pip install -r requirements.txt
 script:
     - cd tests
     - nosetests -a '!selenium'


### PR DESCRIPTION
Looks like Travis builds are currently running Python 2.7. This is the boilerplate from Travis's default Python config file.