### PR TITLE
Use updated nested history endpoints from API.

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -1,8 +1,10 @@
-from openfecwebapp.config import api_location, api_version, api_key
+import os
 from urllib import parse
 
-import os
 import requests
+
+from openfecwebapp import utils
+from openfecwebapp.config import api_location, api_version, api_key
 
 
 MAX_FINANCIALS_COUNT = 4
@@ -43,6 +45,15 @@ def load_single_type(data_type, c_id, *path, **filters):
 
 def load_nested_type(parent_type, c_id, nested_type, *path, **filters):
     return _call_api(parent_type, c_id, nested_type, *path, per_page=100, **filters)
+
+
+def load_with_nested(primary_type, primary_id, secondary_type, cycle=None):
+    path = ('history', str(cycle)) if cycle else ()
+    data = load_single_type(primary_type, primary_id, *path)
+    cycle = cycle or min(utils.current_cycle(), max(data['results'][0]['cycles']))
+    path = ('history', str(cycle))
+    nested_data = load_nested_type(primary_type, primary_id, secondary_type, *path)
+    return data, nested_data['results']
 
 
 def load_cmte_financials(committee_id, **filters):

--- a/static/js/modules/filters.js
+++ b/static/js/modules/filters.js
@@ -49,10 +49,6 @@ var bindFilters = function() {
     cycleSelect.change(function() {
         var query = {cycle: cycleSelect.val()};
         var selected = cycleSelect.find('option:selected');
-        var history = selected.attr('data-history');
-        if (history) {
-            query.history = history;
-        }
         window.location.href = URI(window.location.href).query(query).toString();
     });
 };

--- a/templates/candidates-single.html
+++ b/templates/candidates-single.html
@@ -64,7 +64,6 @@
             {% for each in range(max(cycles), min(cycles) - 2, -2) | restrict_cycles %}
               <option
                   value="{{ each }}"
-                  data-history="{{ each | next_cycle(cycles) }}"
                   {% if each == cycle %}selected{% endif %}
                 >{{ each | fmt_year_range }}</option>
             {% endfor %}


### PR DESCRIPTION
Also discard the now-unnecessary `history` query parameter used for the
candidate detail page. Since candidates now have history records for all
election cycles between their first and last elections, the `history`
parameter and associated logic is no longer necessary.

Depends on https://github.com/18F/openFEC/pull/933.