### PR TITLE
Commenting out authorized committees in the header

### DIFF
--- a/templates/candidates-single.html
+++ b/templates/candidates-single.html
@@ -37,14 +37,14 @@
             <a href="{{ url_for('committee_page', c_id=primary_committee[0].committee_id) }}">{{ primary_committee[0].committee_name }}</a>
           </li>
           {% endif %}
-          {% if authorized_committees %}
+          <!-- {% if authorized_committees %}
           <li class="entity__term--wide">
             <h5 class="entity__term__label"><a class="term" data-term="Authorized Committee">Authorized Committees</a></h5>
             {% for c in authorized_committees %}
             <p class="entity__term__data"><a href="{{ url_for('committee_page', c_id=c.committee_id) }}">{{ c.committee_name }}</a></p>
             {% endfor %}
           </li>
-          {% endif %}
+          {% endif %} -->
       </div>
     </div>
   </header>


### PR DESCRIPTION
Temporary fix to hide authorized committees from the candidate header. We can add them back in later.