### PR TITLE
Arrow button on rows for panel

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -168,12 +168,25 @@ function modalAfterRender(template, api, data, response) {
     $row.siblings().toggleClass('row-active', false);
     $row.toggleClass('row-active', true);
     $('body').toggleClass('panel-active', true);
+    var hideColumns = api.columns('.hide-panel');
+    hideColumns.visible(false);
+    // When under $large-screen
+    // TODO figure way to share these values with CSS.
+    if ($(document).width() < 980) {
+      api.columns('.hide-panel-tablet').visible(false);
+    }
   });
 
   $modal.on('click', '.js-panel-close', function(ev) {
     ev.preventDefault();
     $('.js-panel-toggle tr').toggleClass('row-active', false);
     $('body').toggleClass('panel-active', false);
+    var hideColumns = api.columns('.hide-panel');
+    hideColumns.visible(true);
+    // When under $large-screen
+    if ($(document).width() < 980) {
+      api.columns('.hide-panel-tablet').visible(true);
+    }
   });
 }
 
@@ -226,7 +239,7 @@ function initTable($table, $form, baseUrl, baseQuery, columns, callbacks, opts) 
     language: {
       lengthMenu: 'Results per page: _MENU_'
     },
-    dom: '<"results-info meta-box results-info--top"lfrip>t<"results-info meta-box"ip>',
+    dom: '<"results-info meta-box results-info--top"lfrip><"panel__main"t><"results-info meta-box"ip>',
     ajax: function(data, callback, settings) {
       var api = this.api();
       if ($form) {

--- a/static/js/pages/receipts.js
+++ b/static/js/pages/receipts.js
@@ -13,7 +13,7 @@ var columns = [
     data: 'contributor',
     orderable: false,
     className: 'all',
-    width: '27%',
+    width: '30%',
     render: function(data, type, row, meta) {
       if (data) {
         return tables.buildEntityLink(data.name, '/committee/' + data.committee_id, 'committee');
@@ -25,13 +25,12 @@ var columns = [
   {data: 'contributor_state', orderable: false, className: 'min-desktop hide-panel'},
   {data: 'contributor_employer', orderable: false, className: 'min-desktop hide-panel'},
   tables.currencyColumn({data: 'contributor_receipt_amount', className: 'min-tablet'}),
-  tables.dateColumn({data: 'contributor_receipt_date', 
-      className: 'min-mobile hide-panel-tablet'}),
+  tables.dateColumn({data: 'contributor_receipt_date', className: 'min-tablet hide-panel-tablet'}),
   {
     data: 'committee',
     orderable: false,
     className: 'all hide-panel',
-    width: '27%',
+    width: '30%',
     render: function(data, type, row, meta) {
       if (data) {
         return tables.buildEntityLink(data.name, '/committee/' + data.committee_id, 'committee');
@@ -41,8 +40,8 @@ var columns = [
     }
   },
   {
-    className: 'min-mobile',
-    width: '4%',
+    className: 'min-tablet',
+    width: '20px',
     orderable: false,
     render: function(data, type, row, meta) {
       return '<i class="icon ti-angle-right"></i>';

--- a/static/js/pages/receipts.js
+++ b/static/js/pages/receipts.js
@@ -43,7 +43,7 @@ var columns = [
     width: '3%',
     orderable: false,
     render: function(data, type, row, meta) {
-      return '<i class="icon ti-angle-right"></icon>';
+      return '<i class="icon ti-angle-right"></i>';
     }
   }
 ];

--- a/static/js/pages/receipts.js
+++ b/static/js/pages/receipts.js
@@ -40,10 +40,10 @@ var columns = [
     }
   },
   {
-    width: '5%',
+    width: '3%',
     orderable: false,
     render: function(data, type, row, meta) {
-      return '';
+      return '<i class="icon ti-angle-right"></icon>';
     }
   }
 ];

--- a/static/js/pages/receipts.js
+++ b/static/js/pages/receipts.js
@@ -13,7 +13,7 @@ var columns = [
     data: 'contributor',
     orderable: false,
     className: 'all',
-    width: '30%',
+    width: '27%',
     render: function(data, type, row, meta) {
       if (data) {
         return tables.buildEntityLink(data.name, '/committee/' + data.committee_id, 'committee');
@@ -25,12 +25,13 @@ var columns = [
   {data: 'contributor_state', orderable: false, className: 'min-desktop hide-panel'},
   {data: 'contributor_employer', orderable: false, className: 'min-desktop hide-panel'},
   tables.currencyColumn({data: 'contributor_receipt_amount', className: 'min-tablet'}),
-  tables.dateColumn({data: 'contributor_receipt_date', className: 'min-tablet'}),
+  tables.dateColumn({data: 'contributor_receipt_date', 
+      className: 'min-mobile hide-panel-tablet'}),
   {
     data: 'committee',
     orderable: false,
     className: 'all hide-panel',
-    width: '30%',
+    width: '27%',
     render: function(data, type, row, meta) {
       if (data) {
         return tables.buildEntityLink(data.name, '/committee/' + data.committee_id, 'committee');
@@ -40,7 +41,8 @@ var columns = [
     }
   },
   {
-    width: '3%',
+    className: 'min-mobile',
+    width: '4%',
     orderable: false,
     render: function(data, type, row, meta) {
       return '<i class="icon ti-angle-right"></i>';

--- a/static/styles/_base/_tables.scss
+++ b/static/styles/_base/_tables.scss
@@ -426,4 +426,14 @@ table.dataTable tbody tr.child {
       display: none;
     }
   }
+
+  @include media($small) {
+    .dataTable {
+      width: 52% !important;
+    }
+
+    .hide-panel-tablet {
+      display: none;
+    }
+  }
 }

--- a/static/styles/_base/_tables.scss
+++ b/static/styles/_base/_tables.scss
@@ -63,6 +63,12 @@ table.dataTable {
     padding-left: 20px !important;
     border-bottom: 1px dotted $light-gray;
 
+    .icon {
+      color: $light-gray;
+      cursor: pointer;
+      font-weight: 900;
+    }
+
     @include media($large) {
       padding-left: 10px !important;
     }

--- a/static/styles/_base/_tables.scss
+++ b/static/styles/_base/_tables.scss
@@ -418,21 +418,7 @@ table.dataTable tbody tr.child {
     height: auto;
     overflow: auto;
 
-    .dataTable {
-      width: 50% !important;
-    }
-
     .hide-panel {
-      display: none;
-    }
-  }
-
-  @include media($small) {
-    .dataTable {
-      width: 52% !important;
-    }
-
-    .hide-panel-tablet {
       display: none;
     }
   }

--- a/static/styles/_components/_panel.scss
+++ b/static/styles/_components/_panel.scss
@@ -13,20 +13,15 @@
     @include transform(translateX(0%));
   }
 
-  @include media($small) {
-    &[aria-hidden="false"] {
-      @include transform(translateX(103.5%));
-    }
-  }
-
   @include media($medium) {
     &[aria-hidden="false"] {
-      @include transform(translateX(102%));
+      // 99.5 to ensure when container is not an even number.
+      @include transform(translateX(99.5%));
     }
 
     background: white;
     border: 1px solid $light-gray;
-    width: 95%;
+    width: 100%;
   }
 }
 
@@ -37,6 +32,14 @@
   @include media($medium) {
     padding: 0;
   }
+}
+
+.panel__main {
+  clear: both;
+}
+
+.panel-active .panel__main {
+  width: 50%;
 }
 
 .panel__row {

--- a/static/styles/_components/_panel.scss
+++ b/static/styles/_components/_panel.scss
@@ -15,7 +15,7 @@
 
   @include media($medium) {
     &[aria-hidden="false"] {
-      @include transform(translateX(100%));
+      @include transform(translateX(103.5%));
     }
 
     background: white;

--- a/static/styles/_components/_panel.scss
+++ b/static/styles/_components/_panel.scss
@@ -13,9 +13,15 @@
     @include transform(translateX(0%));
   }
 
-  @include media($medium) {
+  @include media($small) {
     &[aria-hidden="false"] {
       @include transform(translateX(103.5%));
+    }
+  }
+
+  @include media($medium) {
+    &[aria-hidden="false"] {
+      @include transform(translateX(102%));
     }
 
     background: white;


### PR DESCRIPTION
This UI is to make it easier to understand how to open the table
rows to show the details panel. A new table column was used to
contain the button so that everything fits within data tables
width interface. Additional styles were set from the table scss
as its generally safe to ensure these styles for any icon in the
table.

@noahmanger whats the best way to make the arrows as thick as in
the mockup? Right now they are thinner.