### PR TITLE
Feature/add purpose filter

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -212,6 +212,7 @@ var expenditureColumns = [
       return Handlebars.helpers.datetime(data);
     }
   },
+  {data: 'disbursement_description', className: 'min-tablet', orderable: false},
   {
     data: 'committee',
     orderable: false,

--- a/templates/partials/expenditures-filter.html
+++ b/templates/partials/expenditures-filter.html
@@ -18,4 +18,6 @@ Filter Disbursements
 
 {{ text.field('start_date', 'Start Date', {'data-inputmask': '"alias": "mm/dd/yyyy"'}) }}
 {{ text.field('end_date', 'End Date', {'data-inputmask': '"alias": "mm/dd/yyyy"'}) }}
+
+{{ text.field('disbursement_description', 'Purpose') }}
 {% endblock %}

--- a/templates/partials/expenditures-table.html
+++ b/templates/partials/expenditures-table.html
@@ -6,6 +6,7 @@
       <th scope="col">State</th>
       <th scope="col">Amount</th>
       <th scope="col">Date</th>
+      <th scope="col">Purpose</th>
       <th scope="col">Committee</th>
     </tr>
   </thead>


### PR DESCRIPTION
Add disbursement purpose filter and column to Schedule B data table. @noahmanger: the original issue only mentioned the filter, but I think it's helpful to include filtered columns in the table if possible so users can understand how the filters work. I can take out the extra column if it's distracting though.