### PR TITLE
Feature/contextual search box

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -140,12 +140,12 @@ def committee_page(c_id, cycle=None):
 
 @app.route('/candidates')
 def candidates():
-    return render_template('candidates.html')
+    return render_template('candidates.html', result_type='candidates')
 
 
 @app.route('/committees')
 def committees():
-    return render_template('committees.html')
+    return render_template('committees.html', result_type='committees')
 
 
 @app.errorhandler(404)

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -7,14 +7,12 @@ from openfecwebapp.api_caller import load_cmte_financials
 
 
 def render_search_results(results, query, result_type):
-    # if true will show "no results" message
-    no_results = not len(results)
-
-    return render_template('search-results.html',
-            results=results,
-            result_type=result_type,
-            query=query,
-            no_results=no_results)
+    return render_template(
+        'search-results.html',
+        results=results,
+        result_type=result_type,
+        query=query,
+    )
 
 
 def render_committee(data, candidates=None, cycle=None):

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -24,6 +24,7 @@ def render_committee(data, candidates=None, cycle=None):
     tmpl_vars = committee
 
     tmpl_vars['cycle'] = cycle
+    tmpl_vars['result_type'] = 'committees'
 
     # add related candidates a level below
     tmpl_vars['candidates'] = candidates
@@ -62,6 +63,7 @@ def render_candidate(data, committees, cycle):
     tmpl_vars = results
 
     tmpl_vars['cycle'] = cycle
+    tmpl_vars['result_type'] = 'candidates'
 
     committee_groups = groupby(committees, lambda each: each['designation'])
     committees_authorized = committee_groups.get('P', []) + committee_groups.get('A', [])

--- a/static/js/modules/typeahead.js
+++ b/static/js/modules/typeahead.js
@@ -20,13 +20,13 @@ var officeMap = {
   P: 'President'
 };
 
-var filterCandidates = function(result) {
+function filterCandidates(result) {
   return {
     name: result.name,
     id: result.id,
     office: officeMap[result.office_sought]
   };
-};
+}
 
 module.exports = {
   getUrl: function(resource) {
@@ -151,16 +151,21 @@ module.exports = {
       }
     };
 
-    this.initTypeahead(options, candidateDataSet);
-
-    // When the select committee or candidate box is changed on the search.
-    events.on('searchTypeChanged', function(data) {
+    function updateTypeahead(dataType) {
       $('.search-bar').typeahead('destroy');
-      if (data.type === 'committees') {
+      if (dataType === 'committees') {
         self.initTypeahead(options, committeeDataSet);
       } else {
         self.initTypeahead(options, candidateDataSet);
       }
+    }
+
+    updateTypeahead($('select[name="search_type"]').val());
+
+    // When the select committee or candidate box is changed on the search.
+    events.on('searchTypeChanged', function(data) {
+      $('.search-bar').typeahead('destroy');
+      updateTypeahead(data.type);
     });
   }
 };

--- a/templates/candidates-single.html
+++ b/templates/candidates-single.html
@@ -4,10 +4,6 @@
     {{ name }} - Candidate Overview
 {% endblock %}
 
-{% block header %}
-    {% include 'partials/page-nav.html' %}
-{% endblock %}
-
 {% block body %}
 <div class="entity candidate tab-interface">
   <header class="page-header entity__header page-header--dark">

--- a/templates/candidates.html
+++ b/templates/candidates.html
@@ -4,10 +4,6 @@
    Browse Candidates
 {% endblock %}
 
-{% block header %}
-    {% include 'partials/page-nav.html' %}
-{% endblock %}
-
 {% block body %}
 
 <header class="page-header page-header--dark">

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -6,10 +6,6 @@
     {{ name }} - Committee Overview
 {% endblock %}
 
-{% block header %}
-    {% include 'partials/page-nav.html' %}
-{% endblock %}
-
 {% block body %}
   <div id="main" class="entity committee tab-interface">
     <header class="entity__header page-header page-header--dark">

--- a/templates/committees.html
+++ b/templates/committees.html
@@ -4,10 +4,6 @@
     Browse Committees
 {% endblock %}
 
-{% block header %}
-    {% include 'partials/page-nav.html' %}
-{% endblock %}
-
 {% block body %}
 
 <header class="page-header page-header--dark">

--- a/templates/partials/search-bar.html
+++ b/templates/partials/search-bar.html
@@ -3,7 +3,7 @@
     <option value="candidates">Candidates</option>
     <option
     {% if result_type == 'committees' %}
-      selected="selected"
+      selected
     {% endif %}
     value="committees">
     Committees</option>

--- a/templates/search-results.html
+++ b/templates/search-results.html
@@ -4,14 +4,10 @@
     Search results for "{{query}}"
 {% endblock %}
 
-{% block header %}
-    {% include 'partials/page-nav.html' %}
-{% endblock %}
-
 {% block body %}
 <div class="container">
   <section class="data page-section">
-    {% if no_results %}
+    {% if not results %}
       <h4>Sorry, no results</h4>
     {% else %}
     <h1>Search Results</h1>

--- a/tests/selenium/search_results_test.py
+++ b/tests/selenium/search_results_test.py
@@ -43,3 +43,21 @@ class SearchResultsPageTests(SearchPageTestCase):
             committee_url_re.search(elm.get_attribute('href'))
             for elm in elms
         ]))
+
+    def test_typeahead_from_candidates_page(self):
+        self.url.path.add('candidates')
+        self.driver.get(self.url.url)
+        select = self.driver.find_element_by_css_selector('select[name="search_type"]')
+        self.assertEqual(select.get_attribute('value'), 'candidates')
+        self.driver.find_element_by_css_selector('.header-search .search-bar').send_keys('boeh')
+        results = self.driver.find_elements_by_css_selector('.tt-suggestion')
+        self.assertGreater(len(results), 0)
+
+    def test_typeahead_from_committees_page(self):
+        self.url.path.add('committees')
+        self.driver.get(self.url.url)
+        select = self.driver.find_element_by_css_selector('select[name="search_type"]')
+        self.assertEqual(select.get_attribute('value'), 'committees')
+        self.driver.find_element_by_css_selector('.header-search .search-bar').send_keys('grij')
+        results = self.driver.find_elements_by_css_selector('.tt-suggestion')
+        self.assertGreater(len(results), 0)


### PR DESCRIPTION
Set search type to current page type.

When a user browses to the committee search page or a committee detail
page, set the typeahead search type to committees; else set to
candidates. Update tests accordingly.

[Resolves https://github.com/18F/openFEC/issues/918]