### PR TITLE
Repositioning mobile nav close button

### DIFF
--- a/static/styles/_base/_buttons.scss
+++ b/static/styles/_base/_buttons.scss
@@ -32,7 +32,6 @@
     outline: 3px solid $focus;
     color: $textcolor;
     background: $bgcolor;
-    position: relative;
     z-index: 10;
   }
 

--- a/static/styles/_components/_modals.scss
+++ b/static/styles/_components/_modals.scss
@@ -20,12 +20,18 @@
 }
 
 .modal__row {
+    @include clearfix();
     border-bottom: 1px solid $modal-border;
     padding: 1.5rem 1rem;
 
     &:last-child {
         border-bottom: none;
     }
+}
+
+.modal__header {
+    width: 100%;
+    float: left;
 }
 
 .modal__overlay {
@@ -44,14 +50,19 @@
 
 .modal__close {
     position: absolute;
-    width: 50%;
-    bottom: 1.5rem;
-    left: 25%;
+    top: 0;
+    right: 0;
+    padding: 1rem;
+    // float: right;
     background: none;
     color: #fff;
+    border: none;
 
-    &:focus {
-        position: absolute;
+    &:hover,
+    &:active {
+        background: none;
+        border: none;
+        color: #fff;
     }
 }
 

--- a/templates/layouts/main.html
+++ b/templates/layouts/main.html
@@ -39,10 +39,11 @@
     <div class="modal__row">
       <p class="text--small">An official website of the United States Government <img src="/static/img/us_flag_small.png" alt="US flag signifying that this is a United States Federal Government website"></p>
       <p class="text--small">Looking for fec.gov? <a title="Visit fec.gov" href="http://www.fec.gov">Click here.</a></p>
+      <button title="Close menu" class="js-hide modal__close" data-hides="site-menu"><i class="ti-close"></i></button>
     </div>
     <div class="modal__row">
       <h3>Search the Data</h3>
-      <form id="modal-search" action="/" autocomplete="off">
+      <form id="modal-search" action="/" autocomplete="off" class="js-search">
         {% include 'partials/search-bar.html' %}
       </form>
     </div>
@@ -63,7 +64,6 @@
           <li><a href="mailto:{{ contact_email }}"><i class="ti-email"></i> Contact us</a></li>
         </ul>
       </nav>
-      <button title="Close menu" class="js-hide modal__close" data-hides="site-menu"><i class="ti-close"></i> Close menu</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This moves the close button to the upper right where it belongs ;)

![ios simulator screen shot jun 15 2015 6 15 36 pm](https://cloud.githubusercontent.com/assets/1696495/8172009/8b24e888-138a-11e5-9d20-107d3a8b58d0.png)
