### PR TITLE
Summary charts should not display chart for None

### DIFF
--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -100,9 +100,11 @@
         <div class="table__cell">{{ pretty_name }} </div>
         <div class="table__cell">{{ value|default(0)|currency }}</div>
         <div class="table__cell table__cell--bar">
-          {{ charts.chart_bar(value|default(0),
-                              pretty_name,
-                              tooltip=None) }}
+          {% if value %}
+            {{ charts.chart_bar(value|default(0),
+                                pretty_name,
+                                tooltip=None) }}
+          {% endif %}
         </div>
       </div>
     {% endmacro %}


### PR DESCRIPTION
When there is no information for a candidate/committee, the user won't
want to see any chart bar which confirms a lack of information.