### PR TITLE
fixing glossary definitions

### DIFF
--- a/templates/partials/committee-summary.html
+++ b/templates/partials/committee-summary.html
@@ -6,11 +6,11 @@
   <h4 class="figure__title">Totals for {{totals.cycle|fmt_year_range|default("unavailable")}}</h4>
   <div class="table__half">
     <div class="table__row">
-      <div class="table__cell">Total <span class="term" data-term="Receipts">receipts</span></div>
+      <div class="table__cell">Total <span class="term" data-term="Total Receipts">receipts</span></div>
       <div class="table__cell">{{totals.receipts|currency|default("unavailable")}}</div>
     </div>
     <div class="table__row">
-      <div class="table__cell">Total <span class="term" data-term="Disbursements">disbursements</span></div>
+      <div class="table__cell">Total <span class="term" data-term="Total Disbursements">disbursements</span></div>
       <div class="table__cell">{{totals.disbursements|currency|default("unavailable")}}</div>
     </div>
     <div class="table__row--note">


### PR DESCRIPTION
The term labels were mislabled here so the definitions weren't showing up.