### PR TITLE
Show financial charts in ascending chronological order.

### DIFF
--- a/templates/partials/committee-charts.html
+++ b/templates/partials/committee-charts.html
@@ -15,7 +15,7 @@
         <li><span class="swatch data--disbursements"></span> Disbursements</li>
       </ul>
     </div>
-    {{ charts.chart_series_grouped(committee.totals, ('receipts', 'disbursements'),
+    {{ charts.chart_series_grouped(committee.totals|reverse, ('receipts', 'disbursements'),
        label_key=('coverage_start_date', 'coverage_end_date'), tooltip=group_bar_tooltip) }}
   </figure>
 </div>
@@ -28,7 +28,7 @@
         <li><span class="swatch data--debt"></span> Debt</li>
       </ul>
     </div>
-    {{ charts.chart_series_grouped(committee.reports, ('cash', 'debt'),
+    {{ charts.chart_series_grouped(committee.reports|reverse, ('cash', 'debt'),
        label_key=('coverage_end_date'), tooltip=group_bar_tooltip) }}
   </figure>
 </div>


### PR DESCRIPTION
Reports and totals are returned from the API in descending chronological order, but we want to draw charts in ascending order.

[Resolves https://github.com/18F/openFEC/issues/640]