### PR TITLE
Use harmonized reports names as updated in API.

### DIFF
--- a/templates/partials/committee-report-house-senate.html
+++ b/templates/partials/committee-report-house-senate.html
@@ -34,7 +34,7 @@
 {{ totals_table('Beginning Cash on Hand', reports.0.cash_on_hand_beginning_period) }}
 {{ totals_table('Ending Cash on Hand', reports.0.cash_on_hand_end_period) }}
 {{ totals_table('Net Contributions', reports.0.net_contributions_period) }}
-{{ totals_table('Operating Expenditures', reports.0.net_operating_expenditures_period) }}
+{{ totals_table('Net Operating Expenditures', reports.0.net_operating_expenditures_period) }}
 {{ totals_table('Debts Owed to Committee', reports.0.debts_owed_to_committee) }}
 {{ totals_table('Debts Owed by Committee', reports.0.debts_owed_by_committee) }}
 

--- a/templates/partials/committee-report-house-senate.html
+++ b/templates/partials/committee-report-house-senate.html
@@ -13,7 +13,7 @@
      (reports.0.other_receipts_period, 'Other Receipts'),
    ]
 %}
-{{ totals_table('Total receipts', reports.0.total_receipts_period, table_data,
+{{ totals_table('Total Receipts', reports.0.total_receipts_period, table_data,
     committee.report_year, header_description='Money received by the committee' ) }}
 
 {% set table_data = [
@@ -24,18 +24,18 @@
      (reports.0.refunds_individual_contributions_period, 'Individual Refunds'),
      (reports.0.refunds_political_party_committee_contributions_period, 'Political Party Refunds'),
      (reports.0.refunds_other_political_committee_contributions_period, 'Other Committee Refunds'),
-     (reports.0.other_disbursements_period, 'Other disbursements'),
+     (reports.0.other_disbursements_period, 'Other Disbursements'),
    ]
 %}
 
 {{ totals_table('Total Disbursements', reports.0.total_disbursements_period, table_data,
     committee.report_year, header_description='Money spent by the committee' ) }}
 
-{{ totals_table('Beginning cash on hand', reports.0.cash_on_hand_beginning_period) }}
-{{ totals_table('Ending cash on hand', reports.0.cash_on_hand_end_period) }}
+{{ totals_table('Beginning Cash on Hand', reports.0.cash_on_hand_beginning_period) }}
+{{ totals_table('Ending Cash on Hand', reports.0.cash_on_hand_end_period) }}
 {{ totals_table('Net Contributions', reports.0.net_contributions_period) }}
 {{ totals_table('Operating Expenditures', reports.0.net_operating_expenditures_period) }}
-{{ totals_table('Debts owed to committee', reports.0.debts_owed_to_committee) }}
-{{ totals_table('Debts owed by committee', reports.0.debts_owed_by_committee) }}
+{{ totals_table('Debts Owed to Committee', reports.0.debts_owed_to_committee) }}
+{{ totals_table('Debts Owed by Committee', reports.0.debts_owed_by_committee) }}
 
 {% endwith %}

--- a/templates/partials/committee-report-pac-party.html
+++ b/templates/partials/committee-report-pac-party.html
@@ -41,7 +41,7 @@
 
 {{ totals_table('Beginning cash on hand', reports.0.cash_on_hand_beginning_period) }}
 {{ totals_table('Ending cash on hand', reports.0.cash_on_hand_end_period) }}
-{{ totals_table('Net Contributions', reports.0.net_contributions) }}
+{{ totals_table('Net Contributions', reports.0.net_contributions_period) }}
 {{ totals_table('Net Operating Expenditures', reports.0.net_operating_expenditures_period) }}
 {{ totals_table('Debts owed to committee', reports.0.debts_owed_to_committee) }}
 {{ totals_table('Debts owed by committee', reports.0.debts_owed_by_committee) }}

--- a/templates/partials/committee-report-pac-party.html
+++ b/templates/partials/committee-report-pac-party.html
@@ -6,7 +6,6 @@
      (reports.0.individual_unitemized_contributions_period, 'Unitemized Individual Contributions'),
      (reports.0.political_party_committee_contributions_period, 'Party Committees Contributions'),
      (reports.0.other_political_committee_contributions_period, 'Other Committees Contributions'),
-     (reports.0.other_political_committee_contributions_period, 'Transfers from Affiliated Committees'),
      (reports.0.all_loans_received_period, 'Loans Received'),
      (reports.0.loan_repayments_received_period, 'Loan Repayments Received'),
      (reports.0.offsets_to_operating_expenditures_period, 'Offsets to operating Expenditures'),

--- a/templates/partials/committee-report-pac-party.html
+++ b/templates/partials/committee-report-pac-party.html
@@ -1,4 +1,3 @@
-
 {% with committee=context() %}
 
 {% set table_data = [
@@ -15,7 +14,7 @@
      (reports.0.transfers_from_nonfed_levin_period, 'Levin Funds'),
    ]
 %}
-{{ totals_table('Total receipts', reports.0.total_receipts_period, table_data,
+{{ totals_table('Total Receipts', reports.0.total_receipts_period, table_data,
     committee.report_year, header_description='Money received by the committee' ) }}
 
 {% set table_data = [
@@ -30,7 +29,7 @@
      (reports.0.individual_contribution_refunds_period, 'Individual Refunds'),
      (reports.0.political_party_committee_contribution_refunds_period, 'Politial Party Refunds'),
      (reports.0.other_political_committee_contribution_refunds_period, 'Other Committee Refunds'),
-     (reports.0.other_disbursements_period, 'Other disbursements'),
+     (reports.0.other_disbursements_period, 'Other Disbursements'),
      (reports.0.shared_fed_activity_period, 'Federal Allocated Election Activity'),
      (reports.0.non_allocated_fed_election_activity_period, 'Non-Federal Allocated Election Activity'),
    ]
@@ -38,12 +37,11 @@
 {{ totals_table('Total Disbursements', reports.0.total_disbursements_period, table_data,
     committee.report_year, header_description='Money spent by the committee' ) }}
 
-{{ totals_table('Beginning cash on hand', reports.0.cash_on_hand_beginning_period) }}
-{{ totals_table('Ending cash on hand', reports.0.cash_on_hand_end_period) }}
+{{ totals_table('Beginning Cash on Hand', reports.0.cash_on_hand_beginning_period) }}
+{{ totals_table('Ending Cash on Hand', reports.0.cash_on_hand_end_period) }}
 {{ totals_table('Net Contributions', reports.0.net_contributions_period) }}
 {{ totals_table('Net Operating Expenditures', reports.0.net_operating_expenditures_period) }}
-{{ totals_table('Debts owed to committee', reports.0.debts_owed_to_committee) }}
-{{ totals_table('Debts owed by committee', reports.0.debts_owed_by_committee) }}
+{{ totals_table('Debts Owed to Committee', reports.0.debts_owed_to_committee) }}
+{{ totals_table('Debts Owed by Committee', reports.0.debts_owed_by_committee) }}
 
 {% endwith %}
-

--- a/templates/partials/committee-report-presidential.html
+++ b/templates/partials/committee-report-presidential.html
@@ -36,7 +36,7 @@
 {{ totals_table('Beginning Cash on Hand', committee.reports.0.cash_on_hand_beginning_period) }}
 {{ totals_table('Ending Cash on Hand', committee.reports.0.cash_on_hand_end_period) }}
 {{ totals_table('Net Contributions', reports.0.net_contributions_period) }}
-{{ totals_table('Operating Expenditures', reports.0.net_operating_expenditures_period) }}
+{{ totals_table('Net Operating Expenditures', reports.0.net_operating_expenditures_period) }}
 {{ totals_table('Debts Owed to Committee', committee.reports.0.debts_owed_to_committee) }}
 {{ totals_table('Debts Owed by Committee', committee.reports.0.debts_owed_by_committee) }}
 

--- a/templates/partials/committee-report-presidential.html
+++ b/templates/partials/committee-report-presidential.html
@@ -15,11 +15,11 @@
      (reports.0.other_receipts_period, 'Other Receipts'),
    ]
 %}
-{{ totals_table('Total receipts', reports.0.total_receipts_period, table_data,
+{{ totals_table('Total Receipts', reports.0.total_receipts_period, table_data,
     committee.report_year, header_description='Money received by the committee' ) }}
 
 {% set table_data = [
-     (reports.0.operating_expenditures_period, 'Operating expenditures'),
+     (reports.0.operating_expenditures_period, 'Operating Expenditures'),
      (reports.0.transfer_to_other_authorized_committee_period, 'Transfers to Authorized Committees'),
      (reports.0.repayments_loans_made_by_candidate_period, 'Candidate Loan Repayments'),
      (reports.0.repayments_other_loans_period, 'Other Loan Repayments'),
@@ -27,17 +27,17 @@
      (reports.0.refunds_individual_contributions_period, 'Individual Refunds'),
      (reports.0.refunded_political_party_committee_contributions_period, 'Political Party Refunds'),
      (reports.0.refunded_other_political_committee_contributions_period, 'Other Committee Refunds'),
-     (reports.0.other_disbursements_period, 'Other disbursements'),
+     (reports.0.other_disbursements_period, 'Other Disbursements'),
    ]
 %}
 {{ totals_table('Total Disbursements', reports.0.total_disbursements_period, table_data,
     committee.report_year, header_description='Money spent by the committee' ) }}
 
-{{ totals_table('Beginning cash on hand', committee.reports.0.cash_on_hand_beginning_period) }}
-{{ totals_table('Ending cash on hand', committee.reports.0.cash_on_hand_end_period) }}
+{{ totals_table('Beginning Cash on Hand', committee.reports.0.cash_on_hand_beginning_period) }}
+{{ totals_table('Ending Cash on Hand', committee.reports.0.cash_on_hand_end_period) }}
 {{ totals_table('Net Contributions', reports.0.net_contributions_period) }}
 {{ totals_table('Operating Expenditures', reports.0.net_operating_expenditures_period) }}
-{{ totals_table('Debts owed to committee', committee.reports.0.debts_owed_to_committee) }}
-{{ totals_table('Debts owed by committee', committee.reports.0.debts_owed_by_committee) }}
+{{ totals_table('Debts Owed to Committee', committee.reports.0.debts_owed_to_committee) }}
+{{ totals_table('Debts Owed by Committee', committee.reports.0.debts_owed_by_committee) }}
 
 {% endwith %}

--- a/templates/partials/committee-report-presidential.html
+++ b/templates/partials/committee-report-presidential.html
@@ -35,8 +35,8 @@
 
 {{ totals_table('Beginning cash on hand', committee.reports.0.cash_on_hand_beginning_period) }}
 {{ totals_table('Ending cash on hand', committee.reports.0.cash_on_hand_end_period) }}
-{{ totals_table('Net Contributions', reports.0.net_contribution_summary_period) }}
-{{ totals_table('Operating Expenditures', reports.0.net_operating_expenditures_summary_period) }}
+{{ totals_table('Net Contributions', reports.0.net_contributions_period) }}
+{{ totals_table('Operating Expenditures', reports.0.net_operating_expenditures_period) }}
 {{ totals_table('Debts owed to committee', committee.reports.0.debts_owed_to_committee) }}
 {{ totals_table('Debts owed by committee', committee.reports.0.debts_owed_by_committee) }}
 

--- a/templates/partials/committee-totals-house-senate.html
+++ b/templates/partials/committee-totals-house-senate.html
@@ -14,7 +14,7 @@
      (totals.0.other_receipts, 'Other Receipts'),
    ]
 %}
-{{ totals_table('Total receipts', totals.0.receipts, table_data,
+{{ totals_table('Total Receipts', totals.0.receipts, table_data,
     committee.report_year, header_description='Money received by the committee' ) }}
 
 {% set table_data = [
@@ -26,7 +26,7 @@
      (totals.0.refunds_individual_contributions, 'Individual Refunds'),
      (totals.0.refunds_political_party_committee_contributions, 'Political Party Refunds'),
      (totals.0.refunds_other_political_committee_contributions, 'Other Committee Refunds'),
-     (totals.0.other_disbursements, 'Other disbursements'),
+     (totals.0.other_disbursements, 'Other Disbursements'),
    ]
 %}
 

--- a/templates/partials/committee-totals-pac-party.html
+++ b/templates/partials/committee-totals-pac-party.html
@@ -9,14 +9,14 @@
      (totals.0.other_political_committee_contributions, 'Transfers from Affiliated Committees'),
      (totals.0.all_loans_received, 'Loans Received'),
      (totals.0.loan_repayments_received, 'Loan Repayments Received'),
-     (totals.0.offsets_to_operating_expenditures, 'Offsets to operating Expenditures'),
+     (totals.0.offsets_to_operating_expenditures, 'Offsets to Operating Expenditures'),
      (totals.0.fed_candidate_contribution_refunds, 'Candidate Refunds'),
      (totals.0.other_fed_receipts, 'Other Receipts'),
      (totals.0.transfers_from_nonfed_account, 'Non-Federal Transfers'),
      (totals.0.transfers_from_nonfed_levin, 'Levin Funds'),
    ]
 %}
-{{ totals_table('Total receipts', totals.0.receipts, table_data,
+{{ totals_table('Total Receipts', totals.0.receipts, table_data,
     committee.report_year, header_description='Money received by the committee' ) }}
 
 {% set table_data = [
@@ -32,7 +32,7 @@
      (totals.0.individual_contribution_refunds, 'Individual Refunds'),
      (totals.0.political_party_committee_contribution_refunds, 'Politial Party Refunds'),
      (totals.0.other_political_committee_contribution_refunds, 'Other Committee Refunds'),
-     (totals.0.other_disbursements, 'Other disbursements'),
+     (totals.0.other_disbursements, 'Other Disbursements'),
      (totals.0.shared_fed_activity, 'Federal Allocated Election Activity'),
      (totals.0.non_allocated_fed_election_activity, 'Non-Federal Allocated Election Activity'),
    ]
@@ -41,5 +41,3 @@
     committee.report_year, header_description='Money spent by the committee' ) }}
 
 {% endwith %}
-
-

--- a/templates/partials/committee-totals-presidential.html
+++ b/templates/partials/committee-totals-presidential.html
@@ -15,18 +15,18 @@
      (totals.0.other_receipts, 'Other Receipts'),
    ]
 %}
-{{ totals_table('Total receipts', totals.0.receipts, table_data,
+{{ totals_table('Total Receipts', totals.0.receipts, table_data,
     committee.report_year, header_description='Money received by the committee' ) }}
 
 {% set table_data = [
-     (totals.0.operating_expenditures, 'Operating expenditures'),
+     (totals.0.operating_expenditures, 'Operating Expenditures'),
      (totals.0.transfer_to_other_authorized_committee, 'Transfers to Authorized Committees'),
      (totals.0.repayments_loans_made_by_candidate, 'Candidate Loan Repayments'),
      (totals.0.repayments_other_loans, 'Other Loan Repayments'),
      (totals.0.refunded_individual_contributions, 'Individual Refunds'),
      (totals.0.refunded_political_party_committee_contributions, 'Political Party Refunds'),
      (totals.0.refunded_other_political_committee_contributions, 'Other Committee Refunds'),
-     (totals.0.other_disbursements, 'Other disbursements'),
+     (totals.0.other_disbursements, 'Other Disbursements'),
    ]
 %}
 {{ totals_table('Total Disbursements', totals.0.disbursements, table_data,


### PR DESCRIPTION
Fixes erroneous null values on net contributions for PAC and party
committees pointed out by FEC.

Recommended pairing: https://github.com/18F/openFEC/pull/801