### PR TITLE
Original image button on panel

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -205,6 +205,7 @@ function modalAfterRender(template, api, data, response) {
     var $row = $(ev.target).closest('tr');
     var index = api.row($row).index();
     $modal.find('.js-panel-content').html(template(response.results[index]));
+    $modal.find('.js-pdf_url').attr('href', response.results[index].pdf_url);
     $modal.attr('aria-hidden', 'false');
     $row.siblings().toggleClass('row-active', false);
     $row.toggleClass('row-active', true);

--- a/static/styles/_base/_buttons.scss
+++ b/static/styles/_base/_buttons.scss
@@ -100,6 +100,11 @@ input[type="submit"],
   }
 }
 
+.button--sm {
+  @include rem(font-size, 1.4rem);
+  padding: .3rem 1rem;
+}
+
 .button--unstyled {
   @include appearance(none);
   background: none;

--- a/static/styles/_components/_panel.scss
+++ b/static/styles/_components/_panel.scss
@@ -39,7 +39,9 @@
 }
 
 .panel-active .panel__main {
-  width: 50%;
+  @include media($medium) {
+    width: 50%;
+  }
 }
 
 .panel__row {
@@ -77,6 +79,18 @@
 }
 
 .panel__navigation {
+  text-align: right;
+
+  @include media($medium) {
+    text-align: left;
+  }
+}
+
+.panel__navigation--right {
+  display: inline-block;
+  float: left;
+  margin-right: 1em;
+
   .icon {
     &:before {
       content: "\e64a";
@@ -84,6 +98,8 @@
   }
 
   @include media($medium) {
+    float: right;
+    margin-right: 0;
     text-align: right;
 
     .icon {

--- a/static/templates/disbursements.hbs
+++ b/static/templates/disbursements.hbs
@@ -30,8 +30,4 @@
     <td>Election Type</td>
     <td>{{ election_type_full }}</td>
   </tr>
-  <tr>
-    <td>Image</td>
-    <td><a href="{{ pdf_url }}">View original image</a></td>
-  </tr>
 </table>

--- a/static/templates/receipts.hbs
+++ b/static/templates/receipts.hbs
@@ -53,10 +53,6 @@
       <td>Type</td>
       <td>{{ election_type_full }}</td>
     </tr>
-    <tr>
-      <td>Image</td>
-      <td><a href="{{ pdf_url }}">View original image</a></td>
-    </tr>
   </table>
 </div>
 

--- a/templates/partials/datatable-modal.html
+++ b/templates/partials/datatable-modal.html
@@ -1,7 +1,10 @@
 <div id="datatable-modal" class="panel__overlay" aria-hidden="true">
   <div class="panel">
     <div class="panel__row panel__navigation">
-      <strong>
+      <a class="button button--sm js-pdf_url">
+        View original image
+      </a>
+      <strong class="panel__navigation--right">
         <a href="#" class="js-hide js-panel-close panel__close"
             data-hides="datatable-modal">
           <i class="icon icon--bold ti-angle"></i>


### PR DESCRIPTION
This adds the button for the pdf image of the current thing on the
panel. This uses special jquery code to set the button href to the
pdf from the receipt/whatever data because the button code is not
part of the actual template being rendered. There could be a lot of
unnecessary duplication if this part of the UI was moved into the
template, so I found it easier to keep it outside with this special
code.