### PR TITLE
Restore hiding null values on sorted columns.

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -320,7 +320,7 @@ function initTable($table, $form, baseUrl, baseQuery, columns, callbacks, opts) 
       if (useHideNull) {
         query = _.extend(
           query,
-          {sort_hide_null: $hideNullWidget.find('input').is(':checked')}
+          {sort_hide_null: $hideNullWidget.is(':checked')}
         );
       }
       query.sort = mapSort(data.order, columns);


### PR DESCRIPTION
The markup for the hide null input was changed slightly during the move
to the updated styles, which dropped the corresponding parameter from
the API request. This patch updates the table logic to use the current
markup.

[Resolves #493]