### PR TITLE
Hide pre-1980 cycles in election cycle pickers.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -27,6 +27,8 @@ import sys
 
 locale.setlocale(locale.LC_ALL, '')
 
+START_YEAR = 1979
+
 app = Flask(__name__)
 
 # ===== configure logging =====
@@ -214,8 +216,8 @@ def fmt_report_desc(report_full_description):
 
 
 @app.template_filter()
-def restrict_cycles(value):
-    return [each for each in value if each <= utils.current_cycle()]
+def restrict_cycles(value, start_year=START_YEAR):
+    return [each for each in value if start_year <= each <= utils.current_cycle()]
 
 
 # If HTTPS is on, apply full HSTS as well, to all subdomains.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,6 +41,11 @@ def test_restrict_cycles():
     assert app.restrict_cycles(cycles) == [cycle - 2, cycle]
 
 
+def test_restrict_cycles_after_start_year():
+    cycles = [1978, 1980, 1982]
+    assert app.restrict_cycles(cycles, start_year=1979) == [1980, 1982]
+
+
 def test_fmt_chart_ticks_single_key():
     group = {
         'coverage_start_date': datetime.datetime(2015, 1, 1).isoformat(),


### PR DESCRIPTION
Since we aren't exposing data before 1979.