### PR TITLE
Feature/contributions tab improvements

### DIFF
--- a/static/styles/_base/_buttons.scss
+++ b/static/styles/_base/_buttons.scss
@@ -6,7 +6,7 @@
   -webkit-font-smoothing: antialiased;
   background: $bgcolor;
   border-radius: $base-border-radius;
-  border: 1px solid $bgcolor;
+  border: 1px solid darken($bgcolor, 5%);
   display: inline-block;
   color: $textcolor;
   font-weight: bold;

--- a/static/styles/_components/_toggles.scss
+++ b/static/styles/_components/_toggles.scss
@@ -1,8 +1,10 @@
 .toggles {
-  label {
-    display: inline-block;
-    margin-top: 0;
-    margin-left: -2px;
+  @include clearfix();
+
+  .label {
+    display: block;
+    font-weight: bold;
+    clear: both;
   }
 
   input[type="radio"] {
@@ -11,10 +13,30 @@
 
   input:checked + .toggle-button {
     background-color: $dark-gray;
+    border-color: $dark-gray;
     color: #fff;
+  }
+
+  label {
+    margin-top: 0;
+    float: left;
+  }
+
+  label:first-of-type {
+    .toggle-button {
+      border-radius: 4px 0 0 4px;
+    }
+  }
+
+  label:last-of-type {
+    .toggle-button {
+      border-radius: 0 4px 4px 0;
+      border-right-width: 1px;
+    }
   }
 }
 
 .toggle-button {
-  @include button($light-gray, $dark-gray, $medium-gray, $dark-gray);
+  @include button(#FBFBFD, $dark-gray, $medium-gray, $dark-gray);
+  border-right-width: 0;
 }

--- a/static/styles/_layout/_layout.scss
+++ b/static/styles/_layout/_layout.scss
@@ -94,6 +94,7 @@ body {
 
 .page-section__intro {
   @include clearfix();
+  padding-bottom: 2rem;
 }
 
 // This is a grouping of content withinin a section, labeled by a h3

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -66,19 +66,6 @@
       </div>
       <div class="page-controls__bottom">
         <div class="container">
-          {% if cycles %}
-            <div class="time-period">
-              <label for="election_cycle">Two-Year Period</label>
-              <select name="cycle" id="cycle" data-id="{{ candidate_id }}" data-type="candidate">
-              {% for each in cycles | restrict_cycles | sort(reverse=True) %}
-                <option
-                    value="{{ each }}"
-                    {% if each == cycle %}selected{% endif %}
-                  >{{ each | fmt_year_range }}</option>
-              {% endfor %}
-              </select>
-            </div>
-          {% endif %}
            <nav class="page-tabs">
               <ul role="tablist">
                 <li role="presentation" class="page-tabs__item"><a role="tab" tabindex="0" aria-controls="panel1" aria-selected="true" href="#section-1">Financial Summary</a></li>
@@ -138,6 +125,19 @@
       <div class="container committee-summary">
         {% if reports and totals %}
           <h2 id="section-1-header" tabindex="0">Financial Summary</h2>
+          {% if cycles %}
+            <div class="time-period">
+              <label for="election_cycle">Two-Year Period</label>
+              <select name="cycle" id="cycle" data-id="{{ candidate_id }}" data-type="candidate">
+              {% for each in cycles | restrict_cycles | sort(reverse=True) %}
+                <option
+                    value="{{ each }}"
+                    {% if each == cycle %}selected{% endif %}
+                  >{{ each | fmt_year_range }}</option>
+              {% endfor %}
+              </select>
+            </div>
+          {% endif %}
           <p class="text--lead">Get the full picture of all of the money received and spent by this committee.</p>
           <div class="page-subsection">
             <div class="row js-accordion meta-box recent-report">

--- a/templates/partials/contributions-tab.html
+++ b/templates/partials/contributions-tab.html
@@ -2,52 +2,42 @@
 {% import 'macros/charts.html' as charts %}
 
 <section class="page-section" id="section-2" role="tabpanel" aria-hidden="true" aria-labelledby="section-2-header">
-  <div class="container">
-    <div class="page-subsection">
+  <div class="container"> 
       {% set table_data = [
         (aggregates.size.0, (0, 199.99), 'Under $200'),
         (aggregates.size.200, (200, 499.99), '$200 - $499'),
         (aggregates.size.500, (500, 999.99), '$500 - $999'),
         (aggregates.size.1000, (1000, 1999.99), '$1000 - $1999'),
         (aggregates.size.2000, (2000, None), 'Over $2000'),
-      ] %}
-      <h3 class="section-header">Contributions by Size {{ cycle | fmt_year_range }}</h3>
-      <figure class="table--simple totals-table totals-table--charts">
-        <div class="table__row table__row--header">
-          <div class="table__cell">
-            <h5>Contribution Size</h5>
-          </div>
-          <div class="table__cell">
-            <h5>Contribution Size</h5>
-          </div>
-        </div>
-        <div class="table js-chart-series chart-series--horizontal">
-          {% for value, limits, label in table_data %}
-            <div class="table__row">
-              <div class="table__cell">
-                <a
-                    href="{{ url_for(
-                      'donations',
-                      committee_id=committee.committee_id,
-                      min_amount=limits[0],
-                      max_amount=limits[1],
-                      min_date=cycle_start(cycle).strftime('%m/%d/%Y'),
-                      max_date=cycle_end(cycle).strftime('%m/%d/%Y'),
-                    ) }}"
-                >{{ label }}</a>
-              </div>
-              <div class="table__cell">{{ null.null(value | currency) }}</div>
-              <div class="table__cell table__cell--bar">
-                {{ charts.chart_bar(value | default(0), label, tooltip=None) }}
-              </div>
-            </div>
-          {% endfor %}
-        </div>
-      </figure>
+      ] %}         
+    <div class="page-section__intro">
+      <h2>Analyze Contributions {{ year if year else cycle | fmt_year_range }}</h2>
+      <div class="toggles">
+        <span class="label">Compare by:</span>
+        <label for="toggle-state">
+          <input id="toggle-state" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-state" checked>
+          <span class="toggle-button">State</span>
+        </label>
+        <label for="toggle-contribution-size">
+          <input id="toggle-contribution-size" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-contribution-size">
+          <span class="toggle-button">Contribution Size</span>
+        </label>
+        <label for="toggle-committee">
+          <input id="toggle-committee" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-committee">
+          <span class="toggle-button">Committee</span>
+        </label>
+        <label for="toggle-employer">
+          <input id="toggle-employer" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-employer">
+          <span class="toggle-button">Employer</span>
+        </label>
+        <label for="toggle-occupation">
+          <input id="toggle-occupation" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-occupation">
+          <span class="toggle-button">Occupation</span>
+        </label>
+      </div>
     </div>
