### PR TITLE
Creates a separate class to control styles

### DIFF
--- a/static/js/modules/filings.js
+++ b/static/js/modules/filings.js
@@ -39,7 +39,7 @@ var renderModal = tables.modalRenderFactory(
 
 function renderRow(row, data, index) {
   if (data.form_type && data.form_type.match(/^F3[XP]?$/)) {
-    row.classList.add(tables.MODAL_TRIGGER_CLASS);
+    row.classList.add(tables.MODAL_TRIGGER_CLASS, 'row--has-panel');
   }
 }
 

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -238,7 +238,7 @@ var MODAL_TRIGGER_CLASS = 'js-panel-trigger';
 var MODAL_TRIGGER_HTML = '<i class="icon arrow--right"></li>';
 
 function modalRenderRow(row, data, index) {
-  row.classList.add(MODAL_TRIGGER_CLASS);
+  row.classList.add(MODAL_TRIGGER_CLASS, 'row--has-panel');
 }
 
 function modalRenderFactory(template, fetch) {


### PR DESCRIPTION
This patch separates the presentation from the js functionality by creating a new class for rows with panels. (Goes with https://github.com/18F/fec-style/pull/60)