### PR TITLE
Move HTML markup for "None" to macro.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -176,8 +176,7 @@ def server_error(e):
 def currency_filter(num, grouping=True):
     if isinstance(num, (int, float)):
         return locale.currency(num, grouping=grouping)
-    else:
-        return "<a class='term' data-term='None'>None</a>"
+    return None
 
 
 def _unique(values):

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -1,5 +1,6 @@
 {% extends 'layouts/main.html' %}
 {% import 'macros/missing.html' as missing %}
+{% import 'macros/null.html' as null %}
 
 {% block title %}
     {{ name }} - Committee Overview
@@ -98,7 +99,7 @@
       {% import 'macros/charts.html' as charts %}
       <div class="table__row table__row--nested js-accordion_item">
         <div class="table__cell">{{ pretty_name }} </div>
-        <div class="table__cell">{{ value|currency|safe }}</div>
+        <div class="table__cell">{{ null.null(value | currency) }}</div>
         <div class="table__cell table__cell--bar">
           {% if value %}
             {{ charts.chart_bar(value|default(0),
@@ -115,7 +116,7 @@
           <h5>{{ pretty_name }}</h5>
         </div>
         <div class="table__cell">
-          <span>{{ value|currency|safe }}</span>
+          <span>{{ null.null( value | currency ) }}</span>
         </div>
         {% if description %}
         <div class="table__cell table__cell--header-description">

--- a/templates/macros/null.html
+++ b/templates/macros/null.html
@@ -1,0 +1,7 @@
+{% macro null(value) %}
+  {% if value is not none or value is not defined %}
+    {{ value }}
+  {% else %}
+    <a class='term' data-term='None'>None</a>
+  {% endif %}
+{% endmacro %}

--- a/templates/partials/committee-charts.html
+++ b/templates/partials/committee-charts.html
@@ -2,10 +2,11 @@
 {% set reports = committee.reports  %}
 {% set totals = committee.totals  %}
 {% import 'macros/charts.html' as charts %}
+{% import 'macros/null.html' as null %}
 {% macro group_bar_tooltip(value, key) %}
 <div class="chart-series__bar__tooltip">
   <h5 class="chart-series__bar__tooltip__title">{{ key|replace('_', ' ')|title }}</h5>
-  <span class="chart-series__bar__tooltip__value">{{ value|currency }}</span>
+  <span class="chart-series__bar__tooltip__value">{{ null.null( value | currency )}}</span>
 </div>
 {% endmacro %}
 

--- a/templates/partials/committee-summary.html
+++ b/templates/partials/committee-summary.html
@@ -1,3 +1,5 @@
+{% import 'macros/null.html' as null %}
+
 {% with %}
 {% set report = committee.reports.0 if committee.reports else {} %}
 {% set totals = committee.totals.0 if committee.totals else {} %}
@@ -7,11 +9,11 @@
   <div class="table__half">
     <div class="table__row">
       <div class="table__cell">Total <span class="term" data-term="Total Receipts">Receipts</span></div>
-      <div class="table__cell">{{totals.receipts|currency|default("unavailable")}}</div>
+      <div class="table__cell">{{ null.null( totals.receipts | currency ) }}</div>
     </div>
     <div class="table__row">
       <div class="table__cell">Total <span class="term" data-term="Total Disbursements">Disbursements</span></div>
-      <div class="table__cell">{{totals.disbursements|currency|default("unavailable")}}</div>
+      <div class="table__cell">{{ null.null( totals.disbursements | currency ) }}</div>
     </div>
     <div class="table__row--note">
       Calculated from reports filed {{ totals.cycle|fmt_year_range|default("unknown") }}
@@ -20,11 +22,11 @@
   <div class="table__half">
     <div class="table__row">
       <div class="table__cell"><span class="term" data-term="Ending Cash on Hand">Ending Cash on Hand</span></div>
-      <div class="table__cell">{{report.cash_on_hand_end_period|currency|default("unavailable")}}</div>
+      <div class="table__cell">{{ null.null( report.cash_on_hand_end_period | currency ) }}</div>
     </div>
     <div class="table__row">
       <div class="table__cell"><span class="term" data-term="Debt">Debt</span></div>
-      <div class="table__cell">{{report.debts_owed_by_committee|currency|default("unavailable")}}</div>
+      <div class="table__cell">{{ null.null( report.debts_owed_by_committee | currency ) }}</div>
     </div>
     <div class="table__row--note">
       {% if report.pdf_url %}

--- a/templates/partials/financial-aggregates.html
+++ b/templates/partials/financial-aggregates.html
@@ -1,23 +1,25 @@
+{% import 'macros/null.html' as null %}
+
 <figure class="table--simple reports-table">
   <h3 class="figure__title">Combined Totals for {{cycle|fmt_year_range|default("unavailable")}}</h3>
   <div class="table__half">
     <div class="table__row">
       <div class="table__cell">Total <span class="term" data-term="Total Receipts">Receipts</span></div>
-      <div class="table__cell">{{aggregate.receipts|currency|default("unavailable")}}</div>
+      <div class="table__cell">{{ null.null( aggregate.receipts | currency ) }}</div>
     </div>
     <div class="table__row">
       <div class="table__cell">Total <span class="term" data-term="Total Disbursements">Disbursements</span></div>
-      <div class="table__cell">{{aggregate.disbursements|currency|default("unavailable")}}</div>
+      <div class="table__cell">{{ null.null( aggregate.disbursements | currency ) }}</div>
     </div>
   </div>
   <div class="table__half">
     <div class="table__row">
       <div class="table__cell"><span class="term" data-term="Ending Cash on Hand">Ending Cash on Hand</span></div>
-      <div class="table__cell">{{aggregate.cash|currency|default("unavailable")}}</div>
+      <div class="table__cell">{{ null.null( aggregate.cash | currency ) }}</div>
     </div>
     <div class="table__row">
       <div class="table__cell"><span class="term" data-term="Debt">Debt</span></div>
-      <div class="table__cell">{{aggregate.debt|currency|default("unavailable")}}</div>
+      <div class="table__cell">{{ null.null( aggregate.debt | currency ) }}</div>
     </div>
   </div>
   <div class="table__row--note">


### PR DESCRIPTION
Putting HTML in a string literal in the `currency` filter was breaking
tests. It's also not ideal, since it requires using the `safe` filter,
and unsafe content could potentially leak through. This patch restores
the behavior of the `currency` filter and moves the markup for the "None"
element to a macro. This also applies the new `null` macro to other uses
of the `currency` filter.