### PR TITLE
Avoid hard-coded dependencies on test data where possible.

### DIFF
--- a/tests/selenium/search_results_test.py
+++ b/tests/selenium/search_results_test.py
@@ -15,17 +15,17 @@ class SearchResultsPageTests(SearchPageTestCase):
         self.url = furl.furl(self.base_url)
 
     def test_search_results_page_load(self):
-        self.url.args.update({'search': 'boehner'})
+        self.url.args.update({'search': 'john'})
         self.driver.get(self.url.url)
         self.assertIn('Search results', self.driver.title)
 
     def test_search_results_page_type(self):
-        self.url.args.update({'search': 'boehner', 'search_type': 'candidates'})
+        self.url.args.update({'search': 'john', 'search_type': 'candidates'})
         self.driver.get(self.url.url)
         self.assertIn('Search results', self.driver.title)
 
     def test_search_results_page_link_candidates(self):
-        self.url.args.update({'search': 'boehner', 'search_type': 'candidates'})
+        self.url.args.update({'search': 'john', 'search_type': 'candidates'})
         self.driver.get(self.url.url)
         elms = self.driver.find_elements_by_css_selector('.tst-search_results h3 a')
         self.assertTrue(elms)
@@ -35,7 +35,7 @@ class SearchResultsPageTests(SearchPageTestCase):
         ]))
 
     def test_search_results_page_link_committees(self):
-        self.url.args.update({'search': 'grijalva', 'search_type': 'committees'})
+        self.url.args.update({'search': 'americ', 'search_type': 'committees'})
         self.driver.get(self.url.url)
         elms = self.driver.find_elements_by_css_selector('.tst-search_results h5 a')
         self.assertTrue(elms)
@@ -49,7 +49,7 @@ class SearchResultsPageTests(SearchPageTestCase):
         self.driver.get(self.url.url)
         select = self.driver.find_element_by_css_selector('input[value="candidates"]')
         self.assertEqual(select.get_attribute('checked'), 'true')
-        self.driver.find_element_by_css_selector('.header-search .search-input').send_keys('boeh')
+        self.driver.find_element_by_css_selector('.header-search .search-input').send_keys('john')
         results = self.driver.find_elements_by_css_selector('.tt-suggestion')
         self.assertGreater(len(results), 0)
 
@@ -58,6 +58,6 @@ class SearchResultsPageTests(SearchPageTestCase):
         self.driver.get(self.url.url)
         select = self.driver.find_element_by_css_selector('input[value="committees"]')
         self.assertEqual(select.get_attribute('checked'), 'true')
-        self.driver.find_element_by_css_selector('.header-search .search-input').send_keys('grij')
+        self.driver.find_element_by_css_selector('.header-search .search-input').send_keys('americ')
         results = self.driver.find_elements_by_css_selector('.tt-suggestion')
         self.assertGreater(len(results), 0)

--- a/tests/selenium/search_results_test.py
+++ b/tests/selenium/search_results_test.py
@@ -4,6 +4,8 @@ import furl
 
 from .base_test_class import SearchPageTestCase
 
+from tests.selenium import utils
+
 
 candidate_url_re = re.compile('\/candidate\/\w+$')
 committee_url_re = re.compile('\/committee\/\w+$')
@@ -11,21 +13,37 @@ committee_url_re = re.compile('\/committee\/\w+$')
 
 class SearchResultsPageTests(SearchPageTestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.driver.get(cls.base_url + '/candidates')
+        utils.wait_for_event(cls.driver, 'draw.dt', 'draw')
+        cls.candidate = cls.driver.find_element_by_css_selector(
+            'a[data-category="candidate"]'
+        ).text
+
+        cls.driver.get(cls.base_url + '/committees')
+        utils.wait_for_event(cls.driver, 'draw.dt', 'draw')
+        cls.committee = cls.driver.find_element_by_css_selector(
+            'a[data-category="committee"]'
+        ).text
+
     def setUp(self):
         self.url = furl.furl(self.base_url)
 
     def test_search_results_page_load(self):
-        self.url.args.update({'search': 'john'})
+        self.url.args.update({'search': self.candidate})
         self.driver.get(self.url.url)
         self.assertIn('Search results', self.driver.title)
 
     def test_search_results_page_type(self):
-        self.url.args.update({'search': 'john', 'search_type': 'candidates'})
+        self.url.args.update({'search': self.candidate, 'search_type': 'candidates'})
         self.driver.get(self.url.url)
         self.assertIn('Search results', self.driver.title)
 
     def test_search_results_page_link_candidates(self):
-        self.url.args.update({'search': 'john', 'search_type': 'candidates'})
+        self.url.args.update({'search': self.candidate, 'search_type': 'candidates'})
         self.driver.get(self.url.url)
         elms = self.driver.find_elements_by_css_selector('.tst-search_results h3 a')
         self.assertTrue(elms)
@@ -35,7 +53,7 @@ class SearchResultsPageTests(SearchPageTestCase):
         ]))
 
     def test_search_results_page_link_committees(self):