-    <div class="page-subsection">
-      <h3 class="section-header">Contributions by State {{ cycle | fmt_year_range }}</h3>
-      <div class="row">
+    <div class="row">
+      <div id="by-state" class="panel-toggle-element">
         <div class="chunk--half">
           <table
               class="data-table"
@@ -65,70 +55,82 @@
           <div class="state-map" data-committee-id="{{ committee.committee_id }}" data-cycle="{{ cycle }}"></div>
         </div>
       </div>
-    </div>
-    <div class="page-subsection">
-      <div class="section-header">
-        <h3>Top Contributors {{ year if year else cycle | fmt_year_range }}</h3>
-        <div class="toggles">
-          <span class="label">Compare by:</span>
-          <label for="toggle-committee">
-            <input id="toggle-committee" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-committee" checked>
-            <span class="toggle-button">Committee</span>
-          </label>
-          <label for="toggle-employer">
-            <input id="toggle-employer" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-employer">
-            <span class="toggle-button">Employer</span>
-          </label>
-          <label for="toggle-occupation">
-            <input id="toggle-occupation" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-occupation">
-            <span class="toggle-button">Occupation</span>
-          </label>
-        </div>
+      <div id="by-contribution-size" class="panel-toggle-element">
+        <figure class="table--simple totals-table totals-table--charts">
+          <div class="table__row table__row--header">
+            <div class="table__cell">
+              <h5>Contribution Size</h5>
+            </div>
+            <div class="table__cell">
+              <h5>Contribution Size</h5>
+            </div>
+          </div>
+          <div class="table js-chart-series chart-series--horizontal">
+            {% for value, limits, label in table_data %}
+              <div class="table__row">
+                <div class="table__cell">
+                  <a
+                      href="{{ url_for(
+                        'donations',
+                        committee_id=committee.committee_id,
+                        min_amount=limits[0],
+                        max_amount=limits[1],
+                        min_date=cycle_start(cycle).strftime('%m/%d/%Y'),
+                        max_date=cycle_end(cycle).strftime('%m/%d/%Y'),
+                      ) }}"
+                  >{{ label }}</a>
+                </div>
+                <div class="table__cell">{{ null.null(value | currency) }}</div>
+                <div class="table__cell table__cell--bar">
+                  {{ charts.chart_bar(value | default(0), label, tooltip=None) }}
+                </div>
+              </div>
+            {% endfor %}
+          </div>
+        </figure>
       </div>
-      <div class="row">
-        <div id="by-committee" class="panel-toggle-element">
-          <table
-             class="data-table"
-             data-type="committee-contributor"
-             data-committee="{{ committee.committee_id }}"
-             data-cycle="{{ cycle }}"
-             {% if year %}data-year"{{ year }}"{% endif %}>
-            <thead>
-              <th scope="col">Committee</th>
-              <th scope="col">Total Contributed</th>
-            </thead>
-          </table>
-          <a href={{ url_for('donations', committee_id=committee.committee_id, contributor_type='committee') }}>
-            View all contributions from committees &raquo;</a>
-        </div>
+      <div id="by-committee" class="panel-toggle-element">
+        <table
+           class="data-table"
+           data-type="committee-contributor"
+           data-committee="{{ committee.committee_id }}"
+           data-cycle="{{ cycle }}"
+           {% if year %}data-year"{{ year }}"{% endif %}>
+          <thead>
+            <th scope="col">Committee</th>
+            <th scope="col">Total Contributed</th>
+          </thead>
+        </table>
+        <a href={{ url_for('donations', committee_id=committee.committee_id, contributor_type='committee') }}>
+          View all contributions from committees &raquo;</a>
+      </div>
 
