### PR TITLE
Adding tooltips to filters

### DIFF
--- a/static/js/modules/maps.js
+++ b/static/js/modules/maps.js
@@ -156,7 +156,7 @@ var tooltipTemplate = _.template(
 function stateTooltips(svg, path, results) {
   var tooltip = d3.select('body').append('div')
     .attr('id', 'map-tooltip')
-    .attr('class', 'tooltip')
+    .attr('class', 'tooltip tooltip--above')
     .style('position', 'absolute')
     .style('pointer-events', 'none')
     .style('display', 'none');

--- a/templates/partials/receipts-filter.html
+++ b/templates/partials/receipts-filter.html
@@ -31,8 +31,11 @@ Filter receipts
     <legend class="label">Restrict contributions</legend>
     <ul>
       <li>
-        <input id="is-individual" name="is_individual" type="checkbox" value="true" checked>
-        <label for="is-individual">Unique only</label>
+        <input id="is-individual" name="is_individual" type="checkbox" value="true" class="tooltip-trigger" aria-describedby="unique-tooltip" checked>
+        <label for="is-individual" class="tooltip-trigger">Unique only</label>
+        <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under">
+          <p class="tooltip__content">Some transactions — such as earmarked contributions and partnership contributions — are reported more than once for clarity on the printed page but can lead to confusion when viewed as data online. Use the unique only filter to remove these extra transactions.</p>
+        </div>
       </li>
     </ul>
   </fieldset>


### PR DESCRIPTION
Adds the tooltip to the unique filters.
Adds an additional class to specify that map tooltips should have the arrow below the tooltip.

Depends on https://github.com/18F/fec-style/pull/101

Resolves https://github.com/18F/openFEC-web-app/issues/529