### PR TITLE
Miscellaneous improvements to cache busting.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,3 @@
 https://github.com/cloudfoundry/python-buildpack
 https://github.com/cloudfoundry/nodejs-buildpack
+https://github.com/cloudfoundry/ruby-buildpack

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+ruby '2.0.0'
+
+gem 'sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,10 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sass (3.4.13)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sass

--- a/README.md
+++ b/README.md
@@ -36,49 +36,34 @@ Those vars are `FEC_WEB_USERNAME` and `FEC_WEB_PASSWORD`. There are other config
 can set, but that have defaults. You can see those in `openfecwebapp/config.py`.
 
 ### Run server
-To make the site fully functional, you will need to compile the client side JS:
+To make the site fully functional, you will need to compile the client side JS and CSS:
 
-```
-$ npm run build
-```
+    $ npm run build
 
 Then start the server:
 
-```
-$ python __init__.py
-```
+    $ python __init__.py
 
 If you'd like the app to cache API requests it makes, use the `--cached` flag:
 
-```
-$ python __init__.py --cached
-```
+    $ python __init__.py --cached
 
 ### Development
-To compile client side JS changes once:
-```
-$ npm run build
-```
+To compile client side JS once:
 
-To compile whenever changes are made to the client side JS:
-```
-$ npm run watch
-```
+    $ npm run build-js
 
 Compile Sass once:
-```
-$ npm run sass-build
-```
+
+    $ npm run build-sass
+
+Compile JS as changes are made:
+
+    $ npm run watch-js
 
 Compile Sass as changes are made:
-```
-$ npm run sass-watch
-```
 
-Or, if you want to get crazy, watch both Sass and JS changes: (hat tip [@ascott1](http://github.com/ascott1))
-```
-$ npm run watch-all
-```
+    $ npm run watch-sass
 
 ### Deployment
 
@@ -86,9 +71,9 @@ See directions in the 18F/openFEC repo.
 
 ### Run Tests
 #### Unit Tests
-```
-$ py.test openfecwebapp/tests
-```
+
+    $ py.test openfecwebapp/tests
+
 #### Browser Tests
 First, install [PhantomJS](http://phantomjs.org/).
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,10 +35,10 @@ function bundle(watch) {
 wb.on('update', bundle);
 wb.on('log', gutil.log);
 
-gulp.task('build', bundle.bind(this, false));
-gulp.task('watch', bundle.bind(this, true));
+gulp.task('build-js', bundle.bind(this, false));
+gulp.task('watch-js', bundle.bind(this, true));
 
-gulp.task('sass-build', function() {
+gulp.task('build-sass', function() {
   return sass('./static/styles/styles.scss')
     .pipe(rename('static/styles/styles.css'))
     .pipe(rev())
@@ -47,6 +47,6 @@ gulp.task('sass-build', function() {
     .pipe(gulp.dest('.'));
 });
 
-gulp.task('sass-watch', function() {
+gulp.task('watch-sass', function() {
   gulp.watch('./static/styles/**/*.scss', ['sass-build']);
 });

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
   },
   "scripts": {
     "test": "mocha --reporter nyan tests/unit",
+    "build": "gulp build-js && gulp build-sass",
+    "build-js": "gulp build-js",
+    "build-sass": "gulp build-sass",
     "watch": "gulp watch",
-    "build": "gulp build",
-    "sass-watch": "gulp sass-watch",
-    "sass-build": "gulp sass-build",
-    "watch-all": "gulp watch & gulp sass-watch"
+    "watch-js": "gulp watch-js",
+    "watch-sass": "gulp watch-sass"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Build sass on Cloud Foundry
* Update README with command names
* Rename npm commands so common commands have shorter names
    * `npm run build` builds js and sass
    * `npm run build-js` builds js
    * `npm run build-sass` builds sass
    * `npm run watch` watches js and sass
    * `npm run watch-js` watches js
    * `npm run watch-sass` watches sass