### PR TITLE
Hide duplicate dates in charts.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -129,6 +129,29 @@ def currency_filter(num, grouping=True):
         return locale.currency(num, grouping=grouping)
 
 
+def _unique(values):
+    ret = []
+    for value in values:
+        if value not in ret:
+            ret.append(value)
+    return ret
+
+
+def _fmt_chart_tick(value):
+    return parse_date(value).strftime('%m/%y')
+
+
+@app.template_filter('fmt_chart_ticks')
+def fmt_chart_ticks(group, keys):
+    if not group or not keys:
+        return ''
+    if isinstance(keys, (list, tuple)):
+        values = [_fmt_chart_tick(group[key]) for key in keys]
+        values = _unique(values)
+        return ' - '.join(values)
+    return _fmt_chart_tick(group[keys])
+
+
 @app.template_filter('date_sm')
 def date_filter_sm(date_str):
     if not date_str:

--- a/templates/macros/charts.html
+++ b/templates/macros/charts.html
@@ -34,11 +34,7 @@
       {{ chart_bar(group[key], key, tooltip=tooltip, attr={}) }}
     {% endfor %}
     <div class="chart-series__group__label">
-      {% if label_key is string %}
-        {{ group[label_key]|default('')|date_sm }}
-      {% else %}
-        {{ group[label_key[0]]|default('')|date_sm }} - {{ group[label_key[1]]|default('')|date_sm }}
-      {% endif %}
+      {{ group | fmt_chart_ticks(label_key) }}
     </div>
   </div>
   {% endfor %}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,3 +38,30 @@ def test_fmt_year_range_int():
 def test_fmt_year_range_not_int():
     assert app.fmt_year_range('1985') is None
     assert app.fmt_year_range(None) is None
+
+
+def test_fmt_chart_ticks_single_key():
+    group = {
+        'coverage_start_date': datetime.datetime(2015, 1, 1).isoformat(),
+        'coverage_end_date': datetime.datetime(2015, 2, 1).isoformat(),
+    }
+    keys = 'coverage_start_date'
+    assert app.fmt_chart_ticks(group, keys) == '01/15'
+
+
+def test_fmt_chart_ticks_two_keys():
+    group = {
+        'coverage_start_date': datetime.datetime(2015, 1, 1).isoformat(),
+        'coverage_end_date': datetime.datetime(2015, 2, 1).isoformat(),
+    }
+    keys = ('coverage_start_date', 'coverage_end_date')
+    assert app.fmt_chart_ticks(group, keys) == '01/15 - 02/15'
+
+
+def test_fmt_chart_ticks_two_keys_repeated_value():
+    group = {
+        'coverage_start_date': datetime.datetime(2015, 1, 1).isoformat(),
+        'coverage_end_date': datetime.datetime(2015, 1, 15).isoformat(),
+    }
+    keys = ('coverage_start_date', 'coverage_end_date')
+    assert app.fmt_chart_ticks(group, keys) == '01/15'


### PR DESCRIPTION
For some monthly filings, report dates currently display as e.g. "01/15
- 01/15", which can be confusing (why does the date repeat?). This patch
checks for duplicate dates and only shows one date in that case. Logic
is also moved from templates to a filter, which is also tested.