### PR TITLE
Replace existing modal callback with new callback.

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -266,6 +266,7 @@ function modalRenderRow(row, data, index) {
 }
 
 function modalRenderFactory(template, fetch) {
+  var callback;
   fetch = fetch || identity;
   return function(api, data, response) {
     var $table = $(api.table().node());
@@ -275,7 +276,8 @@ function modalRenderFactory(template, fetch) {
     $modal.appendTo($main);
     $table.find('tr').attr('tabindex', 0);
 
-    $table.on('click keypress', '.js-panel-toggle tr.' + MODAL_TRIGGER_CLASS, function(e) {
+    $table.off('click keypress', '.js-panel-toggle tr.' + MODAL_TRIGGER_CLASS, callback);
+    callback = function(e) {
       if (e.which === 13 || e.type === 'click') {
         // Note: Use `currentTarget` to get parent row, since the target column
         // may have been moved since the triggering event
@@ -313,7 +315,8 @@ function modalRenderFactory(template, fetch) {
           });
         }
       }
-    });
+    };
+    $table.on('click keypress', '.js-panel-toggle tr.' + MODAL_TRIGGER_CLASS, callback);
 
     $modal.on('click', '.js-panel-close', function(e) {
       e.preventDefault();


### PR DESCRIPTION
Fix a subtle issue such that each render adds a new modal callback to
the table. Instead, on render, remove the previous callback if present
before adding the new one.

Related to https://github.com/18F/openFEC-web-app/issues/734.