### PR TITLE
Adding apply and clear buttons to filters

### DIFF
--- a/static/js/modules/filters.js
+++ b/static/js/modules/filters.js
@@ -146,7 +146,24 @@ var activateInitialFilters = function() {
     }
 };
 
-// Clearing the selects
+var clearFilters = function() {
+  var fields = getFields();
+  _.each(fields, function(key) {
+    activateFilter({
+      name: key,
+      value: null
+    })
+  });
+};
+
+// Clearing the filters
+$('.js-clear-filters').on('click keypress', function(e){
+  if (e.which === 13 || e.type === 'click') {
+    clearFilters();
+    $(this).focus();
+  }
+})
+
 $('.button--remove').click(function(e){
     e.preventDefault();
     var removes = $(this).data('removes');

--- a/templates/partials/filters.html
+++ b/templates/partials/filters.html
@@ -5,13 +5,13 @@
   <div class="filters__hider">
     <h2 class="filter__header">
       {% block heading %}
-      Filter {{ result_type | capitalize }}
+      Filter {{ result_type }}
       {% endblock %}
     </h2>
     <form id="category-filters">
+      {% include 'partials/filters/filter-buttons.html' %}
       {% block filters %}{% endblock %}
-      {% block submit %}
-      {% endblock %}
+      {% include 'partials/filters/filter-buttons.html' %}
     </form>
   </div>
 </div>

--- a/templates/partials/filters/filter-buttons.html
+++ b/templates/partials/filters/filter-buttons.html
@@ -1,0 +1,4 @@
+<div class="filter">
+  <button class="button--sm button--primary-contrast" type="button">Apply filters</button>
+  <button class="button--sm button--neutral js-clear-filters" type="button">Clear filters</button>
+</div>

--- a/templates/partials/receipts-filter.html
+++ b/templates/partials/receipts-filter.html
@@ -13,15 +13,6 @@ Filter receipts
 {% block filters %}
 <div class="filter">
   <fieldset>
-    <legend class="label">Restrict contributions</legend>
-    <ul>
-      <li>
-        <input id="is-individual" name="is_individual" type="checkbox" value="true" checked>
-        <label for="is-individual">Unique only</label>
-      </li>
-    </ul>
-  </fieldset>
-  <fieldset>
     <legend class="label">Show contributions from</legend>
     <ul>
       <li>
@@ -31,6 +22,17 @@ Filter receipts
       <li>
         <input id="contributor-type-committee" name="contributor_type" type="checkbox" value="committee">
         <label for="contributor-type-committee">Committees</label>
+      </li>
+    </ul>
+  </fieldset>
+</div>
+<div class="filter">
+  <fieldset>
+    <legend class="label">Restrict contributions</legend>
+    <ul>
+      <li>
+        <input id="is-individual" name="is_individual" type="checkbox" value="true" checked>
+        <label for="is-individual">Unique only</label>
       </li>
     </ul>
   </fieldset>


### PR DESCRIPTION
Based on usability feedback, this adds "Apply filters" and "Clear filters" to the top and bottom of the filter panels. The apply button is basically just a dummy button to get the user to change focus from a text input. The clear button js could maybe be refactored, but it may also make sense to wait and see how if this solves the problem before we optimize.

<img width="380" alt="screen shot 2015-09-17 at 10 03 07 pm" src="https://cloud.githubusercontent.com/assets/1696495/9950463/e2ae5ef2-5d88-11e5-9cce-7154d1cf7888.png">

Resolves https://github.com/18F/openFEC/issues/1170