### PR TITLE
Fix JS error in Safari.

### DIFF
--- a/static/js/modules/performance.js
+++ b/static/js/modules/performance.js
@@ -1,73 +1,44 @@
 'use strict';
 
-/* global require, window, document, perfBar */
+/* global require, module, window, perfBar */
 
 var _ = require('underscore');
 
 require('perfbar/build/perfbar');
 
 var performanceBudgets = {
-  'loadTime': {
-    max: 3000
-  },
-  'latency': {
-    max: 10000
-  },
-  'FirstPaint': {
-    max: 150
-  },
-  'frontEnd': {
-    max: 1200
-  },
-  'backEnd': {
-    max: 300
-  },
-  'large_search_loaded': {
-    max: 400
-  }
+  loadTime: {max: 3000},
+  latency: {max: 10000},
+  FirstPaint: {max: 150},
+  frontEnd: {max: 1200},
+  backEnd: {max: 300},
+  large_search_loaded: {max: 400}
 };
 
-// Performance metrics
-var perf = {
-  bar: function() {
-    var i,
-        ilen,
-        mark,
-        existingMarks = {},
-        filteredMarks = [],
-        marks = window.performance &&
-          window.performance.getEntriesByType('mark');
+function getMetric(mark) {
+  return {
+    id: 'mark_' + mark.name,
+    label: mark.name,
+    unit: 'ms',
+    value: Math.floor(mark.startTime),
+    budget: performanceBudgets[mark.name]
+  };
+}
 
-    perfBar.init({
-      budget: performanceBudgets
+function bar() {
+  var marks = window.performance &&
+    window.performance.getEntriesByType &&
+    window.performance.getEntriesByType('mark') ||
+    [];
+
+  perfBar.init({budget: performanceBudgets});
+
+  _.chain(marks)
+    .groupBy('name')
+    .each(function(marks, name) {
+      var mark = _.max(marks, 'startTime');
+      perfBar.addMetric(getMetric(mark));
     });
+}
 
-    // Max the duplicates
-    _.each(marks, function(mark) {
-      var duplicateMark;
-      if (mark.name in _.keys(existingMarks)) {
-        duplicateMark = existingMarks[mark.name];
-        // already exists, check for duplicates.
-        existingMarks[mark.name] = _.max([mark, duplicateMark], function(compare) {
-          return compare.startTime;
-        });
-      } else {
-        existingMarks[mark.name] = mark;
-      }
-    });
-    filteredMarks = _.values(existingMarks);
-
-    for (i = 0, ilen = filteredMarks.length; i < ilen; i++) {
-      mark = filteredMarks[i];
-      perfBar.addMetric({
-        id: 'mark_' + i,
-        label: mark.name,
-        unit: 'ms',
-        value: Math.floor(mark.startTime),
-        budget: performanceBudgets[mark.name] || null
-      });
-    }
-  }
-};
-
-module.exports = perf;
+module.exports = {bar: bar};


### PR DESCRIPTION
Safari defines `window.performance` but not
`window.performance.getEntriesByType`. Attempting to call this
function in debug mode in Safari crashes the page, blocking other JS.
This patch checks for `getEntriesByType` before calling it, and
additionally tightens up `performance.js` to use fewer local variables.

Ping @msecret to take a look when you have time.