### PR TITLE
Fix the filter panel, not the template org

### DIFF
--- a/static/styles/_components/_side-panel.scss
+++ b/static/styles/_components/_side-panel.scss
@@ -8,6 +8,11 @@
   top: 0;
 }
 
+.side-panel__hider {
+  height: 0;
+  overflow: hidden;
+}
+
 .side-toggle {
   @include rem(padding, 1.0rem);
   @include transition(background-color, .1s);
@@ -146,6 +151,10 @@
 
 .side-panel--open {
   position: relative;
+
+  .side-panel__hider {
+    height: auto;
+  }
 
   .side-panel__toggle {
     .icon {

--- a/templates/partials/filters/container.html
+++ b/templates/partials/filters/container.html
@@ -3,21 +3,23 @@
     <button id="filter-toggle" data-slide="left" class="side-panel__toggle">
       <i class="icon ti-angle"></i>
     </button>
-    <h4>Filter {{ result_type|capitalize }}</h4>
-    <form id="category-filters">
-      <div class="field" id="q-field">
-        <label for="q">Name</label>
-        <input type="text" name="q" />
-        <button type="button" class="button--remove" data-removes="q"><i class="ti-close"></i></button>
-      </div>
+    <div class="side-panel__hider">
+      <h4>Filter {{ result_type|capitalize }}</h4>
+      <form id="category-filters">
+        <div class="field" id="q-field">
+          <label for="q">Name</label>
+          <input type="text" name="q" />
+          <button type="button" class="button--remove" data-removes="q"><i class="ti-close"></i></button>
+        </div>
 
-      {% for filter in filters %}
-        {% include 'partials/filters/' + filter %}
-      {% endfor %}
+        {% for filter in filters %}
+          {% include 'partials/filters/' + filter %}
+        {% endfor %}
 
-      <div class="field">
-        <button type="submit" class="primary">Apply filters</button>
-      </div>
-    </form>
+        <div class="field">
+          <button type="submit" class="primary">Apply filters</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
This fixes the filter panel on mobile by creating a new component
element. It does not fix the template organization problem. This
was done to make the merge conflict in #337 easier as it's less code
that will be modified.