### PR TITLE
Sauce feedback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,26 @@
 python: "3.4"
+
+sudo: false
+
+addons:
+  sauce_connect: true
+
+env:
+  global:
+    - FEC_WEB_TEST: true
+    - FEC_SELENIUM_DRIVER: remote
+    - FEC_WEB_API_URL: http://fec-dev-api.cf.18f.us
+    - secure: SQfanR6GI/1i4v7XPEKT26mKjd1BT/Qt1/5fjrhEIiA4PL2ZWnvArBmcKeq3q3CcVy2KQDTUr4vvPKbo4HGAw1EcUvnJ5lF6v3h0FmZ/bhMdkHk1e/UvfIVjOm0mEO80FDiXRcWEiYgY/Z4LwJ1l2iNC45j/1Odacj9I3fOdteY=
+    - secure: aXkcjh6AHi1MnY1vZ5Nu8/8OexUZ4n8ul5hrM9iex0QdJAm4AoxF0idHybinTAAL7/gSEineX1to6GC3GVnAV/f/FU1mo8sjt0hvwTAx8b+ONR0M0sJW2KrPJRABQK4Dtxu+PQkE4Qim0GaJQ6LBJwTAB+HiegYymqrUFSV5tm0=
+    - FEC_SAUCE_BROWSER: firefox
+
 before_script:
-    - cd openfecwebapp
-install:
-    - sudo pip install -r requirements.txt
+  - apt-get install python-selenium
+  - pip install -r requirements.txt
+  - npm install
+  - npm install -g browserify
+  - npm run build
+  - python __init__.py &
+
 script:
-    - cd tests
-    - nosetests -a '!selenium'
+  - nosetests openfecwebapp/tests -a "selenium"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,34 @@
 python: "3.4"
 
-sudo: false
-
 addons:
   sauce_connect: true
+  postgresql: "9.3"
 
 env:
   global:
+    - SQLA_CONN="postgresql://:@/cfdm_test"
     - FEC_WEB_TEST: true
     - FEC_SELENIUM_DRIVER: remote
-    - FEC_WEB_API_URL: http://fec-dev-api.cf.18f.us
     - secure: SQfanR6GI/1i4v7XPEKT26mKjd1BT/Qt1/5fjrhEIiA4PL2ZWnvArBmcKeq3q3CcVy2KQDTUr4vvPKbo4HGAw1EcUvnJ5lF6v3h0FmZ/bhMdkHk1e/UvfIVjOm0mEO80FDiXRcWEiYgY/Z4LwJ1l2iNC45j/1Odacj9I3fOdteY=
     - secure: aXkcjh6AHi1MnY1vZ5Nu8/8OexUZ4n8ul5hrM9iex0QdJAm4AoxF0idHybinTAAL7/gSEineX1to6GC3GVnAV/f/FU1mo8sjt0hvwTAx8b+ONR0M0sJW2KrPJRABQK4Dtxu+PQkE4Qim0GaJQ6LBJwTAB+HiegYymqrUFSV5tm0=
     - FEC_SAUCE_BROWSER: firefox
 
 before_script:
-  - apt-get install python-selenium
-  - pip install -r requirements.txt
+  - sudo pip install -r requirements.txt
   - npm install
   - npm install -g browserify
   - npm run build
   - python __init__.py &
+
+  - git clone git@github.com:18F/openFEC.git@master
+  - cd openFEC
+  - psql -c 'create database cfdm_test;' -U postgres
+  - md5sum data/cfdm_test.pgdump.sql
+  - psql -f data/cfdm_test.pgdump.sql -U postgres cfdm_test
+  - psql -c "SELECT count(*) FROM dimcand" -U postgres cfdm_test
+  - pip install -r requirements.txt
+  - python manage.py update_schemas
+  - python manage.py runserver &
 
 script:
   - nosetests openfecwebapp/tests -a "selenium"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
-python: "3.4"
+language: python
+
+python:
+  - "3.4"
 
 addons:
   sauce_connect: true
