### PR TITLE
Aggregate committee financials for multiple authorized committees.

### DIFF
--- a/templates/partials/committee-summary.html
+++ b/templates/partials/committee-summary.html
@@ -6,11 +6,11 @@
   <h4 class="figure__title">Totals for {{totals.cycle|fmt_year_range|default("unavailable")}}</h4>
   <div class="table__half">
     <div class="table__row">
-      <div class="table__cell">Total <span class="term" data-term="Total Receipts">receipts</span></div>
+      <div class="table__cell">Total <span class="term" data-term="Total Receipts">Receipts</span></div>
       <div class="table__cell">{{totals.receipts|currency|default("unavailable")}}</div>
     </div>
     <div class="table__row">
-      <div class="table__cell">Total <span class="term" data-term="Total Disbursements">disbursements</span></div>
+      <div class="table__cell">Total <span class="term" data-term="Total Disbursements">Disbursements</span></div>
       <div class="table__cell">{{totals.disbursements|currency|default("unavailable")}}</div>
     </div>
     <div class="table__row--note">
@@ -19,7 +19,7 @@
   </div>
   <div class="table__half">
     <div class="table__row">
-      <div class="table__cell"><span class="term" data-term="Ending Cash on Hand">Ending cash on hand</span></div>
+      <div class="table__cell"><span class="term" data-term="Ending Cash on Hand">Ending Cash on Hand</span></div>
       <div class="table__cell">{{report.cash_on_hand_end_period|currency|default("unavailable")}}</div>
     </div>
     <div class="table__row">

--- a/templates/partials/financial-aggregates.html
+++ b/templates/partials/financial-aggregates.html
@@ -1,0 +1,27 @@
+<figure class="table--simple reports-table">
+  <h3 class="figure__title">Combined totals for {{cycle|fmt_year_range|default("unavailable")}}</h3>
+  <div class="table__half">
+    <div class="table__row">
+      <div class="table__cell">Total <span class="term" data-term="Total Receipts">receipts</span></div>
+      <div class="table__cell">{{aggregate.receipts|currency|default("unavailable")}}</div>
+    </div>
+    <div class="table__row">
+      <div class="table__cell">Total <span class="term" data-term="Total Disbursements">disbursements</span></div>
+      <div class="table__cell">{{aggregate.disbursements|currency|default("unavailable")}}</div>
+    </div>
+  </div>
+  <div class="table__half">
+    <div class="table__row">
+      <div class="table__cell"><span class="term" data-term="Ending Cash on Hand">Ending cash on hand</span></div>
+      <div class="table__cell">{{aggregate.cash|currency|default("unavailable")}}</div>
+    </div>
+    <div class="table__row">
+      <div class="table__cell"><span class="term" data-term="Debt">Debt</span></div>
+      <div class="table__cell">{{aggregate.debt|currency|default("unavailable")}}</div>
+    </div>
+  </div>
+  <div class="table__row--note">
+    Calculated from reports filed {{ cycle|fmt_year_range|default("unknown") }}
+    by {{ committees_authorized | map(attribute='name') | join(', ') }}
+  </div>
+</figure>

--- a/templates/partials/financial-aggregates.html
+++ b/templates/partials/financial-aggregates.html
@@ -1,18 +1,18 @@
 <figure class="table--simple reports-table">
-  <h3 class="figure__title">Combined totals for {{cycle|fmt_year_range|default("unavailable")}}</h3>
+  <h3 class="figure__title">Combined Totals for {{cycle|fmt_year_range|default("unavailable")}}</h3>
   <div class="table__half">
     <div class="table__row">
-      <div class="table__cell">Total <span class="term" data-term="Total Receipts">receipts</span></div>
+      <div class="table__cell">Total <span class="term" data-term="Total Receipts">Receipts</span></div>
       <div class="table__cell">{{aggregate.receipts|currency|default("unavailable")}}</div>
     </div>
     <div class="table__row">
