### PR TITLE
Link election aggregates to individual transactions.

### DIFF
--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -7,6 +7,14 @@ var _ = require('underscore');
 var tables = require('./tables');
 var decoders = require('./decoders');
 
+var sizeInfo = {
+  0: {limits: [0, 199.99], label: 'Under $200'},
+  200: {limits: [200, 499.99], label: '$200 - $499'},
+  500: {limits: [500, 999.99], label: '$500 - $999'},
+  1000: {limits: [1000, 1999.99], label: '$1000 - $1999'},
+  2000: {limits: [2000, null], label: 'Over $2000'},
+};
+
 var filings = {
   pdf_url: tables.urlColumn('pdf_url', {data: 'document_description', className: 'all', orderable: false}),
   filer_name: {
@@ -56,5 +64,6 @@ function getColumns (columns, keys) {
 
 module.exports = {
   filings: filings,
+  sizeInfo: sizeInfo,
   getColumns: getColumns
 };

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -96,10 +96,11 @@ function buildTotalLink(path, getParams) {
     var link = document.createElement('a');
     link.textContent = helpers.currency(data);
     link.setAttribute('title', 'View individual transactions');
+    var params = getParams(data, type, row, meta);
     var uri = URI(path)
-      .query({committee_id: row.committee_id})
-      .addQuery(getParams(row));
-    link.setAttribute('href', buildAggregateUrl(uri, row.cycle));
+      .addQuery({committee_id: row.committee_id})
+      .addQuery(params);
+    link.setAttribute('href', buildAggregateUrl(uri, _.extend({}, row, params).cycle));
     span.appendChild(link);
     return span.outerHTML;
   };

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -22,29 +22,21 @@ var tableOpts = {
   useHideNull: false
 };
 
-var sizeInfo = {
-  0: {limits: [0, 199.99], label: 'Under $200'},
-  200: {limits: [200, 499.99], label: '$200 - $499'},
-  500: {limits: [500, 999.99], label: '$500 - $999'},
-  1000: {limits: [1000, 1999.99], label: '$1000 - $1999'},
-  2000: {limits: [2000, null], label: 'Over $2000'},
-};
-
 var sizeColumns = [
   {
     data: 'size',
     width: '50%',
     className: 'all',
     render: function(data, type, row, meta) {
-      return sizeInfo[data].label;
+      return columns.sizeInfo[data].label;
     }
   },
   {
     data: 'total',
     width: '50%',
     className: 'all',
-    render: tables.buildTotalLink('/receipts', function(row) {
-      var info = sizeInfo[row.size];
+    render: tables.buildTotalLink('/receipts', function(data, type, row, meta) {
+      var info = columns.sizeInfo[row.size];
       return {
         min_amount: info.limits[0],
         max_amount: info.limits[1],
@@ -67,7 +59,7 @@ var committeeColumns = [
     data: 'total',
     className: 'all',
     orderable: false,
-    render: tables.buildTotalLink('/receipts', function(row) {
+    render: tables.buildTotalLink('/receipts', function(data, type, row, meta) {
       return {
         contributor_id: row.contributor_id,
         is_individual: 'true'
@@ -93,7 +85,7 @@ var stateColumns = [
     data: 'total',
     width: '50%',
     className: 'all',
-    render: tables.buildTotalLink('/receipts', function(row) {
+    render: tables.buildTotalLink('/receipts', function(data, type, row, meta) {
       return {
         contributor_state: row.state,
         is_individual: 'true'
@@ -108,7 +100,7 @@ var employerColumns = [
     data: 'total',
     className: 'all',
     orderable: false,
-    render: tables.buildTotalLink('/receipts', function(row) {
+    render: tables.buildTotalLink('/receipts', function(data, type, row, meta) {
       return {
         contributor_employer: row.employer,
         is_individual: 'true'
@@ -123,7 +115,7 @@ var occupationColumns = [
     data: 'total',
     className: 'all',
     orderable: false,
-    render: tables.buildTotalLink('/receipts', function(row) {
+    render: tables.buildTotalLink('/receipts', function(data, type, row, meta) {
       return {
         contributor_occupation: row.occupation,
         is_individual: 'true'
@@ -152,7 +144,7 @@ var disbursementRecipientColumns = [
     data: 'total',
     className: 'all',
     orderable: false,
-    render: tables.buildTotalLink('/disbursements', function(row) {
+    render: tables.buildTotalLink('/disbursements', function(data, type, row, meta) {
       return {recipient_name: row.recipient_name};
     })
   }
@@ -171,7 +163,7 @@ var disbursementRecipientIDColumns = [
     data: 'total',
     className: 'all',
     orderable: false,
-    render: tables.buildTotalLink('/disbursements', function(row) {
+    render: tables.buildTotalLink('/disbursements', function(data, type, row, meta) {
       return {recipient_committee_id: row.recipient_id};
     })
   }

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -62,8 +62,24 @@ var electionColumns = [
   },
   {data: 'incumbent_challenge_full', className: 'min-tablet'},
   {data: 'party_full', className: 'min-tablet'},
-  tables.barCurrencyColumn({data: 'total_receipts'}),
-  tables.barCurrencyColumn({data: 'total_disbursements'}),
+  {
+    data: 'total_receipts',
+    render: tables.buildTotalLink('/receipts', function(data, type, row, meta) {
+      return {
+        committee_id: row.committee_ids,
+        cycle: context.election.cycle
+      };
+    })
+  },
+  {
+    data: 'total_disbursements',
+    render: tables.buildTotalLink('/disbursements', function(data, type, row, meta) {
+      return {
+        committee_id: row.committee_ids,
+        cycle: context.election.cycle
+      };
+    })
+  },
   tables.barCurrencyColumn({data: 'cash_on_hand_end_period'}),
   tables.urlColumn('pdf_url', {data: 'document_description', className: 'all', orderable: false})
 ];

--- a/templates/elections.html
+++ b/templates/elections.html
@@ -56,7 +56,6 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/{{ assets['dist/js/pages/elections.js'] }}"></script>
 <script>
 var context = {
   election: {
@@ -68,4 +67,5 @@ var context = {
   }
 };
 </script>
+<script src="/{{ assets['dist/js/pages/elections.js'] }}"></script>
 {% endblock %}

--- a/templates/partials/receipts-filter.html
+++ b/templates/partials/receipts-filter.html
@@ -21,6 +21,19 @@ Filter Receipts
       </li>
     </ul>
   </fieldset>
+  <fieldset>
+    <legend class="label">Show contributions from</legend>
+    <ul>
+      <li>
+        <input id="contributor-type-individual" name="contributor_type" type="checkbox" value="individual">
+        <label for="contributor-type-individual">Individuals</label>
+      </li>
+      <li>
+        <input id="contributor-type-committee" name="contributor_type" type="checkbox" value="committee">
+        <label for="contributor-type-committee">Committees</label>
+      </li>
+    </ul>
+  </fieldset>
 </div>
 
 {{ typeahead.field('committee_id', 'Committee') }}


### PR DESCRIPTION
Link election aggregates by size, location, and contributor type to itemized receipts.

@noahmanger: did we want to link the totals in the top election table to itemized receipts and disbursements as well? This patch just covers our custom aggregates so far.

Part of #449.