### PR TITLE
Fix data table bars with missing data.

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -122,7 +122,7 @@ function barColumn(formatter) {
       render: function(data, type, row, meta) {
         var span = document.createElement('div');
         span.textContent = formatter(_.max([data, 0]));
-        span.setAttribute('data-value', data);
+        span.setAttribute('data-value', data || 0);
         span.setAttribute('data-row', meta.row);
         return span.outerHTML;
       }
@@ -319,10 +319,9 @@ function barsAfterRender(template, api, data, response) {
   $cols.after(function() {
     var value = $(this).attr('data-value');
     var width = 100 * parseFloat(value) / max;
-    var bar = '<div class="bar-container">' +
-                '<div class="value-bar" style="width: ' + width + '%">' +
-                '</div></div>';
-    return bar;
+    return '<div class="bar-container">' +
+      '<div class="value-bar" style="width: ' + width + '%"></div>' +
+    '</div>';
   });
 }
 


### PR DESCRIPTION
Currently, some data table bars with missing values are rendered as
full-width instead of empty. This patch fixes the bug and cleans up the
bar render function.

Current behavior on dev:
<img width="966" alt="screen shot 2015-09-04 at 12 45 11 pm" src="https://cloud.githubusercontent.com/assets/1633460/9689297/2098c13e-5303-11e5-8740-4d7c334897f8.png">
