### PR TITLE
Add API version to URLs.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,5 @@
 from openfecwebapp.config import (port, debug, host, api_location,
-    api_version, username, password, test, analytics)
+    api_version, api_key_public, username, password, test, analytics)
 from flask import Flask, render_template, request
 from flask.ext.basicauth import BasicAuth
 from openfecwebapp.views import (render_search_results, render_table,
@@ -22,6 +22,7 @@ def get_context(c):
 
 app.jinja_env.globals['api_location'] = api_location
 app.jinja_env.globals['api_version'] = api_version
+app.jinja_env.globals['api_key'] = api_key_public
 app.jinja_env.globals['context'] = get_context
 
 if not test:

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,5 @@
 from openfecwebapp.config import (port, debug, host, api_location,
-    username, password, test, analytics)
+    api_version, username, password, test, analytics)
 from flask import Flask, render_template, request
 from flask.ext.basicauth import BasicAuth
 from openfecwebapp.views import (render_search_results, render_table,
@@ -21,6 +21,7 @@ def get_context(c):
     return c
 
 app.jinja_env.globals['api_location'] = api_location
+app.jinja_env.globals['api_version'] = api_version
 app.jinja_env.globals['context'] = get_context
 
 if not test:

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -1,13 +1,16 @@
-import requests
-from urllib.parse import urlencode
+import os
+from urllib import parse
 
-from openfecwebapp.config import api_location, api_key
+import requests
+
+from openfecwebapp.config import api_location, api_version, api_key
 
 
 def _call_api(path, filters):
     if api_key:
         filters['api_key'] = api_key
-    url = api_location + path
+    path = os.path.join(api_version, path.strip('/'))
+    url = parse.urljoin(api_location, path)
     results = requests.get(url, params=filters)
 
     if results.status_code == requests.codes.ok:
@@ -52,5 +55,5 @@ def install_cache():
     requests_cache.install_cache()
 
 def limit_by_amount(curr_url, amount):
-    query = urlencode({'page': 1, 'per_page': amount})
+    query = parse.urlencode({'page': 1, 'per_page': amount})
     return '{0}?{1}'.format(curr_url, query)

--- a/openfecwebapp/config.py
+++ b/openfecwebapp/config.py
@@ -6,6 +6,7 @@ api_version = os.getenv('FEC_WEB_API_VERSION', 'v1')
 host = os.getenv('FEC_WEB_HOST', '0.0.0.0')
 port = os.getenv('VCAP_APP_PORT', '3000')
 api_key = os.getenv('FEC_WEB_API_KEY', '')
+api_key_public = os.getenv('FEC_WEB_API_KEY_PUBLIC', '')
 
 # the username and password should be the same for both the
 # web app and API

--- a/openfecwebapp/config.py
+++ b/openfecwebapp/config.py
@@ -2,6 +2,7 @@ import os
 
 # no trailing slash
 api_location = os.getenv('FEC_WEB_API_URL', 'http://localhost:5000')
+api_version = os.getenv('FEC_WEB_API_VERSION', 'v1')
 host = os.getenv('FEC_WEB_HOST', '0.0.0.0')
 port = os.getenv('VCAP_APP_PORT', '3000')
 api_key = os.getenv('FEC_WEB_API_KEY', '')

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -32,7 +32,6 @@ def render_table(data_type, results, params):
 
     results_table = {}
     results_table[data_type] = []
-    heading = "Browse " + data_type
 
     results_table['pagination'] = generate_pagination_values(
         results, params, data_type)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "https://github.com/theresaanna/openfec-web-app/issues"
   },
   "dependencies": {
+    "URIjs": "^1.15.0",
     "browserify": "~6.1.0",
     "d3": "^3.5.3",
     "eventemitter2": "~0.4.14",

--- a/static/js/modules/typeahead.js
+++ b/static/js/modules/typeahead.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global require, module, Bloodhound, API_LOCATION, API_VERSION */
+/* global require, module, Bloodhound, API_LOCATION, API_VERSION, API_KEY */
 
 var $ = require('jquery');
 require('typeahead.js');
@@ -57,7 +57,7 @@ module.exports = {
           .path([API_VERSION, 'names'].join('/'))
           .query({
             q: '%QUERY',
-            api_key: '6wpqET5GjxCwAyBqXjc4dWrfMdshFE6wu3txb6yZ'
+            api_key: API_KEY
           })
           .readable();
     }

--- a/static/js/modules/typeahead.js
+++ b/static/js/modules/typeahead.js
@@ -1,9 +1,10 @@
 'use strict';
 
-/* global require, Bloodhound */
+/* global require, module, Bloodhound, API_LOCATION, API_VERSION */
 
 var $ = require('jquery');
 require('typeahead.js');
+var URI = require('URIjs');
 var Handlebars = require('handlebars');
 
 var events = require('./events.js');
@@ -52,8 +53,13 @@ module.exports = {
         url = "/rest/names?q=%QUERY";
 
     if (typeof API_LOCATION !== 'undefined') {
-        url = "/names?q=%QUERY&api_key=6wpqET5GjxCwAyBqXjc4dWrfMdshFE6wu3txb6yZ"; // Replace with the correct api key
-        url = API_LOCATION.concat(url);
+        url = URI(API_LOCATION)
+          .path([API_VERSION, 'names'].join('/'))
+          .query({
+            q: '%QUERY',
+            api_key: '6wpqET5GjxCwAyBqXjc4dWrfMdshFE6wu3txb6yZ'
+          })
+          .readable();
     }
 
     // Creating a candidate suggestion engine

--- a/templates/layouts/main.html
+++ b/templates/layouts/main.html
@@ -17,6 +17,7 @@
     {% if api_location %}
     <script>
         API_LOCATION = "{{api_location}}"
+        API_VERSION = "{{api_version}}"
     </script>
     {% endif %}
 </head>

--- a/templates/layouts/main.html
+++ b/templates/layouts/main.html
@@ -18,6 +18,7 @@
     <script>
         API_LOCATION = "{{api_location}}"
         API_VERSION = "{{api_version}}"
+        API_KEY = "{{api_key}}"
     </script>
     {% endif %}
 </head>


### PR DESCRIPTION
Prefix API URLs with the current API version, starting with `v1`.

Note: Depends on https://github.com/18F/openFEC/pull/665

[Resolves https://github.com/18F/openFEC/issues/44]