### PR TITLE
Chart data from reports

### DIFF
--- a/static/styles/_components/_charts.scss
+++ b/static/styles/_components/_charts.scss
@@ -111,7 +111,7 @@ $tooltip-border-color: #999;
     position: relative;
     height: 100%;
     
-    margin-left: 15px;
+    margin-left: 10%;
 
     &:first-of-type {
       margin-left: 0;

--- a/static/styles/_components/_charts.scss
+++ b/static/styles/_components/_charts.scss
@@ -25,14 +25,16 @@ $tooltip-border-color: #999;
 }
 
 .data--disbursement,
-.data--disbursements { 
+.data--disbursements,
+.data--total_disbursements_period { 
   background: $data-disbursement; 
   .chart-series__bar__tooltip {
     color: $data-disbursement;
   }
 }
 
-.data--receipts { 
+.data--receipts,
+.data--total_receipts_period { 
   background: $data-receipt; 
   .chart-series__bar__tooltip {
     color: $data-receipt;
@@ -109,7 +111,7 @@ $tooltip-border-color: #999;
     position: relative;
     height: 100%;
     
-    margin-left: 10%;
+    margin-left: 15px;
 
     &:first-of-type {
       margin-left: 0;

--- a/templates/partials/committee-charts.html
+++ b/templates/partials/committee-charts.html
@@ -18,7 +18,7 @@
         <li><span class="swatch data--disbursements"></span> Disbursements</li>
       </ul>
     </div>
-    {{ charts.chart_series_grouped(totals|reverse, ('receipts', 'disbursements'),
+    {{ charts.chart_series_grouped(reports|reverse, ('total_receipts_period', 'total_disbursements_period'),
        label_key=('coverage_start_date', 'coverage_end_date'), tooltip=group_bar_tooltip) }}
   </figure>
 </div>


### PR DESCRIPTION
We should be using reports data for the Receipts and Disbursements chart, so this does that.

Eventually we'll want to filter these to just be the ones in the current two year period and show more than just the last four, but that can happen later.