### PR TITLE
Feature/fix typeahead sort

### DIFF
--- a/openfecwebapp/tests/selenium/base_test_class.py
+++ b/openfecwebapp/tests/selenium/base_test_class.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import unittest
 
 import pytest
@@ -9,6 +10,10 @@ from selenium.webdriver.common.keys import Keys
 from selenium.common.exceptions import NoSuchElementException
 
 from openfecwebapp.sauce import SauceClient
+
+# Silence Selenium logs
+remote_logger = logging.getLogger('selenium.webdriver.remote.remote_connection')
+remote_logger.setLevel(logging.WARN)
 
 
 sauce_url = 'http://{0}:{1}@ondemand.saucelabs.com:80/wd/hub'.format(

--- a/static/js/modules/typeahead.js
+++ b/static/js/modules/typeahead.js
@@ -3,6 +3,7 @@
 /* global require, module, window, Bloodhound, API_LOCATION, API_VERSION, API_KEY */
 
 var $ = require('jquery');
+var _ = require('underscore');
 require('typeahead.js');
 var URI = require('URIjs');
 var Handlebars = require('handlebars');
@@ -11,35 +12,27 @@ var events = require('./events.js');
 var terms = require('./terms');
 var glossary = require('./glossary.js');
 
+
+var officeMap = {
+  H: 'House of Representatives',
+  S: 'Senate',
+  P: 'President'
+};
+
 var filterCandidates = function(result) {
-
-  var officeFull,
-      officeMap,
-      filteredResults;
-
-  officeMap = {
-    "H": "House of Representatives",
-    "S": "Senate",
-    "P": "President"
-  }
-
-  officeFull = officeMap[result.office_sought];
-
-  filteredResults =   {
+  return {
     name: result.name,
     id: result.candidate_id,
-    office: officeFull
-  }
-  return filteredResults;
-}
+    office: officeMap[result.office_sought]
+  };
+};
 
 var filterCommittees = function(result) {
-  var filteredResults =   {
+  return {
     name: result.name,
     id: result.committee_id
-  }
-  return filteredResults;
-}
+  };
+};
 
 module.exports = {
   init: function(){
@@ -68,12 +61,14 @@ module.exports = {
       remote: {
         url: url,
         filter: function(response) {
-          var results = $.map(response.results, function(result){
-            if ( result.candidate_id !== null ) {
+          return _.chain(response.results)
+            .filter(function(result) {
+              return result.candidate_id;
+            })
+            .map(function(result) {
               return filterCandidates(result);
-            }
-          });
-          return results;
+            })
+            .value();
         }
       },
       datumTokenizer: function(d) {
@@ -91,12 +86,14 @@ module.exports = {
       remote: {
         url: url,
         filter: function(response) {
-          var results = $.map(response.results, function(result) {
-            if ( result.committee_id !== null ) {
+          return _.chain(response.results)
+            .filter(function(result) {
+              return result.committee_id;
+            })
+            .map(function(result) {
               return filterCommittees(result);
-            }
-          });
-          return results;
+            })
+            .value();
         }
       },
       datumTokenizer: function(d) {
@@ -117,7 +114,7 @@ module.exports = {
     committeeSuggestion = Handlebars.compile('<span>{{ name }}</span>');
     headerTpl = function(label) {
       return Handlebars.compile('<span class="tt-dropdown-title">' + label + '</span>');
-    }
+    };
 
     // Setting up main search typehead
     $('.search-bar').typeahead({


### PR DESCRIPTION
Fix grouping in main typeahead search.

The actual issue here turned out to be that we were checking the
candidate and committee IDs against `null` but were getting back a
different falsy value of `''`. This patch uses a more general check,
ignoring results with all falsy ID values, and revises the filtering
logic to use a more explicit filter and map, rather than the implicit
filtering in `$.map`.

[Resolves https://github.com/18F/openFEC/issues/741]
