### PR TITLE
Restore glossary search on typeahead select.

### DIFF
--- a/static/js/modules/glossary.js
+++ b/static/js/modules/glossary.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* global require */
+
 var $ = require('jquery');
 var _ = require('underscore');
 
@@ -96,28 +98,28 @@ clearTerm = function() {
     $('#glossary-term').html('');
     $('#glossary-definition').html('');
     $("#glossary-search").val('');
-}
+};
 
 module.exports = {
-  init: function(){
-    glossaryLink.on('click keypress', function(e){
-        if (e.which === 13 || e.type === 'click') {
-            var dataTerm = $(this).data('term'),
-                definedTerm = findDefinition(dataTerm);
-            showGlossary();
-            setDefinition(definedTerm);
-        }
-    })
+    init: function() {
+        glossaryLink.on('click keypress', function(e){
+            if (e.which === 13 || e.type === 'click') {
+                var dataTerm = $(this).data('term'),
+                    definedTerm = findDefinition(dataTerm);
+                showGlossary();
+                setDefinition(definedTerm);
+            }
+        });
 
-    $('#glossary-toggle, #hide-glossary').click(function(){
-        if (glossaryIsOpen) {
-            hideGlossary();
-        } else {
-            showGlossary();
-        }
-    });
+        $('#glossary-toggle, #hide-glossary').click(function(){
+            if (glossaryIsOpen) {
+                hideGlossary();
+            } else {
+                showGlossary();
+            }
+        });
 
- },
-
+    },
+    findDefinition: findDefinition,
     setDefinition: setDefinition
-}
+};

--- a/static/js/modules/typeahead.js
+++ b/static/js/modules/typeahead.js
@@ -155,7 +155,7 @@ module.exports = {
         },
       queryTokenizer: Bloodhound.tokenizers.whitespace,
       limit: 3
-    })
+    });
 
     glossaryEngine.initialize();
     glossarySuggestion = Handlebars.compile('<span>{{ term }}</span>');
@@ -172,7 +172,11 @@ module.exports = {
               suggestion: glossarySuggestion,
             }
         }
-    );  
+    );
+    $('#glossary-search').on('typeahead:selected', function(event, datum) {
+        var definition = glossary.findDefinition(datum.term);
+        glossary.setDefinition(definition);
+    });
 
     $('.twitter-typeahead').css({
       display: 'block',

--- a/templates/partials/glossary.html
+++ b/templates/partials/glossary.html
@@ -1,12 +1,12 @@
 <div id="glossary" class="side-panel side-panel--right glossary text--white"
     aria-describedby="glassary-result">
-  <button title="Close glossary" class="button--close u-float-right" 
+  <button title="Close glossary" class="button--close u-float-right"
       id="hide-glossary"><i class="ti-close text--white"></i></button>
   <h3 class="text--white">FEC Glossary</h3>
   <label for="glossary-search">Search for terms</label>
   <input id="glossary-search" type="text" placeholder="Search for terms">
   <div class="glossary__term" id="glossary-result">
-	  <h4><dt><span id="glossary-term" class="text--white"></span></dt></h4>
-	  <dd><span id="glossary-definition" class="text--white"></span></dd>
+    <h4><dt><span id="glossary-term" class="text--white"></span></dt></h4>
+    <dd><span id="glossary-definition" class="text--white"></span></dd>
   </div>
 </div>


### PR DESCRIPTION
When the user selects an option in the glossary typeahead, the
associated text should appear below. A previous bug fix prevented this
behavior, such that selecting an option did not show the glossary text.

This also uses the `typeahead:selected` custom event, which will hopefully be more robust and easier to understand than listening for particular keypress buttons. @msecret could you verify that the bug you fixed in d013e08137e7fb22ae9dea2761375dbe9c645130 is still fixed with this patch? I think it is, but I'm not sure exactly how the glossary was behaving before you fixed it.