### PR TITLE
Generate correct history parameter when next cycle is not available.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -216,10 +216,14 @@ def restrict_cycles(value):
 
 @app.template_filter()
 def next_cycle(value, cycles):
-    """Get the earliest election cycle greater than or equal to `value`."""
+    """Get the earliest election cycle greater than or equal to `value`. If no
+    cycles match, use the most recent cycle to avoid empty results from the
+    history endpoint.
+    """
+    cycles = sorted(restrict_cycles(cycles))
     return next(
-        (each for each in sorted(cycles) if value <= each),
-        value
+        (each for each in cycles if value <= each),
+        max(cycles),
     )
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -42,9 +42,13 @@ def resolve_cycle(candidate):
     return None
 
 
+def current_cycle():
+    year = datetime.datetime.now().year
+    return year + year % 2
+
+
 def _get_default_cycles():
-    now = datetime.datetime.now().year
-    cycle = now + now % 2
+    cycle = current_cycle()
     return list(range(cycle - 4, cycle + 2, 2))
 
 
@@ -102,7 +106,7 @@ def candidate_page(c_id, cycle=None, history=None):
     history = history or cycle
     path = ('history', str(history)) if history else ()
     data = load_single_type('candidate', c_id, *path)
-    cycle = cycle or max(data['results'][0]['cycles'])
+    cycle = cycle or min(current_cycle(), max(data['results'][0]['cycles']))
     committee_data = load_nested_type('candidate', c_id, 'committees', cycle=cycle)['results']
     return render_candidate(data, committees=committee_data, cycle=cycle)
 
@@ -118,7 +122,7 @@ def committee_page(c_id, cycle=None):
     """
     path = ('history', str(cycle)) if cycle else ()
     data = load_single_type('committee', c_id, *path)
-    cycle = cycle or max(data['results'][0]['cycles'])
+    cycle = cycle or min(current_cycle(), max(data['results'][0]['cycles']))
     candidate_data = load_nested_type('committee', c_id, 'candidates', cycle=cycle)['results']
     return render_committee(data, candidates=candidate_data, cycle=cycle)
 
@@ -209,9 +213,7 @@ def fmt_report_desc(report_full_description):
 
 @app.template_filter()
 def restrict_cycles(value):
-    year = datetime.datetime.now().year
-    cycle = year + year % 2
-    return [each for each in value if each <= cycle]
+    return [each for each in value if each <= current_cycle()]
 
 
 @app.template_filter()

--- a/templates/partials/committee-stats.html
+++ b/templates/partials/committee-stats.html
@@ -8,7 +8,7 @@
   <div class="figure-group__main">
     <div class="figure-group__header">
       <h4 class="figure-group__title">
-        <a href="{{ url_for('committee_page', c_id=committee.committee_id) }}">{{ committee.name }}</a>
+        <a href="{{ url_for('committee_page', c_id=committee.committee_id, cycle=cycle) }}">{{ committee.name }}</a>
       </h4>
     </div>
 

--- a/templates/partials/financial-summary.html
+++ b/templates/partials/financial-summary.html
@@ -25,7 +25,7 @@
     <p class="text--lead">Below, is a list of the candidate’s joint fundraising committees—in joint fundraising, a political committee raises funds with at least one other political committee or unregistered organization. Committees involved in joint fundraising share the costs of the fundraiser and divide up the money raised according to a ratio agreed to by the participants when the joint fundraising committee is formed. Click the links to see more information about a particular committee.</p>
       <ul>
         {% for committee in committees if committee.designation == 'J' %}
-          <li><a href="{{ url_for('committee_page', c_id=committee.committee_id) }}">{{ committee.name }} &raquo;</a></li>
+          <li><a href="{{ url_for('committee_page', c_id=committee.committee_id, cycle=cycle) }}">{{ committee.name }} &raquo;</a></li>
         {% endfor %}
       </ul>
     </div>


### PR DESCRIPTION
We use the `next_cycle` filter to generate the `history` query parameter
for the candidate detail page. The filter is meant to get the next
active cycle greater or equal to the specified cycle. This patch handles
the edge case in which no such cycle is found, in which case we should
simply use the latest active cycle. This fixes some errors on Jeff
Flake's candidate page.