### PR TITLE
Making placeholder text consistent

### DIFF
--- a/static/js/modules/search.js
+++ b/static/js/modules/search.js
@@ -11,7 +11,7 @@ var defaultOpts = {
 };
 
 function onSelectChange($input, updatedText) {
-  $input.attr('placeholder', updatedText);
+  $input.attr('placeholder', updatedText).attr('aria-label', updatedText);
 };
 
 var Search = function($el, opts) {

--- a/templates/partials/search-bar.html
+++ b/templates/partials/search-bar.html
@@ -9,8 +9,8 @@
     Committees</option>
   </select>
   <input class="search-bar" type="text" name="search"
-  aria-label="Search for candidates and committees"
-  placeholder="Search for candidates by name" autocomplete="off"
+  aria-label="Enter a candidate name"
+  placeholder="Enter a candidate name" autocomplete="off"
   autocorrect="off" autocapitalize="off" spellcheck="false"
   value="{{ query or '' }}">
   <button class="search-submit primary"><img width="16" height="16" src="/static/img/icon-search--white.svg" alt="Magnifying glass icon"></button>


### PR DESCRIPTION
Tiny patch to make the placeholder text consistent between the search bar's default state and when the js changes it on select change. 

Also, now changing the select will change the aria label.