### PR TITLE
Use hyphens for all dates in URLs.

### DIFF
--- a/templates/macros/filters/date.html
+++ b/templates/macros/filters/date.html
@@ -4,15 +4,15 @@
   <label for="{{ name }}" class="label">{{ label }}</label>
   <ul>
     <li>
-      <input id="radio-2" name="{{ name }}" type="radio" data-min-date={{ dates['month'][0] | date }} data-max-date={{ dates['month'][1] | date }}>
+      <input id="radio-2" name="{{ name }}" type="radio" data-min-date={{ dates['month'][0] | date(fmt='%m-%d-%Y') }} data-max-date={{ dates['month'][1] | date(fmt='%m-%d-%Y') }}>
       <label for="radio-2">This month</label>
     </li>
     <li>
-      <input id="radio-3" name="{{ name }}" type="radio" data-min-date={{ dates['quarter'][0] | date }} data-max-date={{ dates['quarter'][1] | date }}>
+      <input id="radio-3" name="{{ name }}" type="radio" data-min-date={{ dates['quarter'][0] | date(fmt='%m-%d-%Y') }} data-max-date={{ dates['quarter'][1] | date(fmt='%m-%d-%Y') }}>
       <label for="radio-3">This quarter</label>
     </li>
     <li>
-      <input id="radio-4" name="{{ name }}" type="radio" data-min-date={{ dates['year'][0] | date }} data-max-date={{ dates['year'][1] | date }}>
+      <input id="radio-4" name="{{ name }}" type="radio" data-min-date={{ dates['year'][0] | date(fmt='%m-%d-%Y') }} data-max-date={{ dates['year'][1] | date(fmt='%m-%d-%Y') }}>
       <label for="radio-4">This year</label>
     </li>
     <li>
@@ -22,9 +22,9 @@
   </ul>
   <div class="date-range-input">
     <label for="min_{{ name }}">From</label>
-    <input type="text" id="min_{{ name }}" name="min_{{ name }}" class="js-min-date" data-inputmask="'alias': 'mm/dd/yyyy'">
+    <input type="text" id="min_{{ name }}" name="min_{{ name }}" class="js-min-date" data-inputmask="'alias': 'mm-dd-yyyy'">
     <label for="max_{{ name }}">To</label>
-    <input type="text" id="max_{{ name }}" name="max_{{ name }}" class="js-max-date" data-inputmask="'alias': 'mm/dd/yyyy'">
+    <input type="text" id="max_{{ name }}" name="max_{{ name }}" class="js-max-date" data-inputmask="'alias': 'mm-dd-yyyy'">
   </div>
 </div>
 

--- a/templates/partials/committee/disbursements-tab.html
+++ b/templates/partials/committee/disbursements-tab.html
@@ -11,8 +11,8 @@
           href="{{ url_for(
             'disbursements',
             committee_id=committee_id,
-            min_date=cycle_start(cycle).strftime('%m/%d/%Y'),
-            max_date=cycle_end(cycle).strftime('%m/%d/%Y'),
+            min_date=cycle_start(cycle) | date(fmt='%m-%d-%Y'),
+            max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y'),
           ) }}">All disbursements data
       </a>
     </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -74,8 +74,8 @@
             <li>
               <a href="{{ url_for(
                 'disbursements',
-                min_date=dates['year'][0] | date,
-                max_date=dates['year'][1] | date)
+                min_date=dates['year'][0] | date(fmt='%m-%d-%Y'),
+                max_date=dates['year'][1] | date(fmt='%m-%d-%Y'))
               }}">Disbursements from committees this year &raquo;</a>
             </li>
           </ul>

--- a/templates/search.html
+++ b/templates/search.html
@@ -15,7 +15,7 @@
       <div class="card card--wide">
         <div class="card__image__container">
           <img class="card__image icon--complex" src="/static/img/i-candidates--neutral.svg"  alt="Icon representing candidates">
-          <h2 class="card__title">Candidate data</h2>          
+          <h2 class="card__title">Candidate data</h2>
         </div>
         <div class="card__content">
           <h2 class="card__title">Candidate data</h2>
@@ -50,7 +50,15 @@
         <div class="card__content">
           <h2 class="card__title">Receipt data</h2>
           <ul class="card__links list--bulleted">
-            <li><a href="{{ url_for('receipts', is_individual='true', contributor_type='individual', min_date=dates['year'][0] | date, max_date=dates['year'][1] | date) }}">Contributions from individuals this year &raquo;</a></li>
+            <li>
+              <a href="{{ url_for(
+                'receipts',
+                is_individual='true',
+                contributor_type='individual',
+                min_date=dates['year'][0] | date(fmt='%m-%d-%Y'),
+                max_date=dates['year'][1] | date(fmt='%m-%d-%Y')
+              ) }}">Contributions from individuals this year &raquo;</a>
+            </li>
           </ul>
           <a class="button--neutral button--browse" href="{{ url_for('receipts')}}">All receipt data</a>
         </div>
@@ -63,7 +71,13 @@
         <div class="card__content">
           <h2 class="card__title">Disbursement data</h2>
           <ul class="card__links list--bulleted">
-            <li><a href="{{ url_for('disbursements', min_date=dates['year'][0] | date, max_date=dates['year'][1] | date) }}">Disbursements from committees this year &raquo;</a></li>
+            <li>
+              <a href="{{ url_for(
+                'disbursements',
+                min_date=dates['year'][0] | date,
+                max_date=dates['year'][1] | date)
+              }}">Disbursements from committees this year &raquo;</a>
+            </li>
           </ul>
           <a class="button--neutral button--browse" href="{{ url_for('disbursements') }}">All disbursement data</a>
         </div>


### PR DESCRIPTION
This makes for more readable URLs and fixes a bug on back and forward
navigation resulting from conversion between slash- and hyphen-delimited
dates.

[Resolves #713]