### PR TITLE
Use election cycles for cycle range in candidates table.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -135,11 +135,13 @@ def date_filter_sm(date_str):
         return ''
     return parse_date(date_str).strftime('%m/%y')
 
+
 @app.template_filter('date_md')
 def date_filter_md(date_str):
     if not date_str:
         return ''
     return parse_date(date_str).strftime('%b %Y')
+
 
 @app.template_filter('last_n_characters')
 def last_n_characters(value, nchar=3):
@@ -147,11 +149,21 @@ def last_n_characters(value, nchar=3):
         return value % (10 ** nchar)
     return ''
 
+
 @app.template_filter()
 def fmt_year_range(year):
     if type(year) == int:
         return "{} - {}".format(year - 1, year)
     return None
+
+
+@app.template_filter()
+def fmt_cycles_range(cycles):
+    if not cycles:
+        return None
+    if len(cycles) > 1:
+        return '{} - {}'.format(min(cycles), max(cycles))
+    return '{}'.format(cycles[0])
 
 
 @app.template_filter()

--- a/templates/macros/years.html
+++ b/templates/macros/years.html
@@ -1,7 +1,0 @@
-{% macro fmt_first_last_year(first_year, last_year) %}
-  {% if first_year != last_year %}
-    {{ first_year }} - {{ last_year }}
-  {% else %} 
-    {{ last_year }}
-  {% endif %}
-{% endmacro %}

--- a/templates/partials/candidates-table.html
+++ b/templates/partials/candidates-table.html
@@ -15,7 +15,7 @@
             <tr>
                 <td class="flex-cell" scope="row"><a class="single-link" title="{{c.name}}" data-id="{{ c.candidate_id }}" data-category="candidate" href="{{ url_for('candidate_page', c_id=c.candidate_id) }}">{{c.name}}</a></td>
                 <td>{{c.office_full}}</td>
-                <td>{{ years.fmt_first_last_year(c.election_years[0], c.active_through)}}</td>
+                <td>{{c.cycles | fmt_cycles_range}}
                 <td>{{c.party_full}}</td>
                 <td>{{c.state}}</td>
                 <td>{{c.district}}</td>

--- a/templates/partials/candidates-table.html
+++ b/templates/partials/candidates-table.html
@@ -1,4 +1,3 @@
-{% import 'macros/years.html' as years %}
 <table id="results" class="responsive">
     <thead>
         <tr>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,3 +37,15 @@ def test_fmt_year_range_int():
 def test_fmt_year_range_not_int():
     assert app.fmt_year_range('1985') is None
     assert app.fmt_year_range(None) is None
+
+
+def test_fmt_cycles_range_one_cycle():
+    assert app.fmt_cycles_range([2012]) == '2012'
+
+
+def test_fmt_cycles_range_multiple_cycles():
+    assert app.fmt_cycles_range([1998, 1996, 2002]) == '1996 - 2002'
+
+
+def test_fmt_cycles_none():
+    assert app.fmt_cycles_range(None) is None


### PR DESCRIPTION
The `election_years` and `cycles` columns aren't exactly the same. Since
the filter and table header refer to election cycles, we should use the
cycles data.

* Use election cycles rather than years to build election cycles column.
* Add min-max range filter to display cycle ranges.
* Update unit tests.