### PR TITLE
Don't use deprecated mixin.

### DIFF
--- a/static/styles/_base/_forms.scss
+++ b/static/styles/_base/_forms.scss
@@ -47,9 +47,9 @@ label + #{$all-text-inputs} {
 textarea,
 #{$all-text-inputs},
 select[multiple=multiple] {
-  @include box-sizing(border-box);
   @include transition(border-color);
   @include font-size($form-font-size);
+  box-sizing: border-box;
   margin: 1em 0;
   background-color: white;
   border-radius: $form-border-radius;


### PR DESCRIPTION
Bourbon is deprecating the `box-sizing` mixin because the CSS property
is now well-supported across browsers. Using the mixin throws a warning
with the current version of Bourbon and will error after the next major
release. If we want to support very old browser versions, it's safest to
add `-moz-box-sizing` etc. manually, but this probably isn't necessary.

See https://github.com/thoughtbot/bourbon/blob/86d2147511265db9cdb35b497e195b8c4649ee98/app/assets/stylesheets/_bourbon-deprecated-upcoming.scss#L407-L411 for details.