### PR TITLE
Handle detached HEAD on Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,4 @@ script:
 after_success:
   # Deploy to appropriate Cloud Foundry space on success
   # See `tasks.deploy` for details
-  - if [[ $TRAVIS_PULL_REQUEST = 'false' ]]; then invoke deploy; fi
+  - if [[ $TRAVIS_PULL_REQUEST = 'false' ]]; then invoke deploy --branch $TRAVIS_BRANCH --yes; fi

--- a/tasks.py
+++ b/tasks.py
@@ -15,9 +15,9 @@ def remove_hooks():
     run('rm .git/hooks/post-checkout')
 
 
-def _detect_prod(repo):
+def _detect_prod(repo, branch):
     """Deploy to production if master is checked out and tagged."""
-    if repo.active_branch != 'master':
+    if branch != 'master':
         return False
     try:
         # Equivalent to `git describe --tags --exact-match`
@@ -27,22 +27,29 @@ def _detect_prod(repo):
         return False
 
 
-def _resolve_rule(repo):
+def _resolve_rule(repo, branch):
     """Get space associated with first matching rule."""
     for space, rule in DEPLOY_RULES:
-        if rule(repo):
+        if rule(repo, branch):
             return space
     return None
 
 
-def _detect_space(yes=False):
+def _detect_space(branch=None, yes=False):
     """Detect space from active git branch.
 
+    :param str branch: Optional branch name override
     :param bool yes: Skip confirmation
     :returns: Space name if space is detected and confirmed, else `None`
     """
     repo = git.Repo('.')
-    space = _resolve_rule(repo)
+    # Fail gracefully if `branch` is not provided and repo is in detached
+    # `HEAD` mode
+    try:
+        branch = branch or repo.active_branch.name
+    except TypeError:
+        return None
+    space = _resolve_rule(repo, branch)
     if space is None:
         print(
             'No space detected from repo {repo}; '
@@ -52,7 +59,7 @@ def _detect_space(yes=False):
     print('Detected space {space} from repo {repo}'.format(**locals()))
     if not yes:
         run = input(
-            'Deploy to space {space} (enter "yes" to deploy)? >'.format(**locals())
+            'Deploy to space {space} (enter "yes" to deploy)? > '.format(**locals())
         )
         if run.lower() not in ['y', 'yes']:
             return None
@@ -61,19 +68,20 @@ def _detect_space(yes=False):
 
 DEPLOY_RULES = (
     ('prod', _detect_prod),
-    ('stage', lambda repo: repo.active_branch.name == 'master'),
-    ('dev', lambda repo: repo.active_branch.name == 'develop'),
+    ('stage', lambda _, branch: branch == 'master'),
+    ('dev', lambda _, branch: branch == 'develop'),
 )
 
 
 @task
-def deploy(space=None, yes=False):
+def deploy(space=None, branch=None, yes=False):
     """Deploy app to Cloud Foundry. Log in using credentials stored in
     `FEC_CF_USERNAME` and `FEC_CF_PASSWORD`; push to either `space` or the space
-    detected from the name and tags of the current branch.
+    detected from the name and tags of the current branch. Note: Must pass `space`
+    or `branch` if repo is in detached HEAD mode, e.g. when running on Travis.
     """
     # Detect space
-    space = space or _detect_space(yes)
+    space = space or _detect_space(branch, yes)
     if space is None:
         return
 


### PR DESCRIPTION
Because Travis checks out commits in detached HEAD mode, checking the name of the active branch doesn't work. This patch adds an optional `branch` override before resorting to checking the active branch and passes `$TRAVIS_BRANCH` to that option.

Thanks @arowla for help debugging. Let's see if it works this time. Once the webapp is deploying successfully, I'll submit the changes to the API side as well.