### PR TITLE
Feature/travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
   global:
     - FEC_WEB_TEST: "true"
     - FEC_SELENIUM_DRIVER: "remote"
+    - secure: "Wvz5f/GyjVSooTCDtuTCgrBaiUR/idB0ikdDXWIAL02xpPaVMD0YQTVAE4WYJFEfX25APm79Bs+KHf2vKvUm/HGXfmGsRMb09dy8lVyCzdLuu9ISIH+0Udxj2qH1xdjZAqv8zuouc8N5aq24uMxFCqgxPi2kWnkieqbIw10HhQE="
+    - secure: "QMVCi+DS1BSdaWCmEQXurFDCWAijxJBEswY7s9RaGcTZRBmSsP5VR8uKDSANeRLZ509x3tXcw1X2OeqBFcyIzFi5WvF6oPcKahLrA6XrtjDYsMOBy9a2VDDqFH7ROI6G+99XTDNWoKmbjaO3AGhTGhIJWSf9T400T5imK0KMJB8="
     - secure: "SKKeJG+Pc0xFyq0++/Cf0fMO4fZlK1H3CgedSGiQhwl3Rsh8QgXBhH+/YwWYAozmUNPkJCEuDdB2A1trBEPqkghAnjNdOXu2mwo5ANweu8M/HdafeeDP2klHB7bIieJ5GhUfrZ1/D/nVcE86mePFlx6Ymjdg2DtNUYBIWFs2xPs="
     - secure: "UK4kK8mrj0AsYqL7ohK9wKMCTVSK0phyNw7sW2BynRJYTU3Xi073+m8mGiCvHGEULvriCtuysCsbh5iNUz5VQ/4RBQVOJdugzbWjbwEUzb6w1W5pXvwCRUufhGcr98odfNE09pZicfL0YjH84w/dqrlC3leeyaoF7bFqpaKWwqs="
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,3 +49,8 @@ script:
   - if [[ $FEC_SAUCE_BROWSER = 'false' ]]; then py.test openfecwebapp/tests; fi
   # Run Selenium tests if not pull request
   - if [[ $TRAVIS_PULL_REQUEST = 'false' && $FEC_SAUCE_BROWSER != 'false' ]]; then py.test openfecwebapp/tests --selenium; fi
+
+after_success:
+  # Deploy to appropriate Cloud Foundry space on success
+  # See `tasks.deploy` for details
+  - if [[ $TRAVIS_PULL_REQUEST = 'false' ]]; then invoke deploy; fi

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -1,0 +1,18 @@
+---
+memory: 512M
+stack: lucid64
+env:
+  NEW_RELIC_CONFIG_FILE: newrelic.ini
+  NEW_RELIC_ENV: development
+applications:
+- name: web
+  path: .
+  buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
+  host: fec-dev-web
+  env:
+    NEW_RELIC_APP_NAME: OpenFEC Web (development)
+    FEC_WEB_API_URL: http://fec-dev-api.cf.18f.us
+    FEC_WEB_DEBUG: True
+    # These must be set manually via `cf set-env`
+    # FEC_WEB_PASSWORD
+    # FEC_WEB_USERNAME

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -1,0 +1,19 @@
+---
+memory: 512M
+stack: lucid64
+instances: 2
+env:
+  NEW_RELIC_CONFIG_FILE: newrelic.ini
+  NEW_RELIC_ENV: production
+applications:
+- name: web
+  path: .
+  buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
+  host: fec-prod-web
+  env:
+    NEW_RELIC_APP_NAME: OpenFEC Web (production)
+    FEC_WEB_API_URL: https://api.open.fec.gov/
+    FEC_FORCE_HTTPS: true
+    # These must be set manually via `cf set-env`
+    # FEC_WEB_PASSWORD
+    # FEC_WEB_USERNAME

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -1,0 +1,18 @@
+---
+memory: 512M
+stack: lucid64
+env:
+  NEW_RELIC_CONFIG_FILE: newrelic.ini
+  NEW_RELIC_ENV: staging
+applications:
+- name: web
+  path: .
+  buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
+  host: fec-stage-web
+  env:
+    NEW_RELIC_APP_NAME: OpenFEC Web (staging)
+    FEC_WEB_API_URL: http://fec-stage-api.cf.18f.us
+    FEC_WEB_DEBUG: True
+    # These must be set manually via `cf set-env`
+    # FEC_WEB_PASSWORD
+    # FEC_WEB_USERNAME

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask==0.10.1
 Flask-BasicAuth==0.2.0
 Flask-Testing==0.4.2
