### PR TITLE
Consolidate URL generation logic.

### DIFF
--- a/static/js/modules/election-lookup.js
+++ b/static/js/modules/election-lookup.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global require, module, document, context, API_LOCATION, API_VERSION, API_KEY */
+/* global require, module, document, context */
 
 var $ = require('jquery');
 var URI = require('URIjs');
@@ -138,10 +138,7 @@ ElectionLookup.prototype.handleSelectMap = function(state, district) {
 };
 
 ElectionLookup.prototype.getUrl = function(query) {
-  return URI(API_LOCATION)
-    .path([API_VERSION, 'elections', 'search'].join('/'))
-    .query(query)
-    .toString();
+  return helpers.buildUrl(['elections', 'search'], query);
 };
 
 ElectionLookup.prototype.serialize = function() {

--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -45,7 +45,7 @@ function filterNull(params) {
 
 function buildUrl(path, query) {
   return URI(API_LOCATION)
-    .path([API_VERSION].concat(path).join('/'))
+    .path(Array.prototype.concat(API_VERSION, path, '').join('/'))
     .addQuery({api_key: API_KEY})
     .addQuery(query)
     .toString();

--- a/static/js/modules/maps.js
+++ b/static/js/modules/maps.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global require, module, window, document, API_LOCATION, API_VERSION, API_KEY */
+/* global require, module, window, document */
 
 var d3 = require('d3');
 var $ = require('jquery');

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global require, module, window, document, API_LOCATION, API_VERSION, API_KEY */
+/* global require, module, window, document */
 
 var $ = require('jquery');
 var URI = require('URIjs');
@@ -359,7 +359,7 @@ var defaultCallbacks = {
   preprocess: mapResponse
 };
 
-function initTable($table, $form, baseUrl, baseQuery, columns, callbacks, opts) {
+function initTable($table, $form, path, baseQuery, columns, callbacks, opts) {
   var draw;
   var $processing = $('<div class="overlay is-loading"></div>');
   var $hideNullWidget = $(
@@ -404,11 +404,7 @@ function initTable($table, $form, baseUrl, baseQuery, columns, callbacks, opts) 
       query.sort = mapSort(data.order, columns);
       $processing.show();
       $.getJSON(
-        URI(API_LOCATION)
-        .path([API_VERSION, baseUrl].join('/'))
-        .addQuery(baseQuery || {})
-        .addQuery(query)
-        .toString()
+        helpers.buildUrl(path, _.extend({}, query, baseQuery || {}))
       ).done(function(response) {
         callbacks.handleResponse(api, data, response);
         callback(callbacks.preprocess(response));

--- a/static/js/pages/candidate-single.js
+++ b/static/js/pages/candidate-single.js
@@ -23,7 +23,7 @@ $(document).ready(function() {
   var $table = $('table[data-type="filing"]');
   var $form = $('#category-filters');
   var candidateId = $table.attr('data-candidate');
-  var path = ['candidate', candidateId, 'filings'].join('/');
+  var path = ['candidate', candidateId, 'filings'];
   tables.initTableDeferred($table, $form, path, {}, columns, tables.offsetCallbacks, {
     // Order by receipt date descending
     order: [[2, 'desc']],

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global require, module, document, API_LOCATION, API_VERSION, API_KEY */
+/* global require, module, document */
 
 var $ = require('jquery');
 var URI = require('URIjs');
@@ -11,6 +11,7 @@ var events = require('fec-style/js/events');
 var maps = require('../modules/maps');
 var tables = require('../modules/tables');
 var filings = require('../modules/filings');
+var helpers = require('../modules/helpers');
 var columns = require('../modules/columns');
 
 var tableOpts = {
@@ -177,20 +178,10 @@ var disbursementRecipientIDColumns = [
 ];
 
 function buildStateUrl($elm) {
-  return URI(API_LOCATION)
-    .path([
-      API_VERSION,
-      'committee',
-      $elm.data('committee-id'),
-      'schedules',
-      'schedule_a',
-      'by_state'
-    ].join('/'))
-    .query({
-      cycle: $elm.data('cycle'),
-      per_page: 99
-    })
-    .toString();
+  return helpers.buildUrl(
+    ['committee', $elm.data('committee-id'), 'schedules', 'schedule_a', 'by_state'],
+    {cycle: $elm.data('cycle'), per_page: 99}
+  );
 }
 
 var aggregateCallbacks = _.extend(
@@ -208,7 +199,7 @@ $(document).ready(function() {
     var path;
     switch ($table.attr('data-type')) {
       case 'committee-contributor':
-        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_contributor'].join('/');
+        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_contributor'];
         tables.initTableDeferred($table, null, path, query, committeeColumns, aggregateCallbacks, {
           dom: tables.simpleDOM,
           order: [[1, 'desc']],
@@ -219,7 +210,7 @@ $(document).ready(function() {
         });
         break;
       case 'contribution-size':
-        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_size'].join('/');
+        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_size'];
         tables.initTableDeferred($table, null, path, query, sizeColumns, aggregateCallbacks, {
           dom: 't',
           order: [[1, 'desc']],
@@ -230,7 +221,7 @@ $(document).ready(function() {
         });
         break;
       case 'receipts-by-state':
-        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_state'].join('/');
+        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_state'];
         query = _.extend(query, {per_page: 99, hide_null: true});
         tables.initTableDeferred($table, null, path, query, stateColumns, aggregateCallbacks,
           _.extend(
@@ -259,20 +250,20 @@ $(document).ready(function() {
         });
         break;
       case 'receipts-by-employer':
-        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_employer'].join('/');
+        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_employer'];
         tables.initTableDeferred($table, null, path, query, employerColumns, aggregateCallbacks, _.extend({}, tableOpts, {
           order: [[1, 'desc']],
         }));
         break;
       case 'receipts-by-occupation':
-        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_occupation'].join('/');
+        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_occupation'];
         tables.initTableDeferred($table, null, path, query, occupationColumns, aggregateCallbacks, _.extend({}, tableOpts, {
           order: [[1, 'desc']],
         }));
         break;
       case 'filing':
         var $form = $('#category-filters');
-        path = ['committee', committeeId, 'filings'].join('/');
+        path = ['committee', committeeId, 'filings'];
         tables.initTableDeferred($table, $form, path, query, filingsColumns,
           _.extend({}, tables.offsetCallbacks, {
             afterRender: filings.renderModal
@@ -287,19 +278,19 @@ $(document).ready(function() {
         );
         break;
       case 'disbursements-by-purpose':
-        path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_purpose'].join('/');
+        path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_purpose'];
         tables.initTableDeferred($table, null, path, query, disbursementPurposeColumns, aggregateCallbacks, _.extend({}, tableOpts, {
           order: [[1, 'desc']],
         }));
         break;
       case 'disbursements-by-recipient':
-        path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_recipient'].join('/');
+        path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_recipient'];
         tables.initTableDeferred($table, null, path, query, disbursementRecipientColumns, aggregateCallbacks, _.extend({}, tableOpts, {
           order: [[1, 'desc']],
         }));
         break;
       case 'disbursements-by-recipient-id':
-        path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_recipient_id'].join('/');
+        path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_recipient_id'];
         tables.initTableDeferred($table, null, path, query, disbursementRecipientIDColumns, aggregateCallbacks, _.extend({}, tableOpts, {
           order: [[1, 'desc']],
         }));

--- a/static/js/pages/election-lookup.js
+++ b/static/js/pages/election-lookup.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global require, module, document, context, API_LOCATION, API_VERSION, API_KEY */
+/* global require, document */
 
 var $ = require('jquery');
 var lookup = require('../modules/election-lookup');

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global require, module, window, document, context, API_LOCATION, API_VERSION, API_KEY */
+/* global require, module, window, document, context */
 
 var d3 = require('d3');
 var $ = require('jquery');
@@ -194,13 +194,10 @@ function destroyTable($table) {
 function buildUrl(selected, path) {
   var query = {
     cycle: context.election.cycle,
-    candidate_id: _.pluck(selected, 'candidate_id')
+    candidate_id: _.pluck(selected, 'candidate_id'),
+    per_page: 0
   };
-  return URI(API_LOCATION)
-    .path([API_VERSION, path].join('/'))
-    .addQuery(query)
-    .addQuery({per_page: 0})
-    .toString();
+  return helpers.buildUrl(path, query);
 }
 
 function drawSizeTable(selected) {
@@ -209,7 +206,7 @@ function drawSizeTable(selected) {
     return [result.candidate_id, result];
   }));
   $.getJSON(
-    buildUrl(selected, 'schedules/schedule_a/by_size/by_candidate')
+    buildUrl(selected, ['schedules', 'schedule_a', 'by_size', 'by_candidate'])
   ).done(function(response) {
     var data = mapSize(response, primary);
     $table.dataTable(_.extend({
@@ -227,7 +224,7 @@ function drawStateTable(selected) {
     return [result.candidate_id, result];
   }));
   $.getJSON(
-    buildUrl(selected, 'schedules/schedule_a/by_state/by_candidate')
+    buildUrl(selected, ['schedules', 'schedule_a', 'by_state', 'by_candidate'])
   ).done(function(response) {
     destroyTable($table);
     // Clear headers
@@ -253,7 +250,7 @@ function drawTypeTable(selected) {
     return [result.candidate_id, result];
   }));
   $.getJSON(
-    buildUrl(selected, 'schedules/schedule_a/by_contributor_type/by_candidate')
+    buildUrl(selected, ['schedules', 'schedule_a', 'by_contributor_type', 'by_candidate'])
   ).done(function(response) {
     var data = mapType(response, primary);
     $table.dataTable(_.extend({
@@ -266,20 +263,10 @@ function drawTypeTable(selected) {
 }
 
 function drawStateMap($container, candidateId, cached) {
-  var url = URI(API_LOCATION)
-    .path([
-      API_VERSION,
-      'schedules',
-      'schedule_a',
-      'by_state',
-      'by_candidate'
-    ].join('/'))
-    .query({
-      cycle: context.election.cycle,
-      candidate_id: candidateId,
-      per_page: 99
-    })
-    .toString();
+  var url = helpers.buildUrl(
+    ['schedules', 'schedule_a', 'by_state', 'by_candidate'],
+    {cycle: context.election.cycle, candidate_id: candidateId, per_page: 99}
+  );
   var $map = $container.find('.state-map-choropleth');
   $map.html('');
   $.getJSON(url).done(function(data) {
@@ -387,15 +374,15 @@ function initStateMaps(results) {
 
 var tableOpts = {
   'independent-expenditures': {
-    path: ['schedules', 'schedule_e', 'by_candidate'].join('/'),
+    path: ['schedules', 'schedule_e', 'by_candidate'],
     columns: independentExpenditureColumns
   },
   'communication-costs': {
-    path: ['communication_costs', 'by_candidate'].join('/'),
+    path: ['communication_costs', 'by_candidate'],
     columns: communicationCostColumns
   },
   'electioneering': {
-    path: ['electioneering_costs', 'by_candidate'].join('/'),
+    path: ['electioneering_costs', 'by_candidate'],
     columns: electioneeringColumns
   },
 };
@@ -427,11 +414,10 @@ $(document).ready(function() {
     })
     .object()
     .value();
-  var url = URI(API_LOCATION)
-    .path([API_VERSION, 'elections'].join('/'))
-    .addQuery(query)
-    .addQuery({per_page: 0})
-    .toString();
+  var url = helpers.buildUrl(
+    ['elections'],
+    _.extend(query, {per_page: 0})
+  );
   $.getJSON(url).done(function(response) {
     $table.dataTable(_.extend({}, defaultOpts, {
       columns: columns,

--- a/tests/unit/modules/election-lookup.js
+++ b/tests/unit/modules/election-lookup.js
@@ -16,6 +16,7 @@ var lookup = require('../../../static/js/modules/election-lookup');
 _.extend(window, {
   API_LOCATION: '',
   API_VERSION: '/v1',
+  API_KEY: '12345'
 });
 
 _.extend(window, {
@@ -131,7 +132,7 @@ describe('election lookup', function() {
       this.el.search();
       expect($.ajax).to.have.been.called;
       var call = $.ajax.getCall(0);
-      expect(call.args[0].url).to.equal('/v1/elections/search?cycle=2016&zip=19041');
+      expect(call.args[0].url).to.equal('/v1/elections/search/?api_key=12345&cycle=2016&zip=19041');
       expect(this.el.draw).to.have.been.calledWith(this.response.results);
     });
 


### PR DESCRIPTION
* Use `helpers.buildUrl` instead of miscellaneous URL builders
* Add trailing slashes to avoid API redirects

We currently a bunch of repeated logic across functions that build URLs. This patch moves most URL building to `helpers.buildUrl.`