### PR TITLE
Hide beta banner on close button.

### DIFF
--- a/static/styles/_components/_alerts.scss
+++ b/static/styles/_components/_alerts.scss
@@ -20,9 +20,4 @@
   .link--icon {
     text-decoration: none;
   }
-
-  &[aria-hidden="true"] {
-    display: block;
-    top: -50px;
-  }
 }


### PR DESCRIPTION
[Resolves #963]

@noahmanger not sure why we were overriding the `display: none` associated with `[aria-hidden="true"]` in the first place.