### PR TITLE
Removing padding on arrow cells

### DIFF
--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -37,7 +37,7 @@ var filings = {
   total_disbursements: tables.currencyColumn({data: 'total_disbursements', className: 'min-tablet hide-panel'}),
   total_independent_expenditures: tables.currencyColumn({data: 'total_independent_expenditures', className: 'min-tablet hide-panel'}),
   modal_trigger: {
-    className: 'all',
+    className: 'all u-no-padding',
     width: '20px',
     orderable: false,
     render: function(data, type, row, meta) {

--- a/static/js/pages/candidates.js
+++ b/static/js/pages/candidates.js
@@ -1,4 +1,4 @@
-'use strict';
+https://github.com/18F/openFEC-web-app/pull/581#issuecomment-137597693'use strict';
 
 /* global require, document */
 
@@ -29,7 +29,7 @@ var columns = [
   {data: 'state', className: 'min-desktop hide-panel'},
   {data: 'district', className: 'min-desktop hide-panel'},
   {
-    className: 'all',
+    className: 'all u-no-padding',
     width: '20px',
     orderable: false,
     render: function(data, type, row, meta) {

--- a/static/js/pages/committees.js
+++ b/static/js/pages/committees.js
@@ -25,7 +25,7 @@ var columns = [
   {data: 'designation_full', className: 'min-tablet hide-panel'},
   {data: 'organization_type_full', className: 'min-desktop hide-panel'},
   {
-    className: 'all',
+    className: 'all u-no-padding',
     width: '20px',
     orderable: false,
     render: function(data, type, row, meta) {

--- a/static/js/pages/disbursements.js
+++ b/static/js/pages/disbursements.js
@@ -41,7 +41,7 @@ var columns = [
     }
   },
   {
-    className: 'all',
+    className: 'all u-no-padding',
     width: '20px',
     orderable: false,
     render: function(data, type, row, meta) {

--- a/static/js/pages/receipts.js
+++ b/static/js/pages/receipts.js
@@ -41,7 +41,7 @@ var columns = [
     }
   },
   {
-    className: 'min-tablet',
+    className: 'all u-no-padding',
     width: '20px',
     orderable: false,
     render: function(data, type, row, meta) {


### PR DESCRIPTION
Small patch: when I added padding to cells to prevent bars from running into each other, it made the cells that have the arrows for the details panel hide the arrow icons. This removes that padding from those cells so you can see the arrows.