### PR TITLE
Limiting filings on filings tab to the current cycle

### DIFF
--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -276,13 +276,15 @@ $(document).ready(function() {
         break;
       case 'filing':
         var $form = $('#category-filters');
-        tables.initTableDeferred($table, $form, 'committee/' + committeeId + '/filings', {}, filingsColumns,
+        path = ['committee', committeeId, 'filings'].join('/');
+        query = {cycle: parseInt(cycle)};
+        tables.initTableDeferred($table, $form, path, query, filingsColumns,
           _.extend({}, tables.offsetCallbacks, {
             afterRender: filings.renderModal
           }),
           {
             rowCallback: filings.renderRow,
-            dom: '<"panel__main"t><"results-info results-info--bottom meta-box"lfrip>',
+            dom: '<"panel__main"t><"results-info results-info--bottom"frip>',
             // Order by receipt date descending
             order: [[2, 'desc']],
             useFilters: true

--- a/templates/partials/datatable-modal.html
+++ b/templates/partials/datatable-modal.html
@@ -1,7 +1,7 @@
 <div id="datatable-modal" class="panel__overlay" aria-hidden="true">
   <div class="panel">
     <div class="panel__row panel__navigation">
-      <a class="panel__link button--small button--primary js-pdf_url">
+      <a class="panel__link button--small button--neutral js-pdf_url">
         View original image
       </a>
       <button class="js-hide js-panel-close panel__close button--small button"

--- a/templates/partials/filings-tab-committee.html
+++ b/templates/partials/filings-tab-committee.html
@@ -17,7 +17,7 @@
           {% include 'partials/filters/report-type.html' %}
         </form>
       </div>
-      <table class="data-table" data-type="filing" data-committee="{{ committee_id }}" width="100%" class="responsive">
+      <table class="data-table" data-type="filing" data-cycle="{{ cycle }}" data-committee="{{ committee_id }}" width="100%" class="responsive">
         <thead>
           <tr>
           <th scope="col">Document</th>


### PR DESCRIPTION
Limits the filings that show up in the table on the committee page filings tab to those in the current cycle. 

We can discuss if we still need the filters with the shorter list. They might still be useful if you're looking at an older period that has the full range of filings.

[Resolves #424]