### PR TITLE
Fix types of remove buttons.

### DIFF
--- a/static/js/modules/filters.js
+++ b/static/js/modules/filters.js
@@ -8,11 +8,6 @@ var URI = require('URIjs');
 
 var events = require('./events.js');
 
-// http://stackoverflow.com/questions/196972/convert-string-to-title-case-with-javascript/196991#196991
-var toTitleCase = function(str) {
-    return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
-};
-
 // are the panels open?
 var open = true;
 
@@ -41,7 +36,7 @@ $('#filter-toggle').click(function(){
 });
 
 var activateFilter = function(opts) {
-    var $field = $('select[name=' + opts.name + ']');
+    var $field = $('#category-filters [name=' + opts.name + ']');
     if (opts.value) {
         $field.val(opts.value);
         $field.parent().addClass('active');
@@ -110,7 +105,7 @@ $('.button--remove').click(function(e){
     $(this).css('display', 'none');
 });
 
-$('.field select').change(function(){
+$('.field input, .field select').change(function(){
     var name = $(this).attr('name');
     if ( $(this).val() !== '' ) {
         $('[data-removes="' + name + '"]').css('display', 'block');

--- a/templates/candidates.html
+++ b/templates/candidates.html
@@ -24,10 +24,10 @@
 <section class="results-content">
   <div id="filters" class="side-panel side-panel--left">
     <form id="category-filters">
-        <div class="field{% if filter_name %} active{% endif %}" id="name-field">
+        <div class="field" id="name-field">
           <label for="name">Name</label>
-          <input type="text" name="name"{% if filter_name %} value="{{filter_name}}" {% endif %} />
-          <button class="button--remove" data-removes="name"><i class="ti-close"></i></button>
+          <input type="text" name="name" />
+          <button type="button" class="button--remove" data-removes="name"><i class="ti-close"></i></button>
         </div>
 
         {% include 'partials/filters/election-years.html' %}
@@ -37,7 +37,7 @@
         {% include 'partials/filters/office-sought.html' %}
 
       <div class="field">
-        <button class="primary">Apply filters</button>
+        <button type="submit" class="primary">Apply filters</button>
       </div>
     </form>
   </div>

--- a/templates/committees.html
+++ b/templates/committees.html
@@ -28,7 +28,7 @@
         <div class="field" id="name-field">
             <label for="name">Name</label>
             <input type="text" name="name" id="name" />
-            <button class="button--remove" data-removes="name"><i class="ti-close"></i></button>
+            <button type="button" class="button--remove" data-removes="name"><i class="ti-close"></i></button>
         </div>
 
         {% include 'partials/filters/election-years.html' %}
@@ -39,7 +39,7 @@
         {% include 'partials/filters/organization-types.html' %}
 
         <div class="field">
-          <button class="primary">Apply filters</button>
+          <button type="submit" class="primary">Apply filters</button>
         </div>
     </form>
   </div>

--- a/templates/partials/filters/committee-types.html
+++ b/templates/partials/filters/committee-types.html
@@ -19,5 +19,5 @@
         <option value="Y">Party - Qualified</option>
         <option value="Z">National Party Nonfederal Account</option>
     </select>
-    <button class="button--remove" data-removes="committee_type"><i class="ti-close"></i></button>
+    <button type="button" class="button--remove" data-removes="committee_type"><i class="ti-close"></i></button>
 </div>

--- a/templates/partials/filters/designations.html
+++ b/templates/partials/filters/designations.html
@@ -9,5 +9,5 @@
         <option value="B">Lobbyist/Registrant PAC</option>
         <option value="D">Leadership PAC</option>
     </select>
-    <button class="button--remove" data-removes="designation"><i class="ti-close"></i></button>
+    <button type="button" class="button--remove" data-removes="designation"><i class="ti-close"></i></button>
 </div>

--- a/templates/partials/filters/districts.html
+++ b/templates/partials/filters/districts.html
@@ -8,5 +8,5 @@
         {% endwith %}
         {% endfor %}
     </select>
-    <button class="button--remove" data-removes="district"><i class="ti-close"></i></button>
+    <button type="button" class="button--remove" data-removes="district"><i class="ti-close"></i></button>
 </div>

--- a/templates/partials/filters/election-years.html
+++ b/templates/partials/filters/election-years.html
@@ -5,5 +5,5 @@
         <option value={{ year }}>{{ year }}</option>
         {% endfor %}
     </select>
-    <button class="button--remove" data-removes="cycle"><i class="ti-close"></i></button>
+    <button type="button" class="button--remove" data-removes="cycle"><i class="ti-close"></i></button>
 </div>

--- a/templates/partials/filters/office-sought.html
+++ b/templates/partials/filters/office-sought.html
@@ -6,5 +6,5 @@
         <option value="P">Presidential</option>
         <option value="S">Senate</option>
     </select>
-    <button class="button--remove" data-removes="office"><i class="ti-close"></i></button>            
+    <button type="button" class="button--remove" data-removes="office"><i class="ti-close"></i></button>            
 </div>

--- a/templates/partials/filters/organization-types.html
+++ b/templates/partials/filters/organization-types.html
@@ -9,5 +9,5 @@
         <option value="V">Cooperative</option>
         <option value="W">Corporation Without Capital Stock</option>
     </select>
-    <button class="button--remove" data-removes="organization_type"><i class="ti-close"></i></button>
+    <button type="button" class="button--remove" data-removes="organization_type"><i class="ti-close"></i></button>
 </div>

--- a/templates/partials/filters/parties.html
+++ b/templates/partials/filters/parties.html
@@ -48,5 +48,5 @@
         <option value="TX">Taxpayers</option>
         <option value="USP">U.S. People's Party</option>
     </select>
-    <button class="button--remove" data-removes="party"><i class="ti-close"></i></button>  
+    <button type="button" class="button--remove" data-removes="party"><i class="ti-close"></i></button>  
 </div>

--- a/templates/partials/filters/states.html
+++ b/templates/partials/filters/states.html
@@ -59,5 +59,5 @@
         <option value="WV">West Virginia</option>
         <option value="WY">Wyoming</option>
     </select>
-    <button class="button--remove" data-removes="state"><i class="ti-close"></i></button>
+    <button type="button" class="button--remove" data-removes="state"><i class="ti-close"></i></button>
 </div>


### PR DESCRIPTION
By default, `<button>` elements have type `"submit"`, such that pressing
Enter on a form element triggers that button. This means that pressing
Enter when focusing on the candidate or committee name input triggered
the associated remove button, clearing the input. This patch adds the
correct button type of `"button"` to buttons that should not trigger a
form submit.

[Resolves https://github.com/18F/openFEC/issues/669]