### PR TITLE
Adding links to receipts, expenditures and filings from home

### DIFF
--- a/templates/donations.html
+++ b/templates/donations.html
@@ -7,7 +7,7 @@
 {% block body %}
 
 <header class="page-header page-header--dark">
-  <h1><img width="32" height="32" class="category-icon" src="/static/img/icon-committee--white.svg" alt="Icon representing committees"> Donations</h1>
+  <h1><img width="32" height="32" class="category-icon" src="/static/img/icon-committee--white.svg" alt="Icon representing committees"> Receipts</h1>
 </header>
 
 <section class="results-content">

--- a/templates/expenditures.html
+++ b/templates/expenditures.html
@@ -7,7 +7,7 @@
 {% block body %}
 
 <header class="page-header page-header--dark">
-  <h1><img width="32" height="32" class="category-icon" src="/static/img/icon-committee--white.svg" alt="Icon representing committees"> Expenditures</h1>
+  <h1><img width="32" height="32" class="category-icon" src="/static/img/icon-committee--white.svg" alt="Icon representing committees"> Disbursements</h1>
 </header>
 
 <section class="results-content">

--- a/templates/partials/filings-tab.html
+++ b/templates/partials/filings-tab.html
@@ -1,24 +1,27 @@
 <section class="page-section" id="section-4" role="tabpanel" aria-hidden="true" aria-labelledby="section-4-header">
   <div class="container">
-    <div id="filters" class="meta-box">
-      <h4>Filter Filings</h4>
-      <form id="category-filters">
-        <div class="chunk--half">
-          <div class="field" id="report-year">
-            <label for="report_year">Report Year</label>
-            <input type="text" name="report_year" />
-            <button type="button" class="button--remove" data-removes="report-year"><i class="ti-close"></i></button>
+    <div class="page-section__intro">
+      <h2>Committee Filings</h2>
+      <div id="filters" class="meta-box">
+        <h4>Filter Filings</h4>
+        <form id="category-filters">
+          <div class="chunk--half">
+            <div class="field" id="report-year">
+              <label for="report_year">Report Year</label>
+              <input type="text" name="report_year" />
+              <button type="button" class="button--remove" data-removes="report-year"><i class="ti-close"></i></button>
+            </div>
+            {% include 'partials/filters/amendment-indicator.html' %}
           </div>
-          {% include 'partials/filters/amendment-indicator.html' %}
-        </div>
-        <div class="chunk--half">
-          {% include 'partials/filters/primary-general.html' %}
-          {% include 'partials/filters/report-type.html' %}
-          <div class="field">
-            <button type="submit" class="primary">Apply filters</button>
+          <div class="chunk--half">
+            {% include 'partials/filters/primary-general.html' %}
+            {% include 'partials/filters/report-type.html' %}
+            <div class="field">
+              <button type="submit" class="primary">Apply filters</button>
+            </div>
           </div>
-        </div>
-      </form>
+        </form>
+      </div>
     </div>
 
     <table class="data-table" data-type="filing" data-committee="{{ committee_id }}" width="100%" class="responsive">

--- a/templates/search.html
+++ b/templates/search.html
@@ -26,6 +26,14 @@
                 <p><a href="{{ url_for('committees', cycle=default_cycles) }}">Browse all committees &raquo;</a></p>
             </div>
         </div>
+        <div class="row">
+            <div class="card">
+                <h3>Other data:</h3>
+                <p><a href="{{ url_for('donations', cycle=default_cycles) }}">Browse all receipts &raquo;</a></p>
+                <p><a href="{{ url_for('expenditures', cycle=default_cycles) }}">Browse all disbursements &raquo;</a></p>                
+                <p><a href="{{ url_for('filings', cycle=default_cycles) }}">Browse all filings &raquo;</a></p>
+            </div>
+        </div>
     </div>
 </section>
 


### PR DESCRIPTION
This adds links to the home page for purpose of usability testing:

![screen shot 2015-07-22 at 5 43 33 pm](https://cloud.githubusercontent.com/assets/1696495/8840693/ae35b862-3099-11e5-8743-a2061a16be64.png)

It's ugly, but will work for now. Also, this doesn't do the work of renaming the template files / URLs to "Receipts" and "Disbursements" but I was afraid of opening that can of worms.