### PR TITLE
Feature/897 stop collapsing accordion

### DIFF
--- a/static/js/modules/accordion.js
+++ b/static/js/modules/accordion.js
@@ -4,6 +4,10 @@ var $ = require('jquery');
 
 var events = require('./events.js');
 
+var defaultOpts = {
+  closeAll: false
+};
+
 var accordion = {
   SLT_HEADER: '.js-accordion_header',
   SLT_ITEM: '.js-accordion_item',
@@ -19,11 +23,13 @@ var accordion = {
    * Events
    *   accordion:active
    *   @param header {jQuery} The accordion header that is activated to be expanded.
+   *   @param opts {Object} A hash of options to use.
    *
    * @param $base {jQuery} The container of the accordion.
    */
-  init: function($base) {
+  init: function($base, opts) {
     var self = this;
+    this.options = $.extend({}, defaultOpts, opts);
     this.$headers = this.findHeaders($base);
     this.$items = this.findItems($base);
     this.$buttons = this.findButtons(this.$headers);
@@ -34,6 +40,9 @@ var accordion = {
 
     events.on(this.EV_EXPAND, function(props) {
       var $header = $(props.header);
+      if (self.options.closeAll) {
+        self.hideAll();
+      }
       if ($.inArray($header, self.$headers)) {
         self.showHeader($header);
       }
@@ -41,7 +50,11 @@ var accordion = {
     events.on(this.EV_COLLAPSE, function(props) {
       var $header = $(props.header);
       if ($.inArray($header, self.$headers)) {
-        self.hideHeader($header);
+        if (self.options.closeAll) {
+          self.hideAll();
+        } else {
+          self.hideHeader($header);
+        }
       }
     });
   },

--- a/static/js/modules/accordion.js
+++ b/static/js/modules/accordion.js
@@ -34,7 +34,6 @@ var accordion = {
 
     events.on(this.EV_EXPAND, function(props) {
       var $header = $(props.header);
-      self.hideAll();
       if ($.inArray($header, self.$headers)) {
         self.showHeader($header);
       }
@@ -42,7 +41,7 @@ var accordion = {
     events.on(this.EV_COLLAPSE, function(props) {
       var $header = $(props.header);
       if ($.inArray($header, self.$headers)) {
-        self.hideAll();
+        self.hideHeader($header);
       }
     });
   },
@@ -106,6 +105,20 @@ var accordion = {
     });
     this.$headers.toggleClass(this.CLS_COLLAPSED, true);
   },
+
+  /**
+   * Hide all items under the accordion header passed in.
+   * @param $header {jQuery} The header to hide items under.
+   */
+  hideHeader: function($header) {
+    var $items = this.findItemsFromHeader($header),
+        self = this;
+    $items.each(function() {
+      self.hide($(this));
+    });
+    $header.toggleClass(this.CLS_COLLAPSED, true);
+  },
+
   /**
    * Show all items under the accordion header passed in.
    * @param $header {jQuery} The header to show items under.


### PR DESCRIPTION
People want to see the various parts of the report at the same time
so not collapsing the other accordion items when you open a new one
is better.

Users of the accordion plugin might want to configure it so it closes
the various items when you open a new one.