### PR TITLE
Allow different API URLs for internal and external use.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -49,9 +49,10 @@ def _get_default_cycles():
     cycle = current_cycle()
     return list(range(cycle - 4, cycle + 2, 2))
 
+
 app.jinja_env.globals['min'] = min
 app.jinja_env.globals['max'] = max
-app.jinja_env.globals['api_location'] = config.api_location
+app.jinja_env.globals['api_location'] = config.api_location_public
 app.jinja_env.globals['api_version'] = config.api_version
 app.jinja_env.globals['api_key'] = config.api_key_public
 app.jinja_env.globals['context'] = get_context

--- a/openfecwebapp/config.py
+++ b/openfecwebapp/config.py
@@ -2,6 +2,7 @@ import os
 
 # no trailing slash
 api_location = os.getenv('FEC_WEB_API_URL', 'http://localhost:5000')
+api_location_public = os.getenv('FEC_WEB_API_URL_PUBLIC', api_location)
 api_version = os.getenv('FEC_WEB_API_VERSION', 'v1')
 host = os.getenv('FEC_WEB_HOST', '0.0.0.0')
 port = os.getenv('VCAP_APP_PORT', '3000')


### PR DESCRIPTION
Immediate use case: when running on Vagrant, we want to use one API URL
internally (localhost:5000) and another externally (localhost:5001).