### PR TITLE
Feature/adding r and d links

### DIFF
--- a/static/styles/_base/_buttons.scss
+++ b/static/styles/_base/_buttons.scss
@@ -48,8 +48,7 @@
 
 button,
 .button {
-  @include button($lightest-gray, $dark-gray, $medium-gray, $dark-gray);
-  border: 1px solid $medium-gray;
+  @include button(#FBFBFD, $dark-gray, $medium-gray, $dark-gray);
 }
 
 .button--selected {

--- a/static/styles/_base/_typography.scss
+++ b/static/styles/_base/_typography.scss
@@ -227,6 +227,10 @@ cite {
   @include font-size(1.2);
 }
 
+.label {
+  font-weight: bold;
+}
+
 // Data styles
 // When we're presenting data but not using semantic headers
 .data {

--- a/static/styles/_components/_toggles.scss
+++ b/static/styles/_components/_toggles.scss
@@ -3,7 +3,6 @@
 
   .label {
     display: block;
-    font-weight: bold;
     clear: both;
   }
 

--- a/static/styles/_layout/_layout.scss
+++ b/static/styles/_layout/_layout.scss
@@ -97,6 +97,20 @@ body {
   padding-bottom: 2rem;
 }
 
+.section__intro__left {
+  @include media($large) {
+    @include span-columns(18)
+  }
+}
+
+.section__intro__right {
+  @include media($large) {
+    @include span-columns(6);
+    .button {
+      width: 100%;
+    }
+  }
+}
 // This is a grouping of content withinin a section, labeled by a h3
 .page-subsection {
   @include clearfix();

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -69,7 +69,7 @@
            <nav class="page-tabs">
               <ul role="tablist">
                 <li role="presentation" class="page-tabs__item"><a role="tab" tabindex="0" aria-controls="panel1" aria-selected="true" href="#section-1">Financial Summary</a></li>
-                <li role="presentation" class="page-tabs__item"><a role="tab" tabindex="-1" aria-controls="panel2" href="#section-2">Contributions</a></li>
+                <li role="presentation" class="page-tabs__item"><a role="tab" tabindex="-1" aria-controls="panel2" href="#section-2">Receipts</a></li>
                 <li role="presentation" class="page-tabs__item"><a role="tab" tabindex="-1" aria-controls="panel3" href="#section-3">Disbursements</a></li>
                 <li role="presentation" class="page-tabs__item"><a role="tab" tabindex="-1" aria-controls="panel4" href="#section-4">Filings</a></li>
               </ul>

--- a/templates/partials/disbursements-tab.html
+++ b/templates/partials/disbursements-tab.html
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="page-section__intro">
       <h2 class="section-heading" id="section-3-heading">Top Recipients {% include 'partials/cycle-select.html' %}  </h2>
-        <div class="toggles">
+        <div class="toggles section__intro__left">
           <span class="label">Compare by:</span>
           <label for="toggle-purpose">
             <input id="toggle-purpose" type="radio" class="panel-toggle-control" name="disbursement-aggregate" value="by-purpose" checked />
@@ -17,15 +17,14 @@
             <span class="toggle-button">Recipient Committee</span>
           </label>
         </div>
+        <div class="section__intro__right">
+          <span class="label">View the raw data:</span>
+          <a class="button" href="{{ url_for('disbursements', committee_id=committee.committee_id, cycle=cycle) }}">View all disbursements &raquo;</a>
+        </div>
     </div>
     <div class="row">
       <div id="by-purpose" class="panel-toggle-element">
         <h4>Disbursements by Purpose</h4>
-        <div>
-          <a
-              href={{ url_for('disbursements', committee_id=committee.committee_id) }}
-            >View all committee disbursements</a>
-        </div>
         <table
             class="data-table"
             data-type="disbursements-by-purpose"

--- a/templates/partials/filings-tab.html
+++ b/templates/partials/filings-tab.html
@@ -2,15 +2,18 @@
   <div class="container">
     <div class="page-section__intro">
       <h2 class="section-heading" id="section-4-heading">Committee Filings {% include 'partials/cycle-select.html' %}</h2>
-    </div>
-    <div id="filters" class="meta-box filters--horizontal">
+    <div id="filters" class="meta-box filters--horizontal section__intro__left">
       <form id="category-filters">
         {% include 'partials/filters/amendment-indicator.html' %}
         {% include 'partials/filters/primary-general.html' %}
         {% include 'partials/filters/report-type.html' %}
       </form>
     </div>
-
+    <div class="section__intro__right">
+      <span class="label">View the raw data:</span>
+      <a class="button" href="{{ url_for('filings', committee_id=committee.committee_id) }}">View all filings &raquo;</a>
+    </div>
+    </div>
     <table class="data-table" data-type="filing" data-committee="{{ committee_id }}" width="100%" class="responsive">
       <thead>
         <tr>

--- a/templates/partials/receipts-tab.html
+++ b/templates/partials/receipts-tab.html
@@ -11,7 +11,7 @@
         (aggregates.size.2000, (2000, None), 'Over $2000'),
       ] %}
     <div class="page-section__intro">
-      <h2 class="section-heading" id="section-2-heading">Analyze Contributions {% include 'partials/cycle-select.html' %}  </h2>
+      <h2 class="section-heading" id="section-2-heading">Analyze Receipts {% include 'partials/cycle-select.html' %}  </h2>
       <div class="toggles">
         <span class="label">Compare by:</span>
         <label for="toggle-state">

--- a/templates/partials/receipts-tab.html
+++ b/templates/partials/receipts-tab.html
@@ -12,7 +12,7 @@
       ] %}
     <div class="page-section__intro">
       <h2 class="section-heading" id="section-2-heading">Analyze Receipts {% include 'partials/cycle-select.html' %}  </h2>
-      <div class="toggles">
+      <div class="toggles section__intro__left">
         <span class="label">Compare by:</span>
         <label for="toggle-state">
           <input id="toggle-state" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-state" checked>
@@ -34,6 +34,11 @@
           <input id="toggle-occupation" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-occupation">
           <span class="toggle-button">Occupation</span>
         </label>
+      </div>
+
+      <div class="section__intro__right">
+        <span class="label">View the raw data:</span>
+        <a class="button" href="{{ url_for('receipts', committee_id=committee.committee_id, cycle=cycle) }}">View all receipts &raquo;</a>
       </div>
     </div>
     <div class="row">
@@ -102,8 +107,6 @@
               <th scope="col">Total Contributed</th>
             </thead>
           </table>
-          <a href={{ url_for('receipts', committee_id=committee.committee_id, contributor_type='committee') }}>
-            View all contributions from committees &raquo;</a>
         </div>
 
       <div id="by-employer" class="panel-toggle-element">


### PR DESCRIPTION
This adds links to the the Receipts, Disbursements and Filings tabs that take the user to the browse view for each of those types. 

The Receipts and Disbursements links don't currently work because the filters on those pages seem to be broken.

![screen shot 2015-07-27 at 10 35 22 am](https://cloud.githubusercontent.com/assets/1696495/8913068/86af15da-344b-11e5-8070-c2eea0bc66cc.png)
![screen shot 2015-07-27 at 10 35 26 am](https://cloud.githubusercontent.com/assets/1696495/8913067/86ae722e-344b-11e5-887d-1411de209ac2.png)
![screenshot-01](https://cloud.githubusercontent.com/assets/1696495/8913066/86ada0ce-344b-11e5-9c0d-d6c920410786.png)
