### PR TITLE
Preserve casing on committee titles.

### DIFF
--- a/templates/candidates-single.html
+++ b/templates/candidates-single.html
@@ -1,7 +1,7 @@
 {% extends 'layouts/main.html' %}
 
 {% block title %}
-    {{name | title}} - Candidate Overview
+    {{ name }} - Candidate Overview
 {% endblock %}
 
 {% block header %}

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -2,7 +2,7 @@
 {% import 'macros/missing.html' as missing %}
 
 {% block title %}
-    {{name | title}} - Committee Overview
+    {{ name }} - Committee Overview
 {% endblock %}
 
 {% block header %}


### PR DESCRIPTION
[Resolves #851]

The `title` filter capitalizes the first letter of each word and lower-cases the rest. Not what we want for committee or candidate names.