### PR TITLE
Compress static assets.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,13 +1,17 @@
 import http
+import hashlib
 
 import furl
 from webargs import Arg
 from webargs.flaskparser import use_kwargs
+from dateutil.parser import parse as parse_date
 
 from flask import Flask, render_template, request, redirect
-from flask.ext.basicauth import BasicAuth
 from flask_sslify import SSLify
-from dateutil.parser import parse as parse_date
+from flask.ext.compress import Compress
+from flask.ext.compress import DictCache
+from flask.ext.basicauth import BasicAuth
+
 from openfecwebapp import config
 from openfecwebapp.views import render_search_results, render_table, render_candidate, render_committee
 from openfecwebapp.api_caller import load_search_results, load_single_type, load_single_type_summary, load_nested_type, install_cache
@@ -260,6 +264,13 @@ if not config.test:
     app.config['BASIC_AUTH_PASSWORD'] = config.password
     app.config['BASIC_AUTH_FORCE'] = True
     basic_auth = BasicAuth(app)
+
+
+# Serve compressed assets, cached by SHA1.
+cache_key = lambda response: hashlib.sha1(response.get_data()).hexdigest()
+app.config['COMPRESS_CACHE_KEY'] = cache_key
+app.config['COMPRESS_CACHE_BACKEND'] = DictCache
+Compress(app)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ newrelic==2.50.0.39
 gunicorn
 webargs>=0.13.0
 Flask-SSLify
+
+git+https://github.com/jmcarp/flask-compress@cache


### PR DESCRIPTION
Serve compressed assets to clients that accept gzip encoding. This patch
uses a fork of flask-compress that caches compressed responses by SHA1
to avoid re-zipping files.

We may still want to offload this work to S3 / CloudFront in the future, but this is a quick implementation that should significantly reduce load times.