-        <div id="by-employer" class="panel-toggle-element">
-          <table
-              class="data-table"
-              data-type="receipts-by-employer"
-              data-committee="{{ committee.committee_id }}"
-              data-cycle="{{ cycle }}"
-            >
-            <thead>
-              <th scope="col">Employer</th>
-              <th scope="col">Total Contributed</th>
-            </thead>
-          </table>
-        </div>
+      <div id="by-employer" class="panel-toggle-element">
+        <table
+            class="data-table"
+            data-type="receipts-by-employer"
+            data-committee="{{ committee.committee_id }}"
+            data-cycle="{{ cycle }}"
+          >
+          <thead>
+            <th scope="col">Employer</th>
+            <th scope="col">Total Contributed</th>
+          </thead>
+        </table>
+      </div>
 
-        <div id="by-occupation" class="panel-toggle-element">
-          <table
-              class="data-table"
-              data-type="receipts-by-occupation"
-              data-committee="{{ committee.committee_id }}"
-              data-cycle="{{ cycle }}"
-            >
-            <thead>
-              <th scope="col">Occupation</th>
-              <th scope="col">Total Contributed</th>
-            </thead>
-          </table>
-        </div>
+      <div id="by-occupation" class="panel-toggle-element">
+        <table
+            class="data-table"
+            data-type="receipts-by-occupation"
+            data-committee="{{ committee.committee_id }}"
+            data-cycle="{{ cycle }}"
+          >
+          <thead>
+            <th scope="col">Occupation</th>
+            <th scope="col">Total Contributed</th>
+          </thead>
+        </table>
       </div>
     </div>
   </div>

--- a/templates/partials/disbursements-tab.html
+++ b/templates/partials/disbursements-tab.html
@@ -1,22 +1,22 @@
 <section class="page-section" id="section-3" role="tabpanel" aria-hidden="true" aria-labelledby="section-3-header">
   <div class="container">
-    <div class="section-header">
-      <h3>Top Recipients {{ cycle | fmt_year_range }}</h3>
-      <div class="toggles">
-        <span class="label">Compare by:</span>
-        <label for="toggle-purpose">
-          <input id="toggle-purpose" type="radio" class="panel-toggle-control" name="disbursement-aggregate" value="by-purpose" checked />
-          <span class="toggle-button">Purpose</span>
-        </label>
-        <label for="toggle-recipient">
-          <input id="toggle-recipient" type="radio" class="panel-toggle-control" name="disbursement-aggregate" value="by-recipient" />
-          <span class="toggle-button">Recipient Name</span>
-        </label>
-        <label for="toggle-id">
-          <input id="toggle-id" type="radio" class="panel-toggle-control" name="disbursement-aggregate" value="by-recipient-id" />
-          <span class="toggle-button">Recipient Committee</span>
-        </label>
-      </div>
+    <div class="page-section__intro">
+      <h2>Top Recipients {{ cycle | fmt_year_range }}</h2>
+        <div class="toggles">
+          <span class="label">Compare by:</span>
+          <label for="toggle-purpose">
+            <input id="toggle-purpose" type="radio" class="panel-toggle-control" name="disbursement-aggregate" value="by-purpose" checked />
+            <span class="toggle-button">Purpose</span>
+          </label>
+          <label for="toggle-recipient">
+            <input id="toggle-recipient" type="radio" class="panel-toggle-control" name="disbursement-aggregate" value="by-recipient" />
+            <span class="toggle-button">Recipient Name</span>
+          </label>
+          <label for="toggle-id">
+            <input id="toggle-id" type="radio" class="panel-toggle-control" name="disbursement-aggregate" value="by-recipient-id" />
+            <span class="toggle-button">Recipient Committee</span>
+          </label>
+        </div>
     </div>
     <div class="row">
       <div id="by-purpose" class="panel-toggle-element">


### PR DESCRIPTION
In the interest of smaller and more frequent PRs, here's some more styling work on the contributions tab. Jen and I talked and realized that because the Size and State comparisons were simply different views on the same data shown in the toggle-able section at the bottom, it made sense to have them all set as panels like so:

![screen shot 2015-07-22 at 4 39 31 pm](https://cloud.githubusercontent.com/assets/1696495/8840480/a5a9c6a0-3096-11e5-8648-91173ab49709.png)

This also parallels the behavior on the election page as well as on the disbursements panel.

One thing we may want to do as a result of this is moving the Size comparison table to the same standard datatable we use for the others. 