### PR TITLE
Add optional hooks for dependency management.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,17 @@ If the development API is down or for testing with feature branches of the API,
 a local API server can be used:
 
     $ unset FEC_WEB_API_URL
+
+#### Git Hooks
+
+This repo includes optional post-merge and post-checkout hooks to ensure that
+dependencies and compiled assets are up to date. If enabled, these hooks will
+update Python and Node dependencies, and rebuild compiled JS and CSS files,
+on checking out or merging changes to `requirements.txt`, `package.json`,
+or source JS or SCSS files. To enable the hooks, run
+
+    $ invoke add_hooks
+
+To disable, run
+
+    $ invoke remove_hooks

--- a/bin/post-checkout
+++ b/bin/post-checkout
@@ -1,0 +1,19 @@
+#/usr/bin/env bash
+
+# git hook to run a command after `git checkout` if a specified file was changed
+# Run `chmod +x post-checkout` to make it executable then put it into `.git/hooks/`.
+
+PREV_HEAD=$1
+
+changed_files="$(git diff-tree -r --name-only --no-commit-id $PREV_HEAD HEAD)"
+
+check_run() {
+    echo "$changed_files" | grep --quiet "$1" && eval "$2"
+}
+
+# Update dependencies
+check_run package.json "npm install"
+check_run requirements.txt "pip install -r requirements.txt --upgrade"
+
+# Update assets
+check_run static "npm run build"

--- a/bin/post-merge
+++ b/bin/post-merge
@@ -1,0 +1,18 @@
+#/usr/bin/env bash
+# MIT © Sindre Sorhus - sindresorhus.com
+
+# git hook to run a command after `git pull` if a specified file was changed
+# Run `chmod +x post-merge` to make it executable then put it into `.git/hooks/`.
+
+changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+
+check_run() {
+    echo "$changed_files" | grep --quiet "$1" && eval "$2"
+}
+
+# Update dependencies
+check_run package.json "npm install"
+check_run requirements.txt "pip install -r requirements.txt --upgrade"
+
+# Update assets
+check_run static "npm run build"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask==0.10.1
 Flask-BasicAuth==0.2.0
 Flask-Testing==0.4.2
 furl==0.4.5
+invoke>=0.10.1
 nose==1.3.4
 pytest==2.7.0
 requests==2.5.1

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,14 @@
+from invoke import run
+from invoke import task
+
+
+@task
+def add_hooks():
+    run('ln -s ../../bin/post-merge .git/hooks/post-merge')
+    run('ln -s ../../bin/post-checkout .git/hooks/post-checkout')
+
+
+@task
+def remove_hooks():
+    run('rm .git/hooks/post-merge')
+    run('rm .git/hooks/post-checkout')


### PR DESCRIPTION
Add optional post-checkout and post-merge hooks to update dependencies and
compiled assets when underlying dependencies and code change.

After running `invoke add_hooks`, git will automatically check for changes in `requirements.txt`, `package.json`, and all static files on checkout or merge, and install dependencies and/or rebuild compiled assets if the relevant source files are different. The hooks are optional, so nobody would have to use them if they didn't want to.