### PR TITLE
Feature/loading-state & table improvements

### DIFF
--- a/static/js/modules/filters.js
+++ b/static/js/modules/filters.js
@@ -44,6 +44,15 @@ $('#filter-toggle').click(function(){
   }
 });
 
+// Adjust height on table draw
+$(document.body).on('draw.dt', function() {
+  var tableHeight = $('.datatable__container').height(),
+      filterHeight = $('.filters').height();
+  if ( tableHeight > filterHeight && $(document).width() > 980  ) {
+    $('.filters').height(tableHeight);
+  }
+})
+
 var prepareValue = function($elm, value) {
   if ($elm.attr('type') === 'checkbox') {
     return $.isArray(value) ? value : [value];

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -309,7 +309,7 @@ var defaultCallbacks = {
 
 function initTable($table, $form, baseUrl, baseQuery, columns, callbacks, opts) {
   var draw;
-  var $processing = $('<div class="processing">Loading...</div>');
+  var $processing = $('<div class="overlay is-loading"></div>');
   var $hideNullWidget = $(
     '<input id="null-checkbox" type="checkbox" name="sort_hide_null" checked>' +
     '<label for="null-checkbox" class="results-info__null">' +

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -231,45 +231,52 @@ function modalAfterRender(template, api, data, response) {
       if ($(ev.target).is('a')) {
         return true;
       }
-      var $row = $(ev.target).closest('tr');
-      var index = api.row($row).index();
-      $modal.find('.js-panel-content').html(template(response.results[index]));
-      $modal.attr('aria-hidden', 'false');
-      $row.siblings().toggleClass('row-active', false);
-      $row.toggleClass('row-active', true);
-      $('body').toggleClass('panel-active', true);
-      var hideColumns = api.columns('.hide-panel');
-      hideColumns.visible(false);
-      // Populate the pdf button if there is one
-      if ( response.results[index].pdf_url ) {
-        $modal.find('.js-pdf_url').attr('href', response.results[index].pdf_url);
-      } else {
-        $modal.find('.js-pdf_url').remove();
-      }
+      if ( !$(ev.target).closest('td').hasClass('dataTables_empty') ) { 
+        var $row = $(ev.target).closest('tr');
+        var index = api.row($row).index();
+        $modal.find('.js-panel-content').html(template(response.results[index]));
+        $modal.attr('aria-hidden', 'false');
+        $row.siblings().toggleClass('row-active', false);
+        $row.toggleClass('row-active', true);
+        $('body').toggleClass('panel-active', true);
+        var hideColumns = api.columns('.hide-panel');
+        hideColumns.visible(false);
+        // Populate the pdf button if there is one
+        if ( response.results[index].pdf_url ) {
+          $modal.find('.js-pdf_url').attr('href', response.results[index].pdf_url);
+        } else {
+          $modal.find('.js-pdf_url').remove();
+        }
 
-      // Set focus on the close button
-      $('.js-hide').focus();
+        // Set focus on the close button
+        $('.js-hide').focus();
 
-      // When under $large-screen
-      // TODO figure way to share these values with CSS.
-      if ($(document).width() < 980) {
-        api.columns('.hide-panel-tablet').visible(false);
+        // When under $large-screen
+        // TODO figure way to share these values with CSS.
+        if ($(document).width() < 980) {
+          api.columns('.hide-panel-tablet').visible(false);
+        }
       }
     }
   });
 
   $modal.on('click', '.js-panel-close', function(ev) {
     ev.preventDefault();
+    hidePanel(api, $modal);
+  });
+}
+
+function hidePanel(api, $modal) {
     $('.row-active').focus();
     $('.js-panel-toggle tr').toggleClass('row-active', false);
     $('body').toggleClass('panel-active', false);
-    var hideColumns = api.columns('.hide-panel');
-    hideColumns.visible(true);
-    // When under $large-screen
-    if ($(document).width() < 980) {
-      api.columns('.hide-panel-tablet').visible(true);
+    $modal.attr('aria-hidden', 'true');
+    api.columns('.hide-panel-tablet').visible(true);
+
+    if ($(document).width() > 980) {
+      api.columns('.hide-panel').visible(true);
     }
-  });
+
 }
 
 function barsAfterRender(template, api, data, response) {
@@ -295,9 +302,10 @@ var defaultCallbacks = {
   preprocess: mapResponse
 };
 
-function submitOnChange($form, api) {
+function updateOnChange($form, api) {
   function onChange(e) {
     e.preventDefault();
+    hidePanel(api, $('#datatable-modal'));
     api.ajax.reload();
   }
   $form.on('change', 'input,select', _.debounce(onChange, 250));
@@ -391,7 +399,7 @@ function initTable($table, $form, baseUrl, baseQuery, columns, callbacks, opts) 
   $table.css('width', '100%');
   $table.find('tbody').addClass('js-panel-toggle');
   if ($form) {
-    submitOnChange($form, api);
+    updateOnChange($form, api);
   }
 }
 

--- a/static/js/pages/candidates.js
+++ b/static/js/pages/candidates.js
@@ -12,7 +12,7 @@ var columns = [
   {
     data: 'name',
     className: 'all',
-    width: '300px',
+    width: '280px',
     render: function(data, type, row, meta) {
       return tables.buildEntityLink(data, '/candidate/' + row.candidate_id + tables.buildCycle(row), 'candidate');
     }

--- a/static/js/pages/committees.js
+++ b/static/js/pages/committees.js
@@ -12,7 +12,7 @@ var columns = [
   {
     data: 'name',
     className: 'all',
-    width: '300px',
+    width: '280px',
     render: function(data, type, row, meta) {
       return tables.buildEntityLink(data, '/committee/' + row.committee_id + tables.buildCycle(row), 'committee');
     }

--- a/static/js/pages/disbursements.js
+++ b/static/js/pages/disbursements.js
@@ -13,7 +13,7 @@ var columns = [
     data: 'recipient_name',
     orderable: false,
     className: 'all',
-    width: '300px',
+    width: '280px',
     render: function(data, type, row, meta) {
       var committee = row.recipient_committee;
       if (committee) {
@@ -24,8 +24,8 @@ var columns = [
     }
   },
   {data: 'recipient_state', orderable: false, className: 'min-desktop hide-panel'},
-  tables.currencyColumn({data: 'disbursement_amount', className: 'min-tablet'}),
-  tables.dateColumn({data: 'disbursement_date', className: 'min-tablet'}),
+  tables.currencyColumn({data: 'disbursement_amount', className: 'min-tablet hide-panel-tablet'}),
+  tables.dateColumn({data: 'disbursement_date', className: 'min-tablet hide-panel-tablet'}),
   {data: 'disbursement_description', className: 'min-desktop hide-panel', orderable: false},
   {
     data: 'committee',

--- a/static/js/pages/receipts.js
+++ b/static/js/pages/receipts.js
@@ -13,7 +13,7 @@ var columns = [
     data: 'contributor',
     orderable: false,
     className: 'all',
-    width: '300px',
+    width: '280px',
     render: function(data, type, row, meta) {
       if (data) {
         return tables.buildEntityLink(data.name, '/committee/' + data.committee_id, 'committee');
@@ -30,7 +30,7 @@ var columns = [
   {
     data: 'committee',
     orderable: false,
-    className: 'all hide-panel',
+    className: 'min-desktop hide-panel',
     width: '30%',
     render: function(data, type, row, meta) {
       if (data) {


### PR DESCRIPTION
Companion PR to https://github.com/18F/fec-style/pull/46

This:
- Adjusts the height of the filter bar to the height of the table by listening to the `draw.dt` event
- If the panel is open and you change the filters, the panel now closes (so I moved the code to hide the panel to a separate function)
- Adds the markup for the loading animation
- Minor column sizing styles

No reason to hold this up, but just noting that the tables still need some work on small screens. 