@@ -6,11 +9,12 @@ addons:
 
 env:
   global:
-    - SQLA_CONN="postgresql://:@/cfdm_test"
     - FEC_WEB_TEST: true
     - FEC_SELENIUM_DRIVER: remote
+    - SQLA_CONN: "postgresql://:@/cfdm_test"
     - secure: SQfanR6GI/1i4v7XPEKT26mKjd1BT/Qt1/5fjrhEIiA4PL2ZWnvArBmcKeq3q3CcVy2KQDTUr4vvPKbo4HGAw1EcUvnJ5lF6v3h0FmZ/bhMdkHk1e/UvfIVjOm0mEO80FDiXRcWEiYgY/Z4LwJ1l2iNC45j/1Odacj9I3fOdteY=
     - secure: aXkcjh6AHi1MnY1vZ5Nu8/8OexUZ4n8ul5hrM9iex0QdJAm4AoxF0idHybinTAAL7/gSEineX1to6GC3GVnAV/f/FU1mo8sjt0hvwTAx8b+ONR0M0sJW2KrPJRABQK4Dtxu+PQkE4Qim0GaJQ6LBJwTAB+HiegYymqrUFSV5tm0=
+  matrix:
     - FEC_SAUCE_BROWSER: firefox
 
 before_script:
@@ -20,13 +24,13 @@ before_script:
   - npm run build
   - python __init__.py &
 
-  - git clone git@github.com:18F/openFEC.git@master
+  - git clone https://github.com/18F/openFEC
   - cd openFEC
-  - psql -c 'create database cfdm_test;' -U postgres
+  - psql -c "create database cfdm_test" -U postgres
   - md5sum data/cfdm_test.pgdump.sql
   - psql -f data/cfdm_test.pgdump.sql -U postgres cfdm_test
   - psql -c "SELECT count(*) FROM dimcand" -U postgres cfdm_test
-  - pip install -r requirements.txt
+  - sudo pip install -r requirements.txt
   - python manage.py update_schemas
   - python manage.py runserver &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ before_script:
   - cd ..
 
 script:
