### PR TITLE
fixing cash on hand labels and chart key

### DIFF
--- a/static/js/modules/terms.json
+++ b/static/js/modules/terms.json
@@ -32,7 +32,7 @@
     "definition": "The sum of all money spent by a committee as reported to the FEC, during a filing period."
   },  
   {
-    "term": "Cash on Hand",
+    "term": "Ending Cash on Hand",
     "definition": "The ending cash balance on a report for a particular time period. Cash on hand includes funds held in checking and savings accounts, certificates of deposit, petty cash funds, traveler’s checks, treasury bills and other investments valued at cost."
   },
   {

--- a/static/styles/_components/_figures.scss
+++ b/static/styles/_components/_figures.scss
@@ -86,18 +86,25 @@ figure {
   border-bottom: 1px solid $medium-gray;
 
   h4 {
-    float: left;
     margin-bottom: 0;
+  }
+
+  @include media($medium) {
+    h4 {
+      float: left
+    }
   }
 }
 
 .figure__key {
-  float: right;
+  float: left;
   margin-top: 2px;
   
   li {
     @include rem(margin-right, 2.0rem);
+    float: none;
   }
+
   .swatch {
     @include rem(margin-right, 1.0rem);
     height: 20px;
@@ -105,6 +112,14 @@ figure {
     border-radius: 20px;
     padding: 0;
     display: inline-block;
+  }
+
+  @include media($medium) {
+    float: right;
+
+    li {
+      float: left;
+    }
   }
 }
 

--- a/templates/partials/committee-charts.html
+++ b/templates/partials/committee-charts.html
@@ -14,8 +14,8 @@
     <div class="figure__title">
       <h4>Receipts and Disbursements</h4>
       <ul class="figure__key flat-list">
-        <li><span class="swatch data--receipts"></span> Receipts</li>
-        <li><span class="swatch data--disbursements"></span> Disbursements</li>
+        <li><span class="swatch data--receipts"></span> Total Receipts</li>
+        <li><span class="swatch data--disbursements"></span> Total Disbursements</li>
       </ul>
     </div>
     {{ charts.chart_series_grouped(reports|reverse, ('total_receipts_period', 'total_disbursements_period'),
@@ -27,7 +27,7 @@
     <div class="figure__title">
       <h4>Cash and Debt</h4>
       <ul class="figure__key flat-list">
-        <li><span class="swatch data--cash"></span> Cash</li>
+        <li><span class="swatch data--cash"></span> Ending Cash on Hand</li>
         <li><span class="swatch data--debt"></span> Debt</li>
       </ul>
     </div>

--- a/templates/partials/committee-summary.html
+++ b/templates/partials/committee-summary.html
@@ -19,7 +19,7 @@
   </div>
   <div class="table__half">
     <div class="table__row">
-      <div class="table__cell"><span class="term" data-term="Cash on Hand">Cash on hand</span></div>
+      <div class="table__cell"><span class="term" data-term="Ending Cash on Hand">Ending cash on hand</span></div>
       <div class="table__cell">{{reports.cash_on_hand_end_period|currency|default("unavailable")}}</div>
     </div>
     <div class="table__row">


### PR DESCRIPTION
Addresses 18F/openFEC#822 and also changes the chart key labels to be "Total Receipts, Total Disbursements, Ending Cash on Hand and Debt".