### PR TITLE
Build assets remotely.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/cloudfoundry/python-buildpack
+https://github.com/cloudfoundry/nodejs-buildpack

--- a/.cfignore
+++ b/.cfignore
@@ -1,6 +1,1 @@
-*.swp
-*.pyc
-node_modules
-.sass-cache/
-static/styles/styles.css.map
-app/
+.gitignore

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: newrelic-admin run-program gunicorn __init__:app
+web: npm run build && newrelic-admin run-program gunicorn __init__:app


### PR DESCRIPTION
Build assets on cloud foundry instead of building locally and uploading.
This simplifies deployment somewhat by offloading the work of asset
compilation from the developer's machine to Cloud Foundry and makes the
whole process just a little more reproducible.

* Symlink .gitignore to .cfignore
* Use both Python and Node buildpacks
* Build assets on `push`