-  - nosetests openfecwebapp/tests
+  - py.test openfecwebapp/tests --selenium

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ Ask teammates for the username and password that should be used.
 ### Run Tests
 #### Unit Tests
 ```
-$ nosetests openfecwebapp/tests
+$ py.test openfecwebapp/tests
 ```
 #### Browser Tests
 First, install [PhantomJS](http://phantomjs.org/).
 
 Then:
 ```
-$ nosetests openfecwebapp/tests -a 'selenium'
+$ py.test openfecwebapp/tests --selenium
 ``` 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,27 @@
+# Selenium tests
+
+* Running tests locally with local Selenium
+    * Configure environment
+        ```
+        export FEC_SELENIUM_DRIVER="chrome"
+        ```
+* Running tests locally with Sauce
+    * Configure Sauce OS, browser, version in local environment
+        ```
+        export FEC_SELENIUM_DRIVER="remote"
+        export FEC_SAUCE_PLATFORM="Mac OS X 10.9"
+        export FEC_SAUCE_DRIVER="chrome"
+        export FEC_SAUCE_VERSION="39"
+        ```
+* Running tests on Travis
+    * Secure Sauce Labs credentials
+        * `gem install travis`
+        * `travis encrypt SAUCE_USERNAME=<username>`
+        * `travis encrypt SAUCE_ACCESS_KEY=<access key>`
+        * Add encrypted keys to `.travis.yml`
+    * Add OS / browser / version to Travis build matrix
+        ```
+        matrix:
+            - FEC_SAUCE_PLATFORM="Mac OS X 10.9" FEC_SAUCE_BROWSER=chrome
+            - FEC_SAUCE_BROWSER=firefox
+        ```

--- a/openfecwebapp/sauce.py
+++ b/openfecwebapp/sauce.py
@@ -1,0 +1,53 @@
+import json
+
+import furl
+import requests
+
+
+class SauceError(Exception):
+    pass
+
+
+class SauceClient(object):
+
+    def __init__(self, username, access_key):
+        self.username = username
+        self.access_key = access_key
+
+    @property
+    def _base_url(self):
+        url = furl.furl('https://saucelabs.com/rest/v1')
+        url.path.add(self.username)
+        return url
+
+    @property
+    def _headers(self):
+        return {
+            'Content-Type': 'application/json',
+        }
+
+    def _build_url(self, *segments, **query):
+        url = self._base_url
+        url.path.add(segments)
+        url.args.update(query)
+        return url.url
+
+    def _make_request(self, method, url, data, expects=(200, ), **kwargs):
+        resp = requests.request(
+            method,
+            url,
+            auth=(self.username, self.access_key),
+            headers=self._headers,
+            data=json.dumps(data),
+            **kwargs
+        )
+        if resp.status_code not in expects:
+            raise SauceError
+        return resp.json()
+
+    def update_job(self, job_id, **kwargs):
+        return self._make_request(
+            'PUT',
+            self._build_url('jobs', job_id),
+            kwargs,
+        )

--- a/openfecwebapp/tests/conftest.py
+++ b/openfecwebapp/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption('--selenium', action='store_true', help='Run Selenium tests')
+
+
+def pytest_runtest_setup(item):
+    if 'selenium' in item.keywords and not item.config.getoption('--selenium'):
+        pytest.skip('Pass --selenium option to run')
+
+
+@pytest.mark.tryfirst
+def pytest_runtest_makereport(item, call, __multicall__):
+    """Store pass/fail status on test class for use in teardown."""
+    report = __multicall__.execute()
+    if report.failed and item.cls:
+        item.cls._fail = True
+    return report

--- a/openfecwebapp/tests/selenium/candidates_list_page_test.py
+++ b/openfecwebapp/tests/selenium/candidates_list_page_test.py
@@ -1,50 +1,11 @@
-from .base_test_class import BaseTest
 from selenium.webdriver.common.keys import Keys
-import time
+from .base_test_class import SearchPageTestCase
 
 
-class CandidatesPageTests(BaseTest):
+class CandidatesPageTests(SearchPageTestCase):
 
     def setUp(self):
         self.url = self.base_url + '/candidates'
-
-    def getFilterDivByName(self, name):
-        return self.driver.find_element_by_xpath('//*[@for="' + name + '"]/..')
-
-    def openFilters(self):
-        self.driver.find_element_by_id('filter-toggle').click()
-
-    def getColumn(self, index, data):
-        return [row.find_elements_by_tag_name('td')[index].text
-                for row in data.find_elements_by_tag_name('tr')]
-
-    def checkFilter(self, name, first_entry, second_entry,
-                    count, index, result):
-        self.driver.get(self.url)
-        self.openFilters()
-        div = self.getFilterDivByName(name)
-        time.sleep(1)
-        div.find_element_by_xpath('./div/a/div/b').click()
-        self.assertEqual(
-            div.find_element_by_xpath('./div').get_attribute('class'),
-            ('chosen-container chosen-container-single '
-             'chosen-with-drop chosen-container-active'))
-        div.find_element_by_tag_name('input').send_keys(first_entry)
-        self.assertEqual(
-            len(div.find_elements_by_tag_name('li')),
-            count)
-        div.find_element_by_tag_name('input').send_keys(second_entry)
-        div.find_element_by_tag_name('input').send_keys(Keys.ENTER)
-        self.assertEqual(
-            div.get_attribute('class'),
-            'field active')
-        self.driver.find_element_by_id('category-filters').submit()
-        results = (self.driver.find_elements_by_tag_name('tr'))
-        col = [y.find_elements_by_tag_name('td')[index]
-                .text for y in results[1:]]
-        self.assertEqual(
-            set(col),
-            {result})
 
     def testCandidatesPageLoads(self):
         self.driver.get(self.url)
@@ -74,7 +35,6 @@ class CandidatesPageTests(BaseTest):
         self.driver.get(self.url)
         self.openFilters()
         name_div = self.getFilterDivByName('name')
-        time.sleep(1)
         name_div.find_element_by_tag_name('input').send_keys('Alliegro')
         name_div.find_element_by_tag_name('input').send_keys(Keys.ENTER)
         self.assertEqual(

--- a/openfecwebapp/tests/selenium/committees_list_page_test.py
+++ b/openfecwebapp/tests/selenium/committees_list_page_test.py
@@ -1,49 +1,11 @@
-from .base_test_class import BaseTest
 from selenium.webdriver.common.keys import Keys
-import time
+from .base_test_class import SearchPageTestCase
 
 
-class CommitteesPageTests(BaseTest):
+class CommitteesPageTests(SearchPageTestCase):
 
     def setUp(self):
         self.url = self.base_url + '/committees'
-
-    def getFilterDivByName(self, name):
-        return self.driver.find_element_by_xpath('//*[@for="' + name + '"]/..')
-
-    def openFilters(self):
-        self.driver.find_element_by_id('filter-toggle').click()
-
-    def getColumn(self, index, data):
-        return [row.find_elements_by_tag_name('td')[index].text
-                for row in data.find_elements_by_tag_name('tr')]
-
-    def checkFilter(self, name, first_entry, second_entry,
-                    count, index, result):
-        self.driver.get(self.url)
-        self.openFilters()
-        cycle = self.getFilterDivByName(name)
-        cycle.find_element_by_xpath('./div/a/div/b').click()
-        self.assertEqual(
-            cycle.find_element_by_xpath('./div').get_attribute('class'),
-            ('chosen-container chosen-container-single '
-             'chosen-with-drop chosen-container-active'))
-        cycle.find_element_by_tag_name('input').send_keys(first_entry)
-        self.assertEqual(
-            len(cycle.find_elements_by_tag_name('li')),
-            count)
-        cycle.find_element_by_tag_name('input').send_keys(second_entry)
-        cycle.find_element_by_tag_name('input').send_keys(Keys.ENTER)
-        self.assertEqual(
-            cycle.get_attribute('class'),
-            'field active')
-        self.driver.find_element_by_id('category-filters').submit()
-        results = (self.driver.find_elements_by_tag_name('tr'))
-        col = [y.find_elements_by_tag_name('td')[index]
-                .text for y in results[1:]]
-        self.assertEqual(
-            set(col),
-            {result})
 
     def testCommitteesPageLoads(self):
         self.driver.get(self.url)
@@ -73,7 +35,6 @@ class CommitteesPageTests(BaseTest):
         self.driver.get(self.url)
         self.openFilters()
         name_div = self.getFilterDivByName('name')
-        time.sleep(1)
         name_div.find_element_by_tag_name('input').send_keys('pork')
         name_div.find_element_by_tag_name('input').send_keys(Keys.ENTER)
         self.assertEqual(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,9 @@
 Flask==0.10.1
 Flask-BasicAuth==0.2.0
 Flask-Testing==0.4.2
-Jinja2==2.7.3
-MarkupSafe==0.23
-Werkzeug==0.9.6
-itsdangerous==0.24
+furl==0.4.5
 nose==1.3.4
+pytest==2.7.0
 requests==2.5.1
 requests-cache==0.4.9
 selenium==2.44.0


### PR DESCRIPTION
Log test suites as passed or failed in Sauce Labs.

* Add minimal Sauce Labs API client
* Notify Sauce Labs of suite success / failure in `tearDownClass`

This is a follow-up to #85, but makes the additional change of switching from nose to py.test as the test runner, so I wanted to submit separately for discussion. Py.test is fully compatible with nose and unittest tests, so all existing tests behave as previously. But it's easier to add hooks and generally customize py.test, which is helpful for integration with Sauce Labs.