### PR TITLE
Adding aggregate links to itemized tables

### DIFF
--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -24,7 +24,16 @@ function datetime(value) {
 }
 Handlebars.registerHelper('datetime', datetime);
 
+function cycleDates(value) {
+  var secondYear = value;
+  var firstYear = secondYear - 1;
+  var min_date = '01-01-' + firstYear;
+  var max_date = '12-31-' + secondYear;
+  return { min_date: min_date, max_date: max_date };
+}
+
 module.exports = {
   currency: currency,
-  datetime: datetime
+  datetime: datetime,
+  cycleDates: cycleDates,
 };

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -77,6 +77,14 @@ function buildEntityLink(data, url, category) {
   return anchor.outerHTML;
 }
 
+function buildAggregateLink(data, url) {
+  var anchor = document.createElement('a');
+  anchor.textContent = helpers.currency(data);
+  anchor.setAttribute('href', url);
+  anchor.setAttribute('title', 'View individual transactions');
+  return anchor.outerHTML;
+}
+
 function formattedColumn(formatter) {
   return function(opts) {
     return _.extend({
@@ -289,6 +297,7 @@ module.exports = {
   yearRange: yearRange,
   buildCycle: buildCycle,
   buildEntityLink: buildEntityLink,
+  buildAggregateLink: buildAggregateLink,
   currencyColumn: currencyColumn,
   dateColumn: dateColumn,
   modalAfterRender: modalAfterRender,

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -77,8 +77,11 @@ function buildEntityLink(data, url, category) {
   return anchor.outerHTML;
 }
 
-function buildAggregateLink(data, url) {
+function buildAggregateLink(data, url, cycle) {
   var anchor = document.createElement('a');
+  var min_date = helpers.cycleDates(cycle).min_date;
+  var max_date = helpers.cycleDates(cycle).max_date;
+  url = url + '&min_date=' + min_date + '&max_date=' + max_date;
   anchor.textContent = helpers.currency(data);
   anchor.setAttribute('href', url);
   anchor.setAttribute('title', 'View individual transactions');

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -20,7 +20,14 @@ var committeeColumns = [
       return tables.buildEntityLink(data, '/committee/' + row.contributor_id, 'committee');
     }
   },
-  tables.currencyColumn({data: 'total', className: 'all', orderable: false})
+  {
+    data: 'total', 
+    className: 'all', 
+    orderable: false,
+    render: function(data, type, row, meta) {
+      return tables.buildAggregateLink(data, '/receipts?committee_id=' + row.committee_id + '&contributor_id=' + row.contributor_id);
+    }
+  }
 ];
 
 var stateColumns = [
@@ -42,9 +49,14 @@ var stateColumns = [
     className: 'all',
     render: function(data, type, row, meta) {
       var span = document.createElement('div');
-      span.textContent = helpers.currency(data);
+      var link = document.createElement('a');
+      var url = '/receipts?committee_id=' + row.committee_id + '&contributor_state=' + row.state;
       span.setAttribute('data-value', data);
       span.setAttribute('data-row', meta.row);
+      span.appendChild(link);
+      link.textContent = helpers.currency(data);
+      link.setAttribute('title', 'View individual transactions');
+      link.setAttribute('href', url);
       return span.outerHTML;
     }
   },
@@ -52,12 +64,26 @@ var stateColumns = [
 
 var employerColumns = [
   {data: 'employer', className: 'all', orderable: false},
-  tables.currencyColumn({data: 'total', className: 'all', orderable: false})
+  {
+    data: 'total', 
+    className: 'all', 
+    orderable: false,
+    render: function(data, type, row, meta) {
+      return tables.buildAggregateLink(data, '/receipts?committee_id=' + row.committee_id + '&contributor_employer=' + row.employer);
+    }
+  }
 ];
 
 var occupationColumns = [
   {data: 'occupation', className: 'all', orderable: false},
-  tables.currencyColumn({data: 'total', className: 'all', orderable: false})
+  {
+    data: 'total', 
+    className: 'all', 
+    orderable: false,
+    render: function(data, type, row, meta) {
+      return tables.buildAggregateLink(data, '/receipts?committee_id=' + row.committee_id + '&contributor_occupation=' + row.occupation);
+    }
+  }
 ];
 
 var filingsColumns = [
@@ -88,7 +114,14 @@ var disbursementPurposeColumns = [
 
 var disbursementRecipientColumns = [
   {data: 'recipient_name', className: 'all', orderable: false},
-  tables.currencyColumn({data: 'total', className: 'all', orderable: false})
+  {
+    data: 'total', 
+    className: 'all', 
+    orderable: false,
+    render: function(data, type, row, meta) {
+      return tables.buildAggregateLink(data, '/disbursements?committee_id=' + row.committee_id + '&recipient_name=' + row.recipient_name);
+    }
+  }
 ];
 
 var disbursementRecipientIDColumns = [
@@ -100,7 +133,14 @@ var disbursementRecipientIDColumns = [
       return tables.buildEntityLink(data, '/committee/' + row.recipient_id, 'committee');
     }
   },
-  tables.currencyColumn({data: 'total', className: 'all', orderable: false})
+  {
+    data: 'total', 
+    className: 'all', 
+    orderable: false,
+    render: function(data, type, row, meta) {
+      return tables.buildAggregateLink(data, '/disbursements?committee_id=' + row.committee_id + '&recipient_id=' + row.recipient_id);
+    }
+  }
 ];
 
 $(document).ready(function() {

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -25,7 +25,7 @@ var committeeColumns = [
     className: 'all', 
     orderable: false,
     render: function(data, type, row, meta) {
-      return tables.buildAggregateLink(data, '/receipts?committee_id=' + row.committee_id + '&contributor_id=' + row.contributor_id);
+      return tables.buildAggregateLink(data, '/receipts?committee_id=' + row.committee_id + '&contributor_id=' + row.contributor_id, row.cycle);
     }
   }
 ];
@@ -50,7 +50,9 @@ var stateColumns = [
     render: function(data, type, row, meta) {
       var span = document.createElement('div');
       var link = document.createElement('a');
-      var url = '/receipts?committee_id=' + row.committee_id + '&contributor_state=' + row.state;
+      var min_date = helpers.cycleDates(row.cycle).min_date;
+      var max_date = helpers.cycleDates(row.cycle).max_date;
+      var url = '/receipts?committee_id=' + row.committee_id + '&contributor_state=' + row.state + '&min_date=' + min_date + '&max_date=' + max_date;
       span.setAttribute('data-value', data);
       span.setAttribute('data-row', meta.row);
       span.appendChild(link);
@@ -69,7 +71,7 @@ var employerColumns = [
     className: 'all', 
     orderable: false,
     render: function(data, type, row, meta) {
-      return tables.buildAggregateLink(data, '/receipts?committee_id=' + row.committee_id + '&contributor_employer=' + row.employer);
+      return tables.buildAggregateLink(data, '/receipts?committee_id=' + row.committee_id + '&contributor_employer=' + row.employer, row.cycle);
     }
   }
 ];
@@ -81,7 +83,7 @@ var occupationColumns = [
     className: 'all', 
     orderable: false,
     render: function(data, type, row, meta) {
-      return tables.buildAggregateLink(data, '/receipts?committee_id=' + row.committee_id + '&contributor_occupation=' + row.occupation);
+      return tables.buildAggregateLink(data, '/receipts?committee_id=' + row.committee_id + '&contributor_occupation=' + row.occupation, row.cycle);
     }
   }
 ];
@@ -119,7 +121,7 @@ var disbursementRecipientColumns = [
     className: 'all', 
     orderable: false,
     render: function(data, type, row, meta) {
-      return tables.buildAggregateLink(data, '/disbursements?committee_id=' + row.committee_id + '&recipient_name=' + row.recipient_name);
+      return tables.buildAggregateLink(data, '/disbursements?committee_id=' + row.committee_id + '&recipient_name=' + row.recipient_name, row.cycle);
     }
   }
 ];
@@ -138,7 +140,7 @@ var disbursementRecipientIDColumns = [
     className: 'all', 
     orderable: false,
     render: function(data, type, row, meta) {
-      return tables.buildAggregateLink(data, '/disbursements?committee_id=' + row.committee_id + '&recipient_id=' + row.recipient_id);
+      return tables.buildAggregateLink(data, '/disbursements?committee_id=' + row.committee_id + '&recipient_id=' + row.recipient_id, row.cycle);
     }
   }
 ];


### PR DESCRIPTION
I saw an opportunity to help with one of the dev tasks ( #376 ), so I went ahead and did it. This adds links to the amounts in the Receipts and Disbursements tab tables to the itemized transactions that make up the total. So when you click the Facebook total in this table:

![screenshot-01](https://cloud.githubusercontent.com/assets/1696495/9051837/27ccc20e-3a15-11e5-97c1-b65fbea84abe.png)

It shows the transactions that make up that total:

![screen shot 2015-08-03 at 7 22 44 pm](https://cloud.githubusercontent.com/assets/1696495/9051849/45133b22-3a15-11e5-93be-eb8e96a4b816.png)

I tried to code this up in a smart, reusable way, but please let me know if there's anything I should do to tighten it up (I imagine there is).

