### PR TITLE
styling the no results message

### DIFF
--- a/static/templates/electionNoResults.hbs
+++ b/static/templates/electionNoResults.hbs
@@ -1,6 +1,6 @@
-<div>
-  Can't find your zip code?
-  Let us know:
-  <a href="mailto:18F-FEC@gsa.gov">email us</a> or
+<div class="message message--alert">
+  <h2>We can't find any results for this ZIP code</h2>
+  <p>Double-check that you entered it correctly, and if it still doesn't work, let us know:</p>
+  <a href="mailto:18F-FEC@gsa.gov">Email us</a> or
   <a href="https://github.com/18f/openFEC/issues/new">open an issue in GitHub</a>.
 </div>


### PR DESCRIPTION
Styles the message that shows up if the zip code isn't found. @emileighoutlaw how doest this language work for you? Made a slight adjustment from @LindsayYoung 's original.

<img width="1029" alt="screen shot 2015-09-10 at 4 52 13 pm" src="https://cloud.githubusercontent.com/assets/1696495/9803910/ad870906-57dc-11e5-81a0-2413117244c0.png">
