### PR TITLE
Adding / fixing filters for committee names

### DIFF
--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -171,7 +171,7 @@ var disbursementRecipientIDColumns = [
     className: 'all',
     orderable: false,
     render: tables.buildTotalLink('/disbursements', function(row) {
-      return {recipient_id: row.recipient_id};
+      return {recipient_committee_id: row.recipient_id};
     })
   }
 ];

--- a/templates/partials/disbursements-filter.html
+++ b/templates/partials/disbursements-filter.html
@@ -12,7 +12,8 @@ Filter Disbursements
 {{ typeahead.field('committee_id', 'Committee') }}
 
 <h4 class="filters__subheader">Recipient Information</h4>
-{{ text.field('recipient_name', 'Recipient Name') }}
+{{ typeahead.field('recipient_committee_id', 'Recipient (Committee)') }}
+{{ text.field('recipient_name', 'Recipient (Non-Committee)') }}
 {{ text.field('recipient_city', 'City') }}
 {{ states.field('recipient_state')}}
 <h4 class="filters__subheader">Transaction Information</h4>

--- a/templates/partials/disbursements-filter.html
+++ b/templates/partials/disbursements-filter.html
@@ -12,8 +12,8 @@ Filter Disbursements
 {{ typeahead.field('committee_id', 'Committee') }}
 
 <h4 class="filters__subheader">Recipient Information</h4>
-{{ typeahead.field('recipient_committee_id', 'Recipient (Committee)') }}
-{{ text.field('recipient_name', 'Recipient (Non-Committee)') }}
+{{ typeahead.field('recipient_committee_id', 'Recipient (committee)') }}
+{{ text.field('recipient_name', 'Recipient (non-committee)') }}
 {{ text.field('recipient_city', 'City') }}
 {{ states.field('recipient_state')}}
 <h4 class="filters__subheader">Transaction Information</h4>

--- a/templates/partials/receipts-filter.html
+++ b/templates/partials/receipts-filter.html
@@ -26,6 +26,8 @@ Filter Receipts
 {{ typeahead.field('committee_id', 'Committee') }}
 
 <h3 class="filters__subheader">Contributor Information</h3>
+{{ typeahead.field('contributor_id', 'Contributor Name (committee)') }}
+{{ text.field('contributor_name', 'Contributor Name (non-committee)') }}
 {{ text.field('contributor_city', 'City') }}
 {{ states.field('contributor_state') }}
 {{ text.field('contributor_employer', 'Employer') }}


### PR DESCRIPTION
A few fixes to make filters more consistent coming from the aggregate tables on committee pages:

**/receipts**
- Adds a filter for Contributor Name
- Adds a separate typeahead filter for Committee Name

**/disbursements**
- Adds a typeahead filter for Recipient Committee
- Fixes js to pass the correct variable (`recipient_committe_id`)

[resolves #511]
