### PR TITLE
Use `offsetX` to handle many candidates in election state table.

### DIFF
--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -281,21 +281,22 @@ function drawStateTable(selected) {
   $.getJSON(
     buildUrl(selected, ['schedules', 'schedule_a', 'by_state', 'by_candidate'])
   ).done(function(response) {
-    destroyTable($table);
-    // Clear headers
-    $table.find('thead').html('');
     var data = mapState(response, primary);
+    // Populate headers with correct text
+    var headerLabels = ['State'].concat(_.pluck(selected, 'candidate_name'));
+    $table.find('thead tr')
+      .empty()
+      .append(_.map(headerLabels, function(label) {
+        return $('<th>').text(label);
+      }));
+    destroyTable($table);
     $table.dataTable(_.extend({
       data: data,
       columns: stateColumns(selected),
-      order: [[1, 'desc']]
+      order: [[1, 'desc']],
+      scrollX: true
     }, defaultOpts));
     tables.barsAfterRender(null, $table.DataTable());
-    // Populate headers with correct text
-    var headerLabels = ['State'].concat(_.pluck(selected, 'candidate_name'));
-    $table.find('th').each(function(index, elm) {
-      $(elm).text(headerLabels[index]);
-    });
   });
 }
 

--- a/templates/partials/elections/candidate-comparison-tab.html
+++ b/templates/partials/elections/candidate-comparison-tab.html
@@ -89,8 +89,8 @@
             </fieldset>
           </div>
           <div id="state-table">
-            <table class="data-table panel-toggle-element" data-type="by-state" aria-hidden="false">
-              <thead></thead>
+            <table class="data-table scrollX panel-toggle-element" data-type="by-state" aria-hidden="false">
+              <thead><tr></tr></thead>
             </table>
           </div>
           <div id="state-maps" class="panel-toggle-element" aria-hidden="true'">


### PR DESCRIPTION
Part of https://github.com/18F/openFEC-web-app/issues/572. Depends on https://github.com/18F/fec-style/pull/85.

@noahmanger: this is *almost* right. There were a few styles that conflicted with `scrollX` in fec-style, which I'm now overriding for tables with the `scrollX` class. The only remaining issue I see is that the header rows don't exactly line up with the columns sometimes--I think it's related to the value bars in the table. If you have the time / interest to take a look, I'd appreciate it, else I'll pick this up again and see if I can get the last kinks worked out.