### PR TITLE
Add button types to dropdown buttons.

### DIFF
--- a/static/templates/comparison.hbs
+++ b/static/templates/comparison.hbs
@@ -10,7 +10,7 @@
       {{/each}}
     </ul>
     <div class="dropdown">
-      <button class="dropdown__button button--neutral">More</button>
+      <button type="button" class="dropdown__button button--neutral">More</button>
       <div class="dropdown__panel" aria-hidden="true">
         <ul class="dropdown__list">
           {{#each this.options}}

--- a/templates/macros/filters/checkbox.html
+++ b/templates/macros/filters/checkbox.html
@@ -15,7 +15,7 @@
 
 {% macro checkbox_options(name, options) %}
 <div class="dropdown">
-  <button class="dropdown__button button--neutral">More</button>
+  <button type="button" class="dropdown__button button--neutral">More</button>
   <div id="{{ name }}-dropdown" class="dropdown__panel" aria-hidden="true">
     {{ checkbox_list(name, options) }}
   </div>

--- a/templates/macros/filters/states.html
+++ b/templates/macros/filters/states.html
@@ -4,7 +4,7 @@
     <legend class="label" for="state">State or Territory</legend>
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
-      <button class="dropdown__button button--neutral">More</button>
+      <button type="button" class="dropdown__button button--neutral">More</button>
       <div id="state-dropdown" class="dropdown__panel" aria-hidden="true">
         <ul class="dropdown__list">
           {% for state in constants.states.items() %}

--- a/templates/partials/filters/committee-types.html
+++ b/templates/partials/filters/committee-types.html
@@ -28,7 +28,7 @@
       </li>
     </ul>
     <div class="dropdown">
-      <button class="dropdown__button button--neutral">More</button>
+      <button type="button" class="dropdown__button button--neutral">More</button>
       <div id="ie-dropdown" class="dropdown__panel" aria-hidden="true">
       <ul class="dropdown__list">
         <li class="dropdown__item">
@@ -50,7 +50,7 @@
     <legend class="label" for="committee_type">PACs</legend>
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
-      <button class="dropdown__button button--neutral">More</button>
+      <button type="button" class="dropdown__button button--neutral">More</button>
       <div id="pac-dropdown" class="dropdown__panel" aria-hidden="true">
       <ul class="dropdown__list">
         <li class="dropdown__item">
@@ -118,7 +118,7 @@
       </li>
     </ul>
     <div class="dropdown">
-      <button class="dropdown__button button--neutral">More</button>
+      <button type="button" class="dropdown__button button--neutral">More</button>
       <div id="other-dropdown" class="dropdown__panel" aria-hidden="true">
       <ul class="dropdown__list">
         <li class="dropdown__item">

--- a/templates/partials/filters/districts.html
+++ b/templates/partials/filters/districts.html
@@ -3,7 +3,7 @@
     <legend class="label" for="district">District</legend>
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
-      <button class="dropdown__button button--neutral">More</button>
+      <button type="button" class="dropdown__button button--neutral">More</button>
       <div id="district-dropdown" class="dropdown__panel" aria-hidden="true">
         <ul class="dropdown__list">
             {% for district in range(100) %}

--- a/templates/partials/filters/election-years.html
+++ b/templates/partials/filters/election-years.html
@@ -3,7 +3,7 @@
     <legend class="label">Election Years</legend>
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
-      <button class="dropdown__button button--neutral">More</button>
+      <button type="button" class="dropdown__button button--neutral">More</button>
       <div id="cycle-dropdown" class="dropdown__panel" aria-hidden="true">
         <ul class="dropdown__list">
         {% for year in range(2016, 1978, -2) %}


### PR DESCRIPTION
Prevent enter keypress from toggling dropdowns. The default "type" of
buttons in most browsers is "submit", which can cause unintended
keyboard interactions if not overridden.