### PR TITLE
Restore paging and sorting.

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -289,11 +289,7 @@ function initTable($table, $form, baseUrl, baseQuery, columns, callbacks, opts) 
       var api = this.api();
       if ($form) {
         var filters = $form.serializeArray();
-        var tempFilters = mapFilters(filters);
-        if (_.isEqual(tempFilters, parsedFilters)) {
-          return;
-        }
-        parsedFilters = tempFilters;
+        parsedFilters = mapFilters(filters);
         pushQuery(parsedFilters);
       }
       var query = _.extend(
@@ -333,7 +329,10 @@ function initTable($table, $form, baseUrl, baseQuery, columns, callbacks, opts) 
     // Update filters and data table on navigation
     $(window).on('popstate', function() {
       filters.activateInitialFilters();
-      api.ajax.reload();
+      var tempFilters = mapFilters(filters);
+      if (!_.isEqual(tempFilters, parsedFilters)) {
+        api.ajax.reload();
+      }
     });
   }
   // Prepare loading message


### PR DESCRIPTION
Since both the data tables and the tabbing interface can change the
window history, the data tables should only refresh on popState when the
relevant query parameters have changed. Previously, this check was
applied on every table reload; this patch applies the check only on
reloads triggered by the popState event.

[Resolves #433]