### PR TITLE
Cycle select update

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -262,7 +262,7 @@ def date_filter_md(date_str):
 @app.template_filter()
 def fmt_year_range(year):
     if type(year) == int:
-        return "{} - {}".format(year - 1, year)
+        return "{}–{}".format(year - 1, year)
     return None
 
 

--- a/static/js/modules/filters.js
+++ b/static/js/modules/filters.js
@@ -76,10 +76,14 @@ var activateFilter = function(opts) {
 };
 
 var bindFilters = function() {
-    var cycleSelect = $('#cycle').change(function() {
-        var query = {cycle: cycleSelect.val()};
-        var selected = cycleSelect.find('option:selected');
+    var cycleSelect = $('.js-cycle');
+    cycleSelect.each(function(){
+      var $this = $(this);
+      $this.change(function() {
+        var query = {cycle: $this.val()};
+        var selected = $this.find('option:selected');
         window.location.href = URI(window.location.href).query(query).toString();
+      });
     });
 };
 

--- a/static/styles/_components/_entity.scss
+++ b/static/styles/_components/_entity.scss
@@ -144,9 +144,7 @@
   }
 }
 
-.time-period {
-  width: 100%;
-  
+.time-period {  
   label {
     @include font-size(1.4);
     width: 40%;
@@ -163,9 +161,12 @@
   }
 
   @include media($medium) {
-    width: 50%;
-    float: right;
+    display: inline;
     text-align: right;
+    font-size: 1.8rem;
+    line-height: 3.7rem;
+    padding: 0 4rem 0 1rem;
+    height: auto;
 
     label {
       @include font-size(1.6);

--- a/static/styles/_layout/_layout.scss
+++ b/static/styles/_layout/_layout.scss
@@ -97,6 +97,10 @@ body {
   padding-bottom: 2rem;
 }
 
+.section-heading {
+  float: left;
+}
+
 // This is a grouping of content withinin a section, labeled by a h3
 .page-subsection {
   @include clearfix();

--- a/static/styles/_layout/_layout.scss
+++ b/static/styles/_layout/_layout.scss
@@ -97,10 +97,6 @@ body {
   padding-bottom: 2rem;
 }
 
-.section-heading {
-  float: left;
-}
-
 // This is a grouping of content withinin a section, labeled by a h3
 .page-subsection {
   @include clearfix();

--- a/templates/candidates-single.html
+++ b/templates/candidates-single.html
@@ -63,19 +63,6 @@
     </div>
     <div class="page-controls__bottom">
       <div class="container">
-        {% if cycles %}
-          <div class="time-period">
-            <label for="cycle">Two-Year Period</label>
-            <select name="cycle" id="cycle" data-id="{{ candidate_id }}" data-type="candidate">
-            {% for each in range(max(cycles), min(cycles) - 2, -2) | restrict_cycles %}
-              <option
-                  value="{{ each }}"
-                  {% if each == cycle %}selected{% endif %}
-                >{{ each | fmt_year_range }}</option>
-            {% endfor %}
-            </select>
-        </div>
-        {% endif %}
          <nav class="page-tabs">
             <ul role="tablist">
               <li role="presentation" class="page-tabs__item"><a role="tab" tabindex="0" aria-controls="panel1" aria-selected="true" href="#section-1">Financial Summary</a></li>
@@ -86,7 +73,7 @@
     </div>
   </div>
 
-  <section class="page-section" id="section-1" role="tabpanel" aria-hidden="false" aria-labelledby="section-1-header">
+  <section class="page-section" id="section-1" role="tabpanel" aria-hidden="false" aria-labelledby="section-1-heading">
     <div class="container">
       {% include 'partials/financial-summary.html' %}
     </div>

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -121,23 +121,12 @@
       </figure>
     {% endmacro %}
 
-    <section class="page-section" id="section-1" role="tabpanel" aria-hidden="false" aria-labelledby="section-1-header">
+    <section class="page-section" id="section-1" role="tabpanel" aria-hidden="false" aria-labelledby="section-1-heading">
       <div class="container committee-summary">
+        <div class="page-section__intro">
+          <h2 class="section-heading" id="section-1-heading" tabindex="0">Financial Summary        {% include 'partials/cycle-select.html' %}    </h2>
+        </div>
         {% if reports and totals %}
-          <h2 id="section-1-header" tabindex="0">Financial Summary</h2>
-          {% if cycles %}
-            <div class="time-period">
-              <label for="election_cycle">Two-Year Period</label>
-              <select name="cycle" id="cycle" data-id="{{ candidate_id }}" data-type="candidate">
-              {% for each in cycles | restrict_cycles | sort(reverse=True) %}
-                <option
-                    value="{{ each }}"
-                    {% if each == cycle %}selected{% endif %}
-                  >{{ each | fmt_year_range }}</option>
-              {% endfor %}
-              </select>
-            </div>
-          {% endif %}
           <p class="text--lead">Get the full picture of all of the money received and spent by this committee.</p>
           <div class="page-subsection">
             <div class="row js-accordion meta-box recent-report">

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -124,10 +124,10 @@
     <section class="page-section" id="section-1" role="tabpanel" aria-hidden="false" aria-labelledby="section-1-heading">
       <div class="container committee-summary">
         <div class="page-section__intro">
-          <h2 class="section-heading" id="section-1-heading" tabindex="0">Financial Summary        {% include 'partials/cycle-select.html' %}    </h2>
+          <h2 class="section-heading" id="section-1-heading" tabindex="0">Financial Summary {% include 'partials/cycle-select.html' %}</h2>
+          <p class="text--lead">Get the full picture of all of the money received and spent by this committee.</p>
         </div>
         {% if reports and totals %}
-          <p class="text--lead">Get the full picture of all of the money received and spent by this committee.</p>
           <div class="page-subsection">
             <div class="row js-accordion meta-box recent-report">
               {% with committee=context() %}

--- a/templates/partials/cycle-select.html
+++ b/templates/partials/cycle-select.html
@@ -1,0 +1,10 @@
+{% if cycles %}
+  <select class="time-period js-cycle" aria-label="Two-Year Period" name="cycle">
+  {% for each in cycles | restrict_cycles | sort(reverse=True) %}
+    <option
+        value="{{ each }}"
+        {% if each == cycle %}selected{% endif %}
+      >{{ each | fmt_year_range }}</option>
+  {% endfor %}
+  </select>
+{% endif %}  

--- a/templates/partials/disbursements-tab.html
+++ b/templates/partials/disbursements-tab.html
@@ -1,7 +1,7 @@
-<section class="page-section" id="section-3" role="tabpanel" aria-hidden="true" aria-labelledby="section-3-header">
+<section class="page-section" id="section-3" role="tabpanel" aria-hidden="true" aria-labelledby="section-3-heading">
   <div class="container">
     <div class="page-section__intro">
-      <h2>Top Recipients {{ cycle | fmt_year_range }}</h2>
+      <h2 class="section-heading" id="section-3-heading">Top Recipients {% include 'partials/cycle-select.html' %}  </h2>
         <div class="toggles">
           <span class="label">Compare by:</span>
           <label for="toggle-purpose">

--- a/templates/partials/filings-tab.html
+++ b/templates/partials/filings-tab.html
@@ -1,27 +1,27 @@
-<section class="page-section" id="section-4" role="tabpanel" aria-hidden="true" aria-labelledby="section-4-header">
+<section class="page-section" id="section-4" role="tabpanel" aria-hidden="true" aria-labelledby="section-4-heading">
   <div class="container">
     <div class="page-section__intro">
-      <h2>Committee Filings</h2>
-      <div id="filters" class="meta-box">
-        <h4>Filter Filings</h4>
-        <form id="category-filters">
-          <div class="chunk--half">
-            <div class="field" id="report-year">
-              <label for="report_year">Report Year</label>
-              <input type="text" name="report_year" />
-              <button type="button" class="button--remove" data-removes="report-year"><i class="ti-close"></i></button>
-            </div>
-            {% include 'partials/filters/amendment-indicator.html' %}
+      <h2 class="section-heading" id="section-4-heading">Committee Filings</h2>
+    </div>
+    <div id="filters" class="meta-box">
+      <h4>Filter Filings</h4>
+      <form id="category-filters">
+        <div class="chunk--half">
+          <div class="field" id="report-year">
+            <label for="report_year">Report Year</label>
+            <input type="text" name="report_year" />
+            <button type="button" class="button--remove" data-removes="report-year"><i class="ti-close"></i></button>
           </div>
-          <div class="chunk--half">
-            {% include 'partials/filters/primary-general.html' %}
-            {% include 'partials/filters/report-type.html' %}
-            <div class="field">
-              <button type="submit" class="primary">Apply filters</button>
-            </div>
+          {% include 'partials/filters/amendment-indicator.html' %}
+        </div>
+        <div class="chunk--half">
+          {% include 'partials/filters/primary-general.html' %}
+          {% include 'partials/filters/report-type.html' %}
+          <div class="field">
+            <button type="submit" class="primary">Apply filters</button>
           </div>
-        </form>
-      </div>
+        </div>
+      </form>
     </div>
 
     <table class="data-table" data-type="filing" data-committee="{{ committee_id }}" width="100%" class="responsive">

--- a/templates/partials/financial-summary.html
+++ b/templates/partials/financial-summary.html
@@ -1,10 +1,10 @@
 {% import 'macros/missing.html' as missing %}
 
-{% if committees_authorized %}
-    <div class="page-section__intro">
-      <h2 id="section-1-header" tabindex="0">Financial Summary</h2>
-      <p class="text--lead">This page provides an overview of all the money received and spent by committees authorized by this candidate, including his or her principal campaign committees and authorized campaign committees, but not joint fundraising committees authorized by the candidate.  For more information about an individual committee — the funding they've received, how they have spent their money, and more — visit the committee’s page.</p>
-    </div>
+  <div class="page-section__intro">
+    <h2 id="section-1-heading" tabindex="0">Financial Summary       {% include 'partials/cycle-select.html' %}</h2>
+    <p class="text--lead">This page provides an overview of all the money received and spent by committees authorized by this candidate, including his or her principal campaign committees and authorized campaign committees, but not joint fundraising committees authorized by the candidate.  For more information about an individual committee — the funding they've received, how they have spent their money, and more — visit the committee’s page.</p>
+  </div>
+  {% if committees_authorized %}
 
     {% if committees_authorized | length > 1 %}
       {% include 'partials/financial-aggregates.html' %}

--- a/templates/partials/receipts-tab.html
+++ b/templates/partials/receipts-tab.html
@@ -1,7 +1,7 @@
 {% import 'macros/null.html' as null %}
 {% import 'macros/charts.html' as charts %}
 
-<section class="page-section" id="section-2" role="tabpanel" aria-hidden="true" aria-labelledby="section-2-header">
+<section class="page-section" id="section-2" role="tabpanel" aria-hidden="true" aria-labelledby="section-2-heading">
   <div class="container">
       {% set table_data = [
         (aggregates.size.0, (0, 199.99), 'Under $200'),
@@ -11,7 +11,7 @@
         (aggregates.size.2000, (2000, None), 'Over $2000'),
       ] %}
     <div class="page-section__intro">
-      <h2>Analyze Contributions {{ year if year else cycle | fmt_year_range }}</h2>
+      <h2 class="section-heading" id="section-2-heading">Analyze Contributions {% include 'partials/cycle-select.html' %}  </h2>
       <div class="toggles">
         <span class="label">Compare by:</span>
         <label for="toggle-state">

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,7 +26,7 @@ def test_date_filter_empty():
 
 
 def test_fmt_year_range_int():
-    assert app.fmt_year_range(1985) == '1984 - 1985'
+    assert app.fmt_year_range(1985) == '1984–1985'
 
 
 def test_fmt_year_range_not_int():


### PR DESCRIPTION
Based on #351, I wanted to come up with a better, more consistent place for the cycle select. So this patch does just that. @jenniferthibault can you review to make sure this captures what we discussed yesterday?

There are now cycle selects on any tab where you can control the cycle (so everything except "Filings"), and changing one changes them all.

![screenshot-02](https://cloud.githubusercontent.com/assets/1696495/8865393/85a9dade-3163-11e5-8efa-16f21efe951b.png)
![screen shot 2015-07-23 at 5 44 26 pm](https://cloud.githubusercontent.com/assets/1696495/8865396/88ef71ae-3163-11e5-8989-3d03ea5e5092.png)
![screen shot 2015-07-23 at 5 44 33 pm](https://cloud.githubusercontent.com/assets/1696495/8865400/8b8080ca-3163-11e5-842d-543aa077bb58.png)

*Also:* I moved the logic on the Candidates and Committees page so that even if there's no records, you still see the "financial summary" section heading and explanatory text.

![screen shot 2015-07-23 at 5 45 38 pm](https://cloud.githubusercontent.com/assets/1696495/8865403/958b8f56-3163-11e5-8ce9-066e0cd65d34.png)

*To do:* Once we have persistent tab URLs, you'll no longer be bumped to the first tab upon changing the select on the second or third tab.