### PR TITLE
Add basic map tooltips.

### DIFF
--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -322,7 +322,7 @@ $(document).ready(function() {
   var $map = $('.state-map');
   var url = buildStateUrl($map);
   $.getJSON(url).done(function(data) {
-    maps.stateMap($map, data, 400, 400);
+    maps.stateMap($map, data, 400, 400, null, true, false);
   });
   events.on('state.table', function(params) {
     maps.highlightState($map, params.state);

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -304,7 +304,7 @@ function drawStateMap($container, candidateId, cached) {
     cached[candidateId] = results;
     updateColorScale($container, cached);
     var max = mapMax(cached);
-    maps.stateMap($map, data, 400, 300, max, false);
+    maps.stateMap($map, data, 400, 300, max, false, true);
   });
 }
 


### PR DESCRIPTION
* Add unstyled tooltip for election state maps
* Bring hovered state to front

Part of https://github.com/18F/openFEC-web-app/issues/420

Looks like this, but will look way better after design by @jenniferthibault:
<img width="397" alt="screen shot 2015-08-24 at 5 01 15 pm" src="https://cloud.githubusercontent.com/assets/1633460/9452478/61f1153e-4a82-11e5-9910-8629031854dc.png">