+GitPython>=1.0.1
 furl==0.4.5
 invoke>=0.10.1
 nose==1.3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [pytest]
 python_files=test_*.py *_test.py *_tests.py
+
+[flake8]
+ignore = E127,E128,E265,E302
+max-line-length = 90

--- a/tasks.py
+++ b/tasks.py
@@ -1,3 +1,4 @@
+import git
 from invoke import run
 from invoke import task
 
@@ -12,3 +13,84 @@ def add_hooks():
 def remove_hooks():
     run('rm .git/hooks/post-merge')
     run('rm .git/hooks/post-checkout')
+
+
+def _detect_prod(repo):
+    """Deploy to production if master is checked out and tagged."""
+    if repo.active_branch != 'master':
+        return False
+    try:
+        # Equivalent to `git describe --tags --exact-match`
+        repo.git().describe('--tags', '--exact-match')
+        return True
+    except git.exc.GitCommandError:
+        return False
+
+
+def _resolve_rule(repo):
+    """Get space associated with first matching rule."""
+    for space, rule in DEPLOY_RULES:
+        if rule(repo):
+            return space
+    return None
+
+
+def _detect_space(yes=False):
+    """Detect space from active git branch.
+
+    :param bool yes: Skip confirmation
+    :returns: Space name if space is detected and confirmed, else `None`
+    """
+    repo = git.Repo('.')
+    space = _resolve_rule(repo)
+    if space is None:
+        print(
+            'No space detected from repo {repo}; '
+            'skipping deploy'.format(**locals())
+        )
+        return None
+    print('Detected space {space} from repo {repo}'.format(**locals()))
+    if not yes:
+        run = input(
+            'Deploy to space {space} (enter "yes" to deploy)? >'.format(**locals())
+        )
+        if run.lower() not in ['y', 'yes']:
+            return None
+    return space
+
+
+DEPLOY_RULES = (
+    ('prod', _detect_prod),
+    ('stage', lambda repo: repo.active_branch.name == 'master'),
+    ('dev', lambda repo: repo.active_branch.name == 'develop'),
+)
+
+
+@task
+def deploy(space=None, yes=False):
+    """Deploy app to Cloud Foundry. Log in using credentials stored in
+    `FEC_CF_USERNAME` and `FEC_CF_PASSWORD`; push to either `space` or the space
+    detected from the name and tags of the current branch.
+    """
+    # Detect space
+    space = space or _detect_space(yes)
+    if space is None:
+        return
+
+    # Select API
+    api = 'cf api https://api.18f.gov'
+    run(api, echo=True)
+
+    # Log in
+    args = (
+        ('--u', '$FEC_CF_USERNAME'),
+        ('--p', '$FEC_CF_PASSWORD'),
+        ('--o', 'fec'),
+        ('--s', space),
+    )
+    login = 'cf login {0}'.format(' '.join(' '.join(arg) for arg in args))
+    run(login, echo=True)
+
+    # Push
+    push = 'cf push -f manifest_{0}.yml'.format(space)
+    run(push, echo=True)


### PR DESCRIPTION
Complement to https://github.com/18F/openFEC/pull/733. This patch moves deployment logic for the webapp into the webapp repo, and uses the same continuous deployment logic as https://github.com/18F/openFEC/pull/733.

After a successful build that is *not* a pull request, deploy as follows:
* if branch is master and has a tag, push to prod
* if branch is master and doesn't have a tag, push to stage
* if branch is develop, push to dev
* else no push

This patch does copy some code from the API repo, but I don't think it's enough duplication to justify a submodule or anything.