### PR TITLE
Remove a redundant API call.

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -59,11 +59,6 @@ def load_cmte_financials(committee_id):
     }
 
 
-def load_election_years(candidate_id):
-    candidate = _call_api('/candidate/', candidate_id)
-    return candidate.get('election_years', [])
-
-
 def install_cache():
     import requests_cache
     requests_cache.install_cache()

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -1,9 +1,8 @@
 from flask import render_template
 from openfecwebapp.models.shared import generate_pagination_values
-from openfecwebapp.api_caller import load_cmte_financials, load_election_years
+from openfecwebapp.api_caller import load_cmte_financials
 from werkzeug.exceptions import abort
 
-import re
 
 def render_search_results(candidates, committees, query):
     # if true will show "no results" message
@@ -52,7 +51,6 @@ def render_candidate(data, committees=None):
 
     # candidate fields will be top-level in the template
     tmpl_vars = results
-    tmpl_vars['election_years'] = load_election_years(results['candidate_id'])
 
     # add 'committees' level to template
     tmpl_vars['has_authorized_cmtes'] = False


### PR DESCRIPTION
The candidate summary view was previously making two calls to the same API endpoint to fetch candidate information. This patch drops the redundant second call. This should make the candidate summary page load a bit faster.