-      <div class="table__cell">Total <span class="term" data-term="Total Disbursements">disbursements</span></div>
+      <div class="table__cell">Total <span class="term" data-term="Total Disbursements">Disbursements</span></div>
       <div class="table__cell">{{aggregate.disbursements|currency|default("unavailable")}}</div>
     </div>
   </div>
   <div class="table__half">
     <div class="table__row">
-      <div class="table__cell"><span class="term" data-term="Ending Cash on Hand">Ending cash on hand</span></div>
+      <div class="table__cell"><span class="term" data-term="Ending Cash on Hand">Ending Cash on Hand</span></div>
       <div class="table__cell">{{aggregate.cash|currency|default("unavailable")}}</div>
     </div>
     <div class="table__row">

--- a/templates/partials/financial-summary.html
+++ b/templates/partials/financial-summary.html
@@ -1,30 +1,32 @@
 {% import 'macros/missing.html' as missing %}
 
-{% if has_authorized_cmtes or has_joint_cmtes %}
+{% if committees_authorized %}
     <div class="page-section__intro">
       <h2 id="section-1-header" tabindex="0">Financial Summary</h2>
       <p class="text--lead">This page provides an overview of all the money received and spent by committees authorized by this candidate, including his or her principal campaign committees and authorized campaign committees, but not joint fundraising committees authorized by the candidate.  For more information about an individual committee — the funding they've received, how they have spent their money, and more — visit the committee’s page.</p>
     </div>
 
-    {% if has_authorized_cmtes %}
+    {% if committees_authorized | length > 1 %}
+      {% include 'partials/financial-aggregates.html' %}
+    {% endif %}
+
     <div class="page-subsection">
       <h3 class="term" data-term="Authorized Committee">Authorized Committees</h3>
-      {% for committee in committees if committee.designation == 'P' %}
+      {% for committee in committee_groups['P'] %}
         {% include 'partials/committee-stats.html' %}
       {% endfor %}
 
-      {% for committee in committees if committee.designation == 'A' %}
+      {% for committee in committee_groups['A'] %}
         {% include 'partials/committee-stats.html' %}
       {% endfor %}
     </div>
-  {% endif %}
 
-  {% if has_joint_cmtes %}
+  {% if committee_groups['J'] %}
     <div class="page-subsection other-committees">
     <h3><span class="term" data-term="Joint Fundraising Committee">Joint Fundraising Committees</span></h3>
     <p class="text--lead">Below, is a list of the candidate’s joint fundraising committees—in joint fundraising, a political committee raises funds with at least one other political committee or unregistered organization. Committees involved in joint fundraising share the costs of the fundraiser and divide up the money raised according to a ratio agreed to by the participants when the joint fundraising committee is formed. Click the links to see more information about a particular committee.</p>
       <ul>
-        {% for committee in committees if committee.designation == 'J' %}
+        {% for committee in committee_groups['J'] %}
           <li><a href="{{ url_for('committee_page', c_id=committee.committee_id, cycle=cycle) }}">{{ committee.name }} &raquo;</a></li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
When a candidate has multiple authorized or principal committees, users
should see aggregated receipts, cash on hand, etc., across all such
committees before the details for each committee. This patch shows these
aggregate on the candidate detail page, but only when the candidate has
multiple authorized committees.

@dcpcc1967 and @jwchumley: Aggregated cash on hand and debt are different from the current FEC site. The logic implemented here simply adds up cash and debt for the most recent report for all relevant committees; it looks like FECViewer is picking a single committee and using its most recent figures, but it's not clear how that committee is chosen. Figures for receipts and disbursements have been identical for the examples I've looked at.

The proposed layout looks like this (any feedback or PRs welcome!):

![screen shot 2015-06-03 at 12 17 20 pm](https://cloud.githubusercontent.com/assets/1633460/7965293/95c0be56-09ea-11e5-9f1c-6b684e21dcca.png)


[Resolves #832]