### PR TITLE
Feature/footer fix

### DIFF
--- a/static/js/modules/terms.json
+++ b/static/js/modules/terms.json
@@ -71,8 +71,4 @@
     "term":"Candidate",
     "definition":"An individual seeking nomination for election, or election, to a federal office becomes a candidate when he or she (or agents working on his or her behalf) raises contributions or makes expenditures that exceed $5,000."
   },
-  {
-    "term": "District",
-    "definition": "A U.S. House District. Because Senators represent an entire state, Senate races do not have districts associated with them."
-  }, 
 ]

--- a/static/js/modules/typeahead.js
+++ b/static/js/modules/typeahead.js
@@ -154,13 +154,13 @@ module.exports = {
           return tokens;
         },
       queryTokenizer: Bloodhound.tokenizers.whitespace,
-      limit: 3
+      limit: 5
     })
 
     glossaryEngine.initialize();
     glossarySuggestion = Handlebars.compile('<span>{{ term }}</span>');
     $('#glossary-search').typeahead({
-            minLength: 3,
+            minLength: 1,
             highlight: true,
             hint: false
         },
@@ -181,7 +181,11 @@ module.exports = {
     // Open single entity pages when selected
     $(document).on('typeahead:selected', function(e, suggestion, datasetName) {
         if ( datasetName === 'Definitions' ) {
-          glossary.setDefinition(suggestion.term, suggestion.definition);
+          var term = {
+            term: suggestion.term,
+            definition: suggestion.definition
+          }
+          glossary.setDefinition(term);
         } 
         else {
           document.location = document.location.origin + '/' + datasetName + '/' + suggestion.id;

--- a/static/styles/_components/_footer.scss
+++ b/static/styles/_components/_footer.scss
@@ -20,10 +20,10 @@ footer {
 }
 
 .footer__right {
-    margin-top: 1rem;
+    margin: 2rem 0;
 
     @include media($medium) {
-        margin-top: 0;
+        margin: 0;
         text-align: right;
     }
 }
@@ -40,7 +40,7 @@ footer {
 .footer__nav {
     li {
         display: inline-block;
-        padding: 0 .625em;
+        padding: 0 2rem;
 
         &:first-child {
             padding-left: 0;


### PR DESCRIPTION
This fixes the padding on the footer items for https://github.com/18F/openFEC/issues/712

Also implements a fix to the glossary so now when you hit enter on a term it pulls up the definition like you expect.