### PR TITLE
Always show committee address.

### DIFF
--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -53,11 +53,11 @@
               {% endfor %}
               </ul>
             </li>
+            {% endif %}
             <li class="entity__term">
               <h5 class="entity__term__label">Address</h5>
               <span class="entity__term__data">{{ street_1 }}{% if street_2 %}<br>{{ street_2 }}{% endif %} <br> {{city}}, {{state}} {{zip}}</span>
             </li>
-          {% endif %}
         </ul>
       </div>
     </header>


### PR DESCRIPTION
Due to a typo in the committee detail template, addresses are currently
hidden for committees that are not associated with a candidate. This
patch moves the relevant `endif` to the right place.

h/t @andrewmaier