### PR TITLE
Feature/election map

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -235,6 +235,7 @@ def elections(office, cycle, state=None, district=None):
         office=office,
         cycle=cycle,
         state=state,
+        state_full=constants.states[state.upper()] if state else None,
         district=district,
     )
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,17 +29,17 @@ gulp.task('copy-vendor-images', function() {
     .pipe(gulp.dest('./dist/images'));
 });
 
-gulp.task('copy-fonts', function() {
-  return gulp.src('./static/fonts/**/*')
-    .pipe(gulp.dest('./dist/fonts'));
-});
-
 gulp.task('copy-images', function() {
   return gulp.src(['./static/img/**/*', './node_modules/fec-style/img/**/*'])
     .pipe(gulp.dest('./dist/img'));
 });
 
-gulp.task('build-sass', ['copy-vendor-images', 'copy-fonts', 'copy-images'], function() {
+gulp.task('copy-maps', function() {
+  return gulp.src('./node_modules/congressional-districts/**/*')
+    .pipe(gulp.dest('./dist/json/districts'));
+});
+
+gulp.task('build-sass', ['copy-vendor-images', 'copy-images', 'copy-maps'], function() {
   return gulp.src('./static/styles/*.scss')
     .pipe(rename(function(path) {
       path.dirname = './dist/styles';

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gulp-util": "^3.0.6",
     "mocha": "^2.2.5",
     "mochify": "^2.12.0",
+    "napa": "^1.2.0",
     "preprocessify": "0.0.3",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0",
@@ -29,6 +30,7 @@
     "watchify": "^3.2.1"
   },
   "scripts": {
+    "install": "napa",
     "build": "gulp build-js && gulp build-sass",
     "build-js": "gulp build-js",
     "build-sass": "gulp build-sass",
@@ -58,10 +60,15 @@
     "jquery": "2.1.4",
     "jquery.inputmask": "3.1.63",
     "keyboardjs": "0.4.2",
+    "leaflet": "0.7.3",
+    "leaflet-providers": "1.1.1",
     "moment": "2.10.3",
     "perfbar": "git://github.com/jmcarp/perfBar.git#issue-24",
     "topojson": "1.6.19",
     "underscore": "1.8.3",
     "watchify": "3.2.1"
+  },
+  "napa": {
+    "congressional-districts": "benbalter/congressional-districts"
   }
 }

--- a/static/js/modules/maps.js
+++ b/static/js/modules/maps.js
@@ -167,6 +167,7 @@ var districtUrl = '/static/json/districts';
 function DistrictMap(elm) {
   this.elm = elm;
   this.map = null;
+  this.overlay = null;
 }
 
 DistrictMap.prototype.load = function(state, district) {
@@ -175,10 +176,10 @@ DistrictMap.prototype.load = function(state, district) {
 };
 
 DistrictMap.prototype.render = function(data) {
-  var centroid = d3.geo.centroid(data);
-  this.map = L.map(this.elm).setView([centroid[1], centroid[0]], 10);
+  this.map = L.map(this.elm);
   L.tileLayer.provider('Stamen.TonerLite').addTo(this.map);
-  L.geoJson(data).addTo(this.map);
+  this.overlay = L.geoJson(data).addTo(this.map);
+  this.map.fitBounds(this.overlay.getBounds());
 };
 
 module.exports = {

--- a/static/js/modules/maps.js
+++ b/static/js/modules/maps.js
@@ -8,6 +8,9 @@ var _ = require('underscore');
 var chroma = require('chroma-js');
 var topojson = require('topojson');
 
+var L = require('leaflet');
+require('leaflet-providers');
+
 var events = require('fec-style/js/events');
 
 var helpers = require('./helpers');
@@ -159,8 +162,28 @@ function highlightState($parent, state) {
   }
 }
 
+var districtUrl = '/static/json/districts';
+
+function DistrictMap(elm) {
+  this.elm = elm;
+  this.map = null;
+}
+
+DistrictMap.prototype.load = function(state, district) {
+  var url = [districtUrl, state, district].join('/') + '.geojson';
+  $.getJSON(url).done(this.render.bind(this));
+};
+
+DistrictMap.prototype.render = function(data) {
+  var centroid = d3.geo.centroid(data);
+  this.map = L.map(this.elm).setView([centroid[1], centroid[0]], 10);
+  L.tileLayer.provider('Stamen.TonerLite').addTo(this.map);
+  L.geoJson(data).addTo(this.map);
+};
+
 module.exports = {
   stateMap: stateMap,
   stateLegend: stateLegend,
-  highlightState: highlightState
+  highlightState: highlightState,
+  DistrictMap: DistrictMap
 };

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -451,7 +451,7 @@ $(document).ready(function() {
   });
 
   var districtMap = new maps.DistrictMap($('#election-map').get(0));
-  districtMap.load(context.election.state, context.election.district);
+  districtMap.load(context.election);
 
   initSpendingTables();
 });

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -450,5 +450,8 @@ $(document).ready(function() {
     initStateMaps(response.results);
   });
 
+  var districtMap = new maps.DistrictMap($('#election-map').get(0));
+  districtMap.load(context.election.state, context.election.district);
+
   initSpendingTables();
 });

--- a/static/styles/styles.scss
+++ b/static/styles/styles.scss
@@ -1,1 +1,3 @@
 // Put overrides here and vendor styles here
+
+@import "leaflet/dist/leaflet";

--- a/templates/elections.html
+++ b/templates/elections.html
@@ -22,8 +22,8 @@
           {% endif %}
         {% endif %}
       </div>
-      {% if district %}
-      <div id="election-map" style="height: 300px;"></div>
+      {% if state %}
+      <div id="election-map" aria-hidden="true" style="height: 300px;"></div>
       {% endif %}
     </div>
   </header>
@@ -59,6 +59,7 @@ var context = {
     cycle: {{ cycle }},
     office: '{{ office }}',
     state: '{{ state or '' }}',
+    stateFull: '{{ state_full or '' }}',
     district: '{{ district or '' }}'
   }
 };

--- a/templates/elections.html
+++ b/templates/elections.html
@@ -22,6 +22,9 @@
           {% endif %}
         {% endif %}
       </div>
+      {% if district %}
+      <div id="election-map" style="height: 300px;"></div>
+      {% endif %}
     </div>
   </header>
 


### PR DESCRIPTION
This adds a really basic district or state map to the election page. This will need styling to match @jenniferthibault's design. We should also be able to reuse most of this code for the election lookup page. Thanks @shawnbot for advice on implementation!

House races:
<img width="1004" alt="screen shot 2015-08-27 at 3 52 07 pm" src="https://cloud.githubusercontent.com/assets/1633460/9531825/f53492d0-4cd5-11e5-9568-cb8f5c4a6986.png">

Senate races:
<img width="988" alt="screen shot 2015-08-27 at 3 51 45 pm" src="https://cloud.githubusercontent.com/assets/1633460/9531828/fa2b8ad2-4cd5-11e5-9403-7ffd545bb88d.png">