### PR TITLE
Removing the search select in favor of radios

### DIFF
--- a/static/js/modules/typeahead.js
+++ b/static/js/modules/typeahead.js
@@ -187,7 +187,7 @@ module.exports = {
       }
     }
 
-    updateTypeahead($('select[name="search_type"]').val());
+    updateTypeahead($('.js-search-type:checked').val());
 
     // When the select committee or candidate box is changed on the search.
     events.on('searchTypeChanged', function(data) {

--- a/static/styles/_components/_search-bar.scss
+++ b/static/styles/_components/_search-bar.scss
@@ -34,6 +34,7 @@
 
   .search__radio {
     text-align: center;
+    font-size: 1.8rem;
   }
 
   @include media($medium) {
@@ -57,14 +58,6 @@
   }
 }
 
-.search__select {
-  display: none;
-  min-width: 140px;
-  @include media($large) {
-    display: block;
-  }
-}
-
 .search__radio {
   text-align: left;
   margin-bottom: 1rem;
@@ -79,7 +72,6 @@
   }
 
   @include media($large) {
-    display: none;
   }
 }
 
@@ -99,7 +91,7 @@
   width: 100%;
 
   @include media($large) {
-    width: 50%;
+    width: 100%;
   }
 }
 
@@ -170,5 +162,12 @@
 
   .tt-suggestion__office {
     color: #fff;
+  }
+}
+
+.search-bar--header {
+  .search__radio {
+    float: left;
+    margin: .5rem 0 0 0;
   }
 }

--- a/templates/layouts/main.html
+++ b/templates/layouts/main.html
@@ -44,7 +44,7 @@
     </div>
     <div class="modal__row">
       <h3>Search the data for:</h3>
-      {{ search.search('modal', result_type) }}
+      {{ search.search('modal', result_type, query) }}
     </div>
     <div class="modal__row">
       <h3>Browse the Data</h3>
@@ -92,9 +92,9 @@
       </div>
       <div class="header__right">
 
-        {% if not page or page != 'home' %}
+        {% if hide_header_search != true %}
         <div class="header-search">
-          {{ search.search('header', result_type) }}
+          {{ search.search('header', result_type, query) }}
         </div>
         {% endif %}
 

--- a/templates/macros/search.html
+++ b/templates/macros/search.html
@@ -1,9 +1,13 @@
-{% macro search(location, result_type) %}
+{% macro search(location, result_type, query) %}
 <form id="{{ location }}-search" action="/" autocomplete="off" class="js-search">
   <div class="search-bar search-bar--{{ location }}">
     <div class="search__radio">
       <label for="{{ location }}-radio--candidates">
-        <input id="{{ location }}-radio--candidates" class="js-search-type" type="radio" name="search_type" value="candidates" checked>Candidates
+        <input id="{{ location }}-radio--candidates" class="js-search-type" type="radio" name="search_type"
+        {% if result_type != 'committees' %}
+          checked
+        {% endif %} 
+        value="candidates">Candidates
       </label>
       <label for="{{ location }}-radio--committees">
         <input id="{{ location }}-radio--committees" class="js-search-type" type="radio" name="search_type"
@@ -14,15 +18,6 @@
       </label>
     </div>
     <div class="input-button-combo">
-      <select name="search_type" class="js-search-type search__select">
-        <option value="candidates">Candidates</option>
-        <option
-        {% if result_type == 'committees' %}
-          selected
-        {% endif %}
-        value="committees">
-        Committees</option>
-      </select>
       <input class="js-search-input search-input" type="text" name="search"
       aria-label="Enter a candidate name"
       placeholder="Enter a candidate name" autocomplete="off"

--- a/templates/partials/search-results-controls.html
+++ b/templates/partials/search-results-controls.html
@@ -1,7 +1,7 @@
 {% import 'macros/search.html' as search %}
 
 <div class="meta-box results-controls">
-  {{ search.search('results') }}
+  {{ search.search('results', result_type, query) }}
   {% if results|length >= 20 %}
   <div class="results-count"> Showing first 20 results. 
     <a href="{{ url_for(result_type, q=query) }}">View all &raquo;</a>

--- a/templates/search-results.html
+++ b/templates/search-results.html
@@ -1,18 +1,21 @@
 {% extends "layouts/main.html" %}
+{% set hide_header_search = true %}
 
 {% block title %}
     Search results for "{{query}}"
 {% endblock %}
 
 {% block body %}
+
 <div class="container">
   <section class="data page-section">
-    {% if not results %}
-      <h4>Sorry, no results</h4>
-    {% else %}
     <h1>Search Results</h1>
     <div class="chunk--two-thirds tst-search_results">
       {% include 'partials/search-results-controls.html' %}
+        
+        {% if not results %}
+          <h4>Sorry, no results</h4>
+        {% else %}
 
         {% if result_type == 'committees' %}
           {% with committees=results %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,4 +1,5 @@
 {% extends "layouts/main.html" %}
+{% set hide_header_search = true %}
 
 {% block title %}
     Home

--- a/tests/selenium/search_results_test.py
+++ b/tests/selenium/search_results_test.py
@@ -47,8 +47,8 @@ class SearchResultsPageTests(SearchPageTestCase):
     def test_typeahead_from_candidates_page(self):
         self.url.path.add('candidates')
         self.driver.get(self.url.url)
-        select = self.driver.find_element_by_css_selector('select[name="search_type"]')
-        self.assertEqual(select.get_attribute('value'), 'candidates')
+        select = self.driver.find_element_by_css_selector('input[value="candidates"]')
+        self.assertEqual(select.get_attribute('checked'), 'true')
         self.driver.find_element_by_css_selector('.header-search .search-input').send_keys('boeh')
         results = self.driver.find_elements_by_css_selector('.tt-suggestion')
         self.assertGreater(len(results), 0)
@@ -56,8 +56,8 @@ class SearchResultsPageTests(SearchPageTestCase):
     def test_typeahead_from_committees_page(self):
         self.url.path.add('committees')
         self.driver.get(self.url.url)
-        select = self.driver.find_element_by_css_selector('select[name="search_type"]')
-        self.assertEqual(select.get_attribute('value'), 'committees')
+        select = self.driver.find_element_by_css_selector('input[value="committees"]')
+        self.assertEqual(select.get_attribute('checked'), 'true')
         self.driver.find_element_by_css_selector('.header-search .search-input').send_keys('grij')
         results = self.driver.find_elements_by_css_selector('.tt-suggestion')
         self.assertGreater(len(results), 0)


### PR DESCRIPTION
This makes the radio buttons the only way to change the search type. Changing the search type now works as expected.

![screenshot-01](https://cloud.githubusercontent.com/assets/1696495/8864320/5156a52c-3155-11e5-8b18-5d55fa137d15.png)

Also, this hides the header search on the search results page, as well as changes the way you hide the header (now just set a variable on the template `hide_header_search = true`).

![screen shot 2015-07-23 at 4 08 07 pm](https://cloud.githubusercontent.com/assets/1696495/8864321/53932ec8-3155-11e5-8996-6c993315d0f6.png)

(Wasn't sure the style for template variables like this, so can change to fit the convention.)