### PR TITLE
Feature/better bar labels

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -162,7 +162,7 @@ def _unique(values):
 
 
 def _fmt_chart_tick(value):
-    return parse_date(value).strftime('%m/%y')
+    return parse_date(value).strftime('%m/%d/%y')
 
 
 @app.template_filter('fmt_chart_ticks')
@@ -172,7 +172,7 @@ def fmt_chart_ticks(group, keys):
     if isinstance(keys, (list, tuple)):
         values = [_fmt_chart_tick(group[key]) for key in keys]
         values = _unique(values)
-        return ' - '.join(values)
+        return ' – '.join(values)
     return _fmt_chart_tick(group[keys])
 
 

--- a/static/js/modules/typeahead.js
+++ b/static/js/modules/typeahead.js
@@ -14,7 +14,7 @@ var glossary = require('./glossary.js');
 
 
 var officeMap = {
-  H: 'House of Representatives',
+  H: 'House',
   S: 'Senate',
   P: 'President'
 };

--- a/static/styles/_components/_charts.scss
+++ b/static/styles/_components/_charts.scss
@@ -126,7 +126,6 @@ $tooltip-border-color: #999;
     @include display(flex);
     @include flex-direction(row);
     @include align-items(flex-end);
-    max-width: 90px;
     z-index: 9;
     
     .chart-series__bar + .chart-series__bar {
@@ -190,7 +189,7 @@ $tooltip-border-color: #999;
   text-align: center;
 
   @include media($medium) {
-    font-size: 1.4rem;
+    font-size: 1.2rem;
   }
 }
 

--- a/static/styles/_components/_search-bar.scss
+++ b/static/styles/_components/_search-bar.scss
@@ -53,7 +53,7 @@
 
 // Typeahead
 .tt-dropdown-menu {
-  @include font-size(1.4);
+  @include font-size(1.2);
   background: #fff;
   top: 32px !important;
   text-align: left;
@@ -67,7 +67,7 @@
 
 #large-search {
   .tt-dropdown-menu {
-    @include font-size(1.6);
+    @include font-size(1.4);
     top: 70px !important;
   }
 }
@@ -101,7 +101,7 @@
 
 .tt-suggestion__office {
   @include truncate();
-  @include font-size(1.4);
+  @include font-size(1.2);
   text-align: right;
   display: block;
   width: 35%;

--- a/static/styles/_components/_search-bar.scss
+++ b/static/styles/_components/_search-bar.scss
@@ -59,7 +59,8 @@
   text-align: left;
   box-shadow: 0 1px 1px rgba(0,0,0,.3);
   border: 1px solid $light-gray;
-
+  width: 100%;
+  
   @include media($medium) {
     width: 75%;
   }
@@ -68,7 +69,13 @@
 #large-search {
   .tt-dropdown-menu {
     @include font-size(1.4);
-    top: 70px !important;
+    top: 40px !important;
+  }
+
+  @include media($medium) {
+    .tt-dropdown-menu {
+      top: 60px !important;
+    }
   }
 }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,10 +50,10 @@ def test_restrict_cycles():
 def test_fmt_chart_ticks_single_key():
     group = {
         'coverage_start_date': datetime.datetime(2015, 1, 1).isoformat(),
-        'coverage_end_date': datetime.datetime(2015, 2, 1).isoformat(),
+        'coverage_end_date': datetime.datetime(2015, 1, 1).isoformat(),
     }
     keys = 'coverage_start_date'
-    assert app.fmt_chart_ticks(group, keys) == '01/15'
+    assert app.fmt_chart_ticks(group, keys) == '01/01/2015'
 
 
 def test_fmt_chart_ticks_two_keys():
@@ -62,7 +62,7 @@ def test_fmt_chart_ticks_two_keys():
         'coverage_end_date': datetime.datetime(2015, 2, 1).isoformat(),
     }
     keys = ('coverage_start_date', 'coverage_end_date')
-    assert app.fmt_chart_ticks(group, keys) == '01/15 - 02/15'
+    assert app.fmt_chart_ticks(group, keys) == '01/01/15 – 02/01/15'
 
 
 def test_fmt_chart_ticks_two_keys_repeated_value():
@@ -71,4 +71,4 @@ def test_fmt_chart_ticks_two_keys_repeated_value():
         'coverage_end_date': datetime.datetime(2015, 1, 15).isoformat(),
     }
     keys = ('coverage_start_date', 'coverage_end_date')
-    assert app.fmt_chart_ticks(group, keys) == '01/15'
+    assert app.fmt_chart_ticks(group, keys) == '01/01/15 – 01/15/15'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,7 +53,7 @@ def test_fmt_chart_ticks_single_key():
         'coverage_end_date': datetime.datetime(2015, 1, 1).isoformat(),
     }
     keys = 'coverage_start_date'
-    assert app.fmt_chart_ticks(group, keys) == '01/01/2015'
+    assert app.fmt_chart_ticks(group, keys) == '01/01/15'
 
 
 def test_fmt_chart_ticks_two_keys():


### PR DESCRIPTION
Changed the dates on the bar chart labels to be `dd/mm/yy` to address https://github.com/18F/openFEC/issues/821 . They make so much more sense now.

![screen shot 2015-05-26 at 4 40 44 pm](https://cloud.githubusercontent.com/assets/1696495/7825812/5c72b610-03c6-11e5-9a21-26cf929f5ce9.png)

Also restyled the typeahead suggestions to make names easier to read (addresses https://github.com/18F/openFEC/issues/833)