### PR TITLE
Restore candidate dropdown.

### DIFF
--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -120,15 +120,10 @@ function refreshTables() {
 }
 
 function drawComparison(results) {
-  _.each(_.first(results, 10), function(result) {
-    result._checked = true;
-  });
   var $comparison = $('#comparison');
-  $comparison.prepend(comparisonTemplate(results));
-  var comparisonDropdown = new dropdown.Dropdown($('#comparison .js-dropdown'));
-  $('#comparison input:checked').each(function(){
-    comparisonDropdown.selectItem($(this));
-  });
+  var context = {selected: results.slice(0, 10), options: results.slice(10)};
+  $comparison.prepend(comparisonTemplate(context));
+ new dropdown.Dropdown($comparison.find('.js-dropdown'));
   $comparison.on('change', 'input[type="checkbox"]', refreshTables);
   refreshTables();
 }

--- a/static/templates/comparison.hbs
+++ b/static/templates/comparison.hbs
@@ -1,16 +1,23 @@
 <div class="row">
   <fieldset class="js-dropdown">
   <legend class="label" for="candidate-list">Candidates to compare:</legend>
-    <ul class="dropdown__selected list--flat"></ul>
+    <ul class="dropdown__selected list--flat">
+      {{#each this.selected}}
+      <li class="dropdown__item">
+        <input id="checkbox-{{ this.candidate_id }}" name="candidate-list" type="checkbox" data-id="{{this.candidate_id}}" data-name="{{this.candidate_name}}" checked>
+        <label class="dropdown__value" for="checkbox-{{ this.candidate_id }}">{{this.candidate_name}}</label>
+      </li>
+      {{/each}}
+    </ul>
     <div class="dropdown">
       <button class="dropdown__button button--neutral">More</button>
       <div class="dropdown__panel" aria-hidden="true">
         <ul class="dropdown__list">
-          {{#each this}}
-              <li class="dropdown__item">
-                <input id="checkbox-{{ this.candidate_id }}" name="candidate-list" type="checkbox" data-id="{{this.candidate_id}}" data-name="{{this.candidate_name}}" {{#if this._checked}}checked{{/if}}>
-                <label class="dropdown__value" for="checkbox-{{ this.candidate_id }}">{{this.candidate_name}}</label>
-              </li>
+          {{#each this.options}}
+          <li class="dropdown__item">
+            <input id="checkbox-{{ this.candidate_id }}" name="candidate-list" type="checkbox" data-id="{{this.candidate_id}}" data-name="{{this.candidate_name}}">
+            <label class="dropdown__value" for="checkbox-{{ this.candidate_id }}">{{this.candidate_name}}</label>
+          </li>
           {{/each}}
         </ul>
       </div>

--- a/templates/partials/elections/candidate-comparison-tab.html
+++ b/templates/partials/elections/candidate-comparison-tab.html
@@ -43,8 +43,8 @@
                 <input id="toggle-contributor-type" type="radio" class="panel-toggle-control" name="election-aggregate" value="by-contributor-type">
                 <span class="button--neutral">Contributor Type</span>
               </label>
-            </fieldset>       
-          </div>        
+            </fieldset>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
A recent patch hid the candidate checkbox dropdown on the election
summary page. This patch restores the dropdown and cleans up the
associated code.

Current behavior on develop:
<img width="988" alt="screen shot 2015-09-03 at 9 15 46 pm" src="https://cloud.githubusercontent.com/assets/1633460/9674640/2536f6b6-5281-11e5-8a14-afc890dbf704.png">
