### PR TITLE
Added a results check to the load_nested_type.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -128,7 +128,7 @@ def candidate_page(c_id, cycle=None, history=None):
     data = load_single_type('candidate', c_id, *path)
     cycle = cycle or min(current_cycle(), max(data['results'][0]['cycles']))
     path = ('history', str(cycle))
-    committee_data = load_nested_type('candidate', c_id, 'committees', *path)['results']
+    committee_data = load_nested_type('candidate', c_id, 'committees', *path)
     return render_candidate(data, committees=committee_data, cycle=cycle)
 
 
@@ -144,7 +144,7 @@ def committee_page(c_id, cycle=None):
     path = ('history', str(cycle)) if cycle else ()
     data = load_single_type('committee', c_id, *path)
     cycle = cycle or min(current_cycle(), max(data['results'][0]['cycles']))
-    candidate_data = load_nested_type('committee', c_id, 'candidates', cycle=cycle)['results']
+    candidate_data = load_nested_type('committee', c_id, 'candidates', cycle=cycle)
     return render_committee(data, candidates=candidate_data, cycle=cycle)
 
 

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -47,7 +47,11 @@ def load_single_type(data_type, c_id, *path, **filters):
 
 
 def load_nested_type(parent_type, c_id, nested_type, *path, **filters):
-    return _call_api(parent_type, c_id, nested_type, *path, per_page=100, **filters)
+    data = _call_api(parent_type, c_id, nested_type, *path, per_page=100, **filters)
+    if 'results' in data:
+      return data['results']
+    else:
+        return []
 
 
 def load_cmte_financials(committee_id, **filters):


### PR DESCRIPTION
Committees might not have f3 reports so there won't be results for them.
This keep the pages form breaking.
I think it fixes the remaining openfec#879 bugs