-        self.url.args.update({'search': 'americ', 'search_type': 'committees'})
+        self.url.args.update({'search': self.committee, 'search_type': 'committees'})
         self.driver.get(self.url.url)
         elms = self.driver.find_elements_by_css_selector('.tst-search_results h5 a')
         self.assertTrue(elms)
@@ -49,7 +67,9 @@ class SearchResultsPageTests(SearchPageTestCase):
         self.driver.get(self.url.url)
         select = self.driver.find_element_by_css_selector('input[value="candidates"]')
         self.assertEqual(select.get_attribute('checked'), 'true')
-        self.driver.find_element_by_css_selector('.header-search .search-input').send_keys('john')
+        self.driver.find_element_by_css_selector(
+            '.header-search .search-input'
+        ).send_keys(self.candidate)
         results = self.driver.find_elements_by_css_selector('.tt-suggestion')
         self.assertGreater(len(results), 0)
 
@@ -58,6 +78,8 @@ class SearchResultsPageTests(SearchPageTestCase):
         self.driver.get(self.url.url)
         select = self.driver.find_element_by_css_selector('input[value="committees"]')
         self.assertEqual(select.get_attribute('checked'), 'true')
-        self.driver.find_element_by_css_selector('.header-search .search-input').send_keys('americ')
+        self.driver.find_element_by_css_selector(
+            '.header-search .search-input'
+        ).send_keys(self.committee)
         results = self.driver.find_elements_by_css_selector('.tt-suggestion')
         self.assertGreater(len(results), 0)

--- a/tests/selenium/single_candidate_page_tests.py
+++ b/tests/selenium/single_candidate_page_tests.py
@@ -2,6 +2,8 @@ import unittest
 
 from .base_test_class import BaseTest
 
+from tests.selenium import utils
+
 
 class SingleCandidatePageTests(BaseTest):
 
@@ -9,11 +11,9 @@ class SingleCandidatePageTests(BaseTest):
         self.url = self.base_url + '/candidate/H0OH08029'
 
     def testSingleCandidatePageLoads(self):
-        self.driver.get(self.url)
-        self.assertEqual(
-            self.driver.find_element_by_tag_name('h1').text,
-            'BOEHNER, JOHN A.',
-        )
+        self.driver.get(self.base_url + '/candidates')
+        utils.wait_for_event(self.driver, 'draw.dt', 'draw')
+        self.driver.find_element_by_css_selector('a[data-category="candidate"]').click()
 
     @unittest.skip('No principal committee links in test subset')
     def testCommitteeLink(self):

--- a/tests/selenium/single_committee_page_tests.py
+++ b/tests/selenium/single_committee_page_tests.py
@@ -2,6 +2,8 @@ import unittest
 
 from .base_test_class import BaseTest
 
+from tests.selenium import utils
+
 
 class SingleCommitteePageTests(BaseTest):
 
@@ -9,11 +11,9 @@ class SingleCommitteePageTests(BaseTest):
         self.url = self.base_url + '/committee/C00374058'
 
     def testSingleCommitteePageLoads(self):
-        self.driver.get(self.url)
-        self.assertEqual(
-            self.driver.find_element_by_tag_name('h1').text,
-            'A WHOLE LOT OF PEOPLE FOR GRIJALVA CONGRESSIONAL COMMITTEE',
-        )
+        self.driver.get(self.base_url + '/committees')
+        utils.wait_for_event(self.driver, 'draw.dt', 'draw')
+        self.driver.find_element_by_css_selector('a[data-category="committee"]').click()
 
     @unittest.skip('No principal committee links in test subset')
     def testCandidateLink(self):


### PR DESCRIPTION
Several of our tests assume that certain candidates and committees will
exist, which can cause spurious failures when the test subset changes.
This patch removes a few of these hard-coded dependencies, although
there's more we could do to decouple these tests from the data.