### PR TITLE
Show glossary options on focus.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node-bourbon": "^4.2.2",
     "node-neat": "^1.7.1-beta1",
     "querystring": "^0.2.0",
-    "typeahead.js": "^0.10.5",
+    "typeahead.js": "^0.11.1",
     "underscore": "^1.7.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",

--- a/static/styles/_components/_search-bar.scss
+++ b/static/styles/_components/_search-bar.scss
@@ -10,14 +10,14 @@
   label {
     margin-bottom: 30px;
   }
-  
+
   @include media($medium) {
     .input-button-combo {
       height: 6rem;
       font-size: 2.0rem;
     }
   }
-  
+
   @include media($large) {
     @include span-columns(18 of 22);
     @include shift(2 of 22);
@@ -46,7 +46,7 @@
   width: 100%;
 }
 
-.tt-dropdown-menu {
+.tt-menu {
   @include font-size(1.2);
   background: #fff;
   text-align: left;
@@ -56,36 +56,33 @@
 }
 
 #large-search {
-  .tt-dropdown-menu {
+  .tt-menu {
     @include font-size(1.6);
     top: 60px !important;
   }
 
   @include media($medium) {
-    .tt-dropdown-menu {
+    .tt-menu {
       top: 60px !important;
     }
   }
 }
 
-.tt-dropdown-title {
-  display: block;
-  color: #fff;
-  padding: 5px 20px;
-  background: $dark-gray;
-}
-
-.tt-suggestions {
-  color: #000;
-}
+// .tt-menu:hover {
+//   display: block;
+//   color: #fff;
+//   padding: 5px 20px;
+//   background: $dark-gray;
+// }
 
 .tt-suggestion {
-  @include clearfix();
+  // @include clearfix();
   position: relative;
   padding: 10px 20px;
   margin-bottom: 0;
   line-height: 1;
   border-bottom: 1px solid $light-gray;
+  color: #000;
 }
 
 .tt-suggestion__name {
@@ -106,7 +103,7 @@
   font-style: italic;
 }
 
-.tt-cursor {
+.tt-suggestion:hover, .tt-suggestion.tt-cursor {
   cursor: pointer;
   background: $blue;
   color: #fff;


### PR DESCRIPTION
* Upgrade to latest typeahead.js.
* Show default glossary options on focus.

NB: Still needs work on updating styles for latest typeahead.js.

@noahmanger: Help with styles much appreciated!