### PR TITLE
Use full-text search for committee and candidate search fields.

### DIFF
--- a/static/js/modules/filters.js
+++ b/static/js/modules/filters.js
@@ -69,7 +69,7 @@ var selectedFilters = {};
 
 // all of the filters we use on candidates and committees
 var fieldMap = [
-    'name',
+    'q',
     'cycle',
     'party',
     'state',

--- a/templates/candidates.html
+++ b/templates/candidates.html
@@ -1,7 +1,7 @@
 {% extends 'layouts/main.html' %}
 
 {% block title %}
-   Browse Candidates 
+   Browse Candidates
 {% endblock %}
 
 {% block header %}
@@ -24,10 +24,10 @@
 <section class="results-content">
   <div id="filters" class="side-panel side-panel--left">
     <form id="category-filters">
-        <div class="field" id="name-field">
-          <label for="name">Name</label>
-          <input type="text" name="name" />
-          <button type="button" class="button--remove" data-removes="name"><i class="ti-close"></i></button>
+        <div class="field" id="q-field">
+          <label for="q">Name</label>
+          <input type="text" name="q" />
+          <button type="button" class="button--remove" data-removes="q"><i class="ti-close"></i></button>
         </div>
 
         {% include 'partials/filters/election-years.html' %}
@@ -45,7 +45,7 @@
   <div id="candidates" class="results-container">
     {% if candidates %}
         {% include 'partials/candidates-table.html' %}
-    {% else %}    
+    {% else %}
       <div class="meta-box error-container">
         <h2 id="section-1-header" tabindex="0">No candidates matched your filters</h2>
         <p class="text--lead">Try adjusting your filters or searching by name.</p>
@@ -61,5 +61,5 @@
     {% if pagination %}
       {% include 'partials/pagination.html' %}
     {% endif %}
-  </div>  
-{% endblock %} 
+  </div>
+{% endblock %}

--- a/templates/committees.html
+++ b/templates/committees.html
@@ -25,10 +25,10 @@
   <div id="filters" class="side-panel side-panel--left">
     <h4>Filter Committees</h4>
     <form id="category-filters">
-        <div class="field" id="name-field">
-            <label for="name">Name</label>
-            <input type="text" name="name" id="name" />
-            <button type="button" class="button--remove" data-removes="name"><i class="ti-close"></i></button>
+        <div class="field" id="q-field">
+            <label for="q">Name</label>
+            <input type="text" name="q" id="q" />
+            <button type="button" class="button--remove" data-removes="q"><i class="ti-close"></i></button>
         </div>
 
         {% include 'partials/filters/election-years.html' %}


### PR DESCRIPTION
This patch passes the name search value as "q" instead of "name",
meaning that we use the full-text search on candidate and committee
names instead of the stricter `ILIKE` used by "name". Practically, this
means that searching for "nancy pelosi", "pelosi nancy", or "pelosi,
nancy" will all yield Nancy Pelosi, which is what I think users will
expect.

One side effect of this proposal is that searching for a
candidate's FEC ID will also find that candidate, since the full-text
search includes both name and ID. If this is a problem, we can fix it on
the backend, but I don't think it's a cause for concern.

[Resolves https://github.com/18F/openFEC/issues/777]