### PR TITLE
[dontmerge] Use 18f.gov for SSL termination.

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -6,5 +6,5 @@ services:
   - fec-creds-dev
 env:
   NEW_RELIC_APP_NAME: OpenFEC Web (development)
-  FEC_WEB_API_URL: http://fec-dev-api.cf.18f.us
+  FEC_WEB_API_URL: https://fec-dev-api.18f.gov
   FEC_WEB_DEBUG: True

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -6,5 +6,5 @@ services:
   - fec-creds-stage
 env:
   NEW_RELIC_APP_NAME: OpenFEC Web (staging)
-  FEC_WEB_API_URL: http://fec-stage-api.cf.18f.us
+  FEC_WEB_API_URL: https://fec-stage-api.18f.gov
   FEC_WEB_DEBUG: True

--- a/tasks.py
+++ b/tasks.py
@@ -82,10 +82,10 @@ def _detect_apps(blue, green):
 
 
 SPACE_URLS = {
-    'dev': [('cf.18f.us', 'fec-dev-web')],
-    'stage': [('cf.18f.us', 'fec-stage-web')],
+    'dev': [('18f.gov', 'fec-dev-web')],
+    'stage': [('18f.gov', 'fec-stage-web')],
     'prod': [
-        ('cf.18f.us', 'fec-prod-web'),
+        ('18f.gov', 'fec-prod-web'),
         ('open.fec.gov', None),
     ],
 }


### PR DESCRIPTION
Switch to 18f.gov. See also https://github.com/18F/openFEC/pull/1089.