### PR TITLE
Styling committee filing filters

### DIFF
--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -9,7 +9,7 @@ var events = require('../modules/events');
 var tables = require('../modules/tables');
 var helpers = require('../modules/helpers');
 
-var singlePageTableDOM = 't<"results-info meta-box"frip>';
+var singlePageTableDOM = 't<"results-info results-info--bottom meta-box"frip>';
 
 var committeeColumns = [
   {
@@ -183,7 +183,7 @@ $(document).ready(function() {
         break;
       case 'filing':
         tables.initTable($table, null, 'committee/' + committeeId + '/filings', {}, filingsColumns, tables.offsetCallbacks, {
-          dom: 't<"results-info meta-box"lfrip>',
+          dom: 't<"results-info results-info--bottom meta-box"lfrip>',
           // Order by receipt date descending
           order: [[4, 'desc']],
         });

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -9,6 +9,8 @@ var events = require('../modules/events');
 var tables = require('../modules/tables');
 var helpers = require('../modules/helpers');
 
+var singlePageTableDOM = 't<"results-info meta-box"frip>';
+
 var committeeColumns = [
   {
     data: 'contributor_name',
@@ -118,7 +120,7 @@ $(document).ready(function() {
           query.cycle = cycle;
         }
         tables.initTable($table, null, path, query, committeeColumns, tables.offsetCallbacks, {
-          dom: '<"results-info meta-box results-info--top"lfrip>t',
+          dom: singlePageTableDOM,
           order: [[1, 'desc']],
           pagingType: 'simple',
           lengthChange: false,
@@ -159,7 +161,7 @@ $(document).ready(function() {
         path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_employer'].join('/');
         query = {cycle: parseInt(cycle)};
         tables.initTable($table, null, path, query, employerColumns, tables.offsetCallbacks, {
-          dom: '<"results-info meta-box results-info--top"lfrip>t',
+          dom: singlePageTableDOM,
           order: [[1, 'desc']],
           pagingType: 'simple',
           lengthChange: false,
@@ -171,7 +173,7 @@ $(document).ready(function() {
         path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_occupation'].join('/');
         query = {cycle: parseInt(cycle)};
         tables.initTable($table, null, path, query, occupationColumns, tables.offsetCallbacks, {
-          dom: '<"results-info meta-box results-info--top"lfrip>t',
+          dom: singlePageTableDOM,
           order: [[1, 'desc']],
           pagingType: 'simple',
           lengthChange: false,
@@ -181,6 +183,7 @@ $(document).ready(function() {
         break;
       case 'filing':
         tables.initTable($table, null, 'committee/' + committeeId + '/filings', {}, filingsColumns, tables.offsetCallbacks, {
+          dom: 't<"results-info meta-box"lfrip>',
           // Order by receipt date descending
           order: [[4, 'desc']],
         });
@@ -189,7 +192,7 @@ $(document).ready(function() {
         path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_purpose'].join('/');
         query = {cycle: parseInt(cycle)};
         tables.initTable($table, null, path, query, disbursementPurposeColumns, tables.offsetCallbacks, {
-          dom: '<"results-info meta-box results-info--top"lfrip>t',
+          dom: singlePageTableDOM,
           order: [[1, 'desc']],
           pagingType: 'simple',
           lengthChange: false,
@@ -201,7 +204,7 @@ $(document).ready(function() {
         path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_recipient'].join('/');
         query = {cycle: parseInt(cycle)};
         tables.initTable($table, null, path, query, disbursementRecipientColumns, tables.offsetCallbacks, {
-          dom: '<"results-info meta-box results-info--top"lfrip>t',
+          dom: singlePageTableDOM,
           order: [[1, 'desc']],
           pagingType: 'simple',
           lengthChange: false,
@@ -213,7 +216,7 @@ $(document).ready(function() {
         path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_recipient_id'].join('/');
         query = {cycle: parseInt(cycle)};
         tables.initTable($table, null, path, query, disbursementRecipientIDColumns, tables.offsetCallbacks, {
-          dom: '<"results-info meta-box results-info--top"lfrip>t',
+          dom: singlePageTableDOM,
           order: [[1, 'desc']],
           pagingType: 'simple',
           lengthChange: false,

--- a/static/styles/_components/_dropdowns.scss
+++ b/static/styles/_components/_dropdowns.scss
@@ -1,9 +1,10 @@
 // Dropdowns
 .button--dropdown {
+  font-size: 1.4rem;
   position: relative;
   text-align: left;
   padding: .5rem 1rem;
-  line-height: 1.8rem;
+  line-height: 1.5rem;
   background-color: #fff;
   font-weight: normal;
 
@@ -57,7 +58,6 @@
   z-index: 999;
 
   li {
-    font-size: 1.2rem;
     border-bottom: 1px solid $light-gray;
     white-space: nowrap;
     padding: .5rem 1rem;

--- a/static/styles/_components/_filters.scss
+++ b/static/styles/_components/_filters.scss
@@ -42,8 +42,11 @@
     margin-right: 0;
   }
 
-  & > .label {
+  label {
     font-size: 1.4rem;
+  }
+
+  & > .label {
     margin-top: 0;
     font-weight: bold;
   }
@@ -85,4 +88,30 @@
   display: none;
   padding: .5rem;
   float: left;
+}
+
+.filters--horizontal {
+
+  @include media($large) {
+    form {
+      @include display(flex);
+      @include justify-content(flex-start);
+    }
+
+    .field {
+      border-top: none;
+      border-right: 1px solid $light-gray;
+      padding: 0 1rem;
+      margin-right: 0;
+      
+      &:first-child {
+        padding-left: 0;
+      }
+
+      &:last-child {
+        border-right: none;
+        padding-right: 0;
+      }
+    }
+  }
 }

--- a/static/styles/_layout/_data-view.scss
+++ b/static/styles/_layout/_data-view.scss
@@ -63,8 +63,12 @@
 }
 
 .results-info {
-  @include font-size(1.6);
+  font-size: 1.4rem;
   clear: both;
+
+  label {
+    font-size: 1.4rem;
+  }
 
   li {
     line-height: 1;
@@ -86,6 +90,11 @@
   margin-top: 0;
 }
 
+.results-info--bottom.meta-box {
+  margin-top: 0;
+  border-top: none;
+}
+
 .results-info__null {
   text-align: center;
   @include media($medium) {
@@ -98,7 +107,6 @@
   .results-info {
 
     &.meta-box {
-      border-top: 0;
       padding-bottom: 2em;
       padding-left: 2rem;
       padding-right: 2rem;
@@ -116,7 +124,6 @@
 
     @include media($medium) {
       &.meta-box {
-        border-top: 1px solid $light-gray;
         padding: .5em;
       }
 

--- a/templates/partials/filings-tab.html
+++ b/templates/partials/filings-tab.html
@@ -2,24 +2,16 @@
   <div class="container">
     <div class="page-section__intro">
       <h2>Committee Filings</h2>
-      <div id="filters" class="meta-box">
-        <h4>Filter Filings</h4>
+      <div id="filters" class="meta-box filters--horizontal">
         <form id="category-filters">
-          <div class="chunk--half">
-            <div class="field" id="report-year">
-              <label for="report_year">Report Year</label>
-              <input type="text" name="report_year" />
-              <button type="button" class="button--remove" data-removes="report-year"><i class="ti-close"></i></button>
-            </div>
-            {% include 'partials/filters/amendment-indicator.html' %}
+          <div class="field" id="report-year">
+            <label for="report_year" class="label">Report Year</label>
+            <input type="text" name="report_year" placeholder="e.g. 2015"/>
+            <button type="button" class="button--remove" data-removes="report-year"><i class="ti-close"></i></button>
           </div>
-          <div class="chunk--half">
-            {% include 'partials/filters/primary-general.html' %}
-            {% include 'partials/filters/report-type.html' %}
-            <div class="field">
-              <button type="submit" class="primary">Apply filters</button>
-            </div>
-          </div>
+          {% include 'partials/filters/amendment-indicator.html' %}
+          {% include 'partials/filters/primary-general.html' %}
+          {% include 'partials/filters/report-type.html' %}
         </form>
       </div>
     </div>

--- a/templates/partials/filters/amendment-indicator.html
+++ b/templates/partials/filters/amendment-indicator.html
@@ -1,15 +1,15 @@
  <div class="field">
-    <label class="dropdown__value" for="amendment-dropdown">Amendment Indicator<span class="any" aria-hidden="true">(Any)</span></label>
+    <label class="label" for="amendment-dropdown">Amendment Indicator<span class="any" aria-hidden="true">(Any)</span></label>
     <fieldset class="js-checkbox-filters">
         <ul class="dropdown__selected">
             <li>
                 <label class="dropdown__value" for="amendment-indicator-N">
-                  <input id=" " name="amendment_indicator" type="checkbox" value="N" />New
+                  <input id="amendment-indicator-N" name="amendment_indicator" type="checkbox" value="N" />New
                 </label>
             </li>
             <li>
                 <label class="dropdown__value" for="amendment-indicator-A">
-                  <input id=" " name="amendment_indicator" type="checkbox" value="A" />Amended
+                  <input id="amendment-indicator-A" name="amendment_indicator" type="checkbox" value="A" />Amended
                 </label>
             </li>
         </ul>
@@ -22,22 +22,22 @@
                 <ul class="dropdown__list">
                     <li>
                         <label class="dropdown__value" for="amendment-indicator-T">
-                            <input id=" " name="amendment_indicator" type="checkbox" value="T" />Terminated
+                            <input id="amendment-indicator-T" name="amendment_indicator" type="checkbox" value="T" />Terminated
                         </label>
                     </li>
                     <li>
                         <label class="dropdown__value" for="amendment-indicator-C">
-                            <input id=" " name="amendment_indicator" type="checkbox" value="C" />Consolidated
+                            <input id="amendment-indicator-C" name="amendment_indicator" type="checkbox" value="C" />Consolidated
                         </label>
                     </li>
                     <li>
                         <label class="dropdown__value" for="amendment-indicator-M">
-                            <input id=" " name="amendment_indicator" type="checkbox" value="M" />Multi-Candidate
+                            <input id="amendment-indicator-M" name="amendment_indicator" type="checkbox" value="M" />Multi-Candidate
                         </label>
                     </li>
                     <li>
                         <label class="dropdown__value" for="amendment-indicator-S">
-                            <input id=" " name="amendment_indicator" type="checkbox" value="S" />Secondary
+                            <input id="amendment-indicator-S" name="amendment_indicator" type="checkbox" value="S" />Secondary
                         </label>
                     </li>
                 </ul>

--- a/templates/partials/filters/primary-general.html
+++ b/templates/partials/filters/primary-general.html
@@ -1,6 +1,6 @@
 <div class="field">
-    <label for="primary_general_indicator">Election Type<span class="any" aria-hidden="true">(Any)</span></label>
-    <fieldset class="js-checkbox-filters">
+    <label class="label" for="primary_general_indicator">Election Type<span class="any" aria-hidden="true">(Any)</span></label>
+    <fieldset>
       <ul>
         <li>
           <label for="cycle-checkbox-p">
@@ -9,12 +9,12 @@
         </li>
         <li>
           <label for="cycle-checkbox-g">
-            <input id="cycle-checkbox-s" name="primary_general_indicator" type="checkbox" value="G" />General
+            <input id="cycle-checkbox-g" name="primary_general_indicator" type="checkbox" value="G" />General
           </label>
         </li>
         <li>
           <label for="cycle-checkbox-s">
-            <input id="cycle-checkbox-h" name="primary_general_indicator" type="checkbox" value="S" />Special
+            <input id="cycle-checkbox-s" name="primary_general_indicator" type="checkbox" value="S" />Special
           </label>
         </li>
       </ul>

--- a/templates/partials/filters/report-type.html
+++ b/templates/partials/filters/report-type.html
@@ -1,5 +1,5 @@
 <div class="field">
-    <label for="report_type">Report Type<span class="any" aria-hidden="true">(Any)</span></label>
+    <label for="report_type" class="label">Report Type<span class="any" aria-hidden="true">(Any)</span></label>
     <fieldset class="js-checkbox-filters">
         <ul class="dropdown__selected"></ul>
         <div class="dropdown">


### PR DESCRIPTION
1. Tightens up the filters on the filings table on committee pages
![screen shot 2015-07-23 at 3 33 48 pm](https://cloud.githubusercontent.com/assets/1696495/8863749/4170133c-3150-11e5-9396-1b91e72eb609.png)

2. Moves the table page controls below tables on the committee page. @jenniferthibault this was the pattern you were using on election pages, correct?
![screen shot 2015-07-23 at 3 34 34 pm](https://cloud.githubusercontent.com/assets/1696495/8863760/58e57ce6-3150-11e5-9931-18baf702b0ea.png)
