### PR TITLE
Remove incumbent indicator from browse view.

### DIFF
--- a/static/js/pages/candidates.js
+++ b/static/js/pages/candidates.js
@@ -17,8 +17,7 @@ var columns = [
       return tables.buildEntityLink(
         data,
         '/candidate/' + row.candidate_id + tables.buildCycle(row),
-        'candidate',
-        {isIncumbent: row.incumbent_challenge_full === 'Incumbent'}
+        'candidate'
       );
     }
   },


### PR DESCRIPTION
As discussed in #647, candidate incumbency status is only defined per
election, and not across a candidate's electoral history. Since the
candidate browse view shows summary information about candidates rather
than per-cycle information, it doesn't make sense to show the incumbency
indicator here.

[Resolves #647]