### PR TITLE
Feature/datatables history

### DIFF
--- a/static/js/modules/filters.js
+++ b/static/js/modules/filters.js
@@ -37,23 +37,24 @@ $('#filter-toggle').click(function(){
 
 var activateFilter = function(opts) {
     var $field = $('#category-filters [name=' + opts.name + ']');
+    var $parent = $field.parent();
     if (opts.value) {
-        $field.val(opts.value);
-        $field.parent().addClass('active');
-        selectedFilters[opts.name] = opts.value;
+        $field.val(opts.value).change();
+        $parent.addClass('active');
+    } else {
+        $field.val('').change();
+        $parent.removeClass('active');
     }
 };
 
 var bindFilters = function() {
-    var cycleSelect = $('#cycle');
-    cycleSelect.change(function() {
+    var cycleSelect = $('#cycle').change(function() {
         var query = {cycle: cycleSelect.val()};
         var selected = cycleSelect.find('option:selected');
         window.location.href = URI(window.location.href).query(query).toString();
     });
 };
 
-var selectedFilters = {};
 
 // all of the filters we use on candidates and committees
 var fieldMap = [
@@ -95,12 +96,9 @@ $('.button--remove').click(function(e){
 });
 
 $('.field input, .field select').change(function(){
-    var name = $(this).attr('name');
-    if ( $(this).val() !== '' ) {
-        $('[data-removes="' + name + '"]').css('display', 'block');
-    } else {
-        $('[data-removes="' + name + '"]').css('display', 'none');
-    }
+    var $this = $(this);
+    $('[data-removes="' + $this.attr('name') + '"]')
+        .css('display', $this.val() ? 'block' : 'none');
 });
 
 module.exports = {
@@ -110,5 +108,6 @@ module.exports = {
 
         // if the page was loaded with filters set in the query string
         activateInitialFilters();
-    }
+    },
+    activateInitialFilters: activateInitialFilters
 };

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -113,7 +113,7 @@ function mapResponse(response) {
 function pushQuery(filters) {
   var params = URI('').query(filters).toString();
   if (window.location.search !== params) {
-    window.history.pushState(filters, params, params);
+    window.history.pushState(filters, params, params || window.location.pathname);
   }
 }
 

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -1,12 +1,14 @@
 'use strict';
 
-/* global require, module, document, API_LOCATION, API_VERSION, API_KEY */
+/* global require, module, window, document, API_LOCATION, API_VERSION, API_KEY */
 
 var $ = require('jquery');
 var _ = require('underscore');
 var URI = require('URIjs');
 require('datatables');
 require('drmonty-datatables-responsive');
+
+var filters = require('./filters');
 
 function yearRange(first, last) {
   if (first === last) {
@@ -108,6 +110,13 @@ function mapResponse(response) {
   };
 }
 
+function pushQuery(filters) {
+  var params = URI('').query(filters).toString();
+  if (window.location.search !== params) {
+    window.history.pushState(filters, params, params);
+  }
+}
+
 function initTable($table, $form, baseUrl, columns) {
   var draw;
   var api = $table.DataTable({
@@ -124,6 +133,7 @@ function initTable($table, $form, baseUrl, columns) {
       var api = this.api();
       var filters = $form.serializeArray();
       parsedFilters = mapFilters(filters);
+      pushQuery(parsedFilters);
       var query = $.extend(
         {
           per_page: data.length,
@@ -142,6 +152,11 @@ function initTable($table, $form, baseUrl, columns) {
         callback(mapResponse(response));
       });
     }
+  });
+  // Update filters and data table on navigation
+  $(window).on('popstate', function() {
+    filters.activateInitialFilters();
+    api.ajax.reload();
   });
   $form.submit(function(event) {
     event.preventDefault();

--- a/tests/selenium/candidates_list_page_test.py
+++ b/tests/selenium/candidates_list_page_test.py
@@ -57,3 +57,15 @@ class CandidatesPageTests(SearchPageTestCase):
 
     def testCandidateOfficeFilter(self):
         self.checkFilter('office', 'P', 1, 'President')
+
+    def test_candidate_filter_history(self):
+        self.checkFilter('state', 'penn', 4, 'PA')
+        self.assertTrue(self.driver.current_url.endswith('state=PA'))
+        self.checkFilter('state', 'tex', 4, 'TX', refresh=False, click=True)
+        self.assertTrue(self.driver.current_url.endswith('state=TX'))
+        self.driver.back()
+        self.check_filter_results(4, 'PA')
+        self.assertTrue(self.driver.current_url.endswith('state=PA'))
+        self.driver.forward()
+        self.check_filter_results(4, 'TX')
+        self.assertTrue(self.driver.current_url.endswith('state=TX'))

--- a/tests/selenium/search_results_test.py
+++ b/tests/selenium/search_results_test.py
@@ -27,7 +27,7 @@ class SearchResultsPageTests(SearchPageTestCase):
     def test_search_results_page_link_candidates(self):
         self.url.args.update({'search': 'boehner', 'search_type': 'candidates'})
         self.driver.get(self.url.url)
-        elms = self.driver.find_elements_by_css_selector('h3 a')
+        elms = self.driver.find_elements_by_css_selector('.tst-search_results h3 a')
         self.assertTrue(elms)
         self.assertTrue(all([
             candidate_url_re.search(elm.get_attribute('href'))
@@ -37,7 +37,7 @@ class SearchResultsPageTests(SearchPageTestCase):
     def test_search_results_page_link_committees(self):
         self.url.args.update({'search': 'grijalva', 'search_type': 'committees'})
         self.driver.get(self.url.url)
-        elms = self.driver.find_elements_by_css_selector('h5 a')
+        elms = self.driver.find_elements_by_css_selector('.tst-search_results h5 a')
         self.assertTrue(elms)
         self.assertTrue(all([
             committee_url_re.search(elm.get_attribute('href'))


### PR DESCRIPTION
Push filters to query parameters.

* Push filters to query parameters on loading data
* Update data on back/forward navigation

[Resolves https://github.com/18F/openFEC/issues/957]

Note: This patch makes use of `window.history.pushState`, which won't work in IE9 and earlier.