### PR TITLE
Feature/data explinations

### DIFF
--- a/static/templates/disbursements.hbs
+++ b/static/templates/disbursements.hbs
@@ -52,7 +52,7 @@
   <h4 class="panel__title">Filing information</h4>
   <table>
     <tr>
-      <td class="panel__term">Receipt date</td>
+      <td class="panel__term">Filing date</td>
       <td>{{{ datetime receipt_date }}}</td>
     </tr>
     <tr>

--- a/static/templates/disbursements.hbs
+++ b/static/templates/disbursements.hbs
@@ -24,7 +24,11 @@
       <td>{{{ currency disbursement_amount }}}</td>
     </tr>
     <tr>
-      <td class="panel__term">Receipt date</td>
+      <td class="panel__term">Description</td>
+      <td>{{ disbursement_description }}</td>
+    </tr>
+    <tr>
+      <td class="panel__term">Disbursement date</td>
       <td>{{{ datetime disbursement_date }}}</td>
     </tr>
     <tr>
@@ -32,8 +36,8 @@
       <td>{{ memo_text }}</td>
     </tr>
     <tr>
-      <td class="panel__term">Description</td>
-      <td>{{ disbursement_description }}</td>
+      <td class="panel__term">Memo code</td>
+      <td>{{ memo_code }}</td>
     </tr>
     {{#if election_type_full }}
     <tr>
@@ -42,6 +46,20 @@
     </tr>
     {{/if}}
   </table>
+</div>
+
+<div class="panel__row">
+  <h4 class="panel__title">Filing information</h4>
+  <table>
+    <tr>
+      <td class="panel__term">Receipt date</td>
+      <td>{{{ datetime receipt_date }}}</td>
+    </tr>
+    <tr>
+      <td class="panel__term">View report page</td>
+      <td><a href="{{{ pdf_url }}}" target="_blank">View on fec.gov</a></td>
+    </tr>
+ </table>
 </div>
 
 <div class="panel__row">

--- a/static/templates/disbursements.hbs
+++ b/static/templates/disbursements.hbs
@@ -24,12 +24,12 @@
       <td>{{{ currency disbursement_amount }}}</td>
     </tr>
     <tr>
-      <td class="panel__term">Description</td>
-      <td>{{ disbursement_description }}</td>
-    </tr>
-    <tr>
       <td class="panel__term">Disbursement date</td>
       <td>{{{ datetime disbursement_date }}}</td>
+    </tr>
+    <tr>
+      <td class="panel__term">Description</td>
+      <td>{{ disbursement_description }}</td>
     </tr>
     <tr>
       <td class="panel__term">Memo</td>
@@ -37,7 +37,7 @@
     </tr>
     <tr>
       <td class="panel__term">Memo code</td>
-      <td>{{ memo_code }}</td>
+      <td>{{ memoed_subtotal }}</td>
     </tr>
     {{#if election_type_full }}
     <tr>

--- a/static/templates/receipts.hbs
+++ b/static/templates/receipts.hbs
@@ -20,7 +20,7 @@
     <tr>
       <td class="panel__term">Employer</td>
       <td>{{ contributor_employer }}</td>
-    </tr>    
+    </tr>
     <tr>
       <td class="panel__term">Year to date</td>
       <td>{{{ currency contributor_aggregate_ytd }}}</td>
@@ -48,6 +48,20 @@
       <td>{{ election_type_full }}</td>
     </tr>
   </table>
+</div>
+
+<div class="panel__row">
+  <h4 class="panel__title">Filing information</h4>
+  <table>
+    <tr>
+      <td class="panel__term">Filing date</td>
+      <td>{{{ datetime receipt_date }}}</td>
+    </tr>
+    <tr>
+      <td class="panel__term">View report page</td>
+      <td><a href="{{{ pdf_url }}}" target="_blank">View on fec.gov</a></td>
+    </tr>
+ </table>
 </div>
 
 <div class="panel__row">

--- a/templates/partials/committees-table.html
+++ b/templates/partials/committees-table.html
@@ -5,7 +5,7 @@
             <th scope="col">Treasurer name</th>
             <th scope="col">State</th>
             <th scope="col">Party</th>
-            <th scope="col">File date</th>
+            <th scope="col">First file date</th>
             <th scope="col">Type</th>
             <th scope="col">Designation</th>
             <th scope="col">Organization type</th>

--- a/templates/partials/disbursements-filter.html
+++ b/templates/partials/disbursements-filter.html
@@ -9,6 +9,7 @@ Filter disbursements
 {% endblock %}
 
 {% block filters %}
+<p>Due to the large number of transactions, records begin in 2011.</p>
 {{ typeahead.field('committee_id', 'Committee') }}
 
 <h4 class="filters__subheader">Recipient information</h4>

--- a/templates/partials/disbursements-filter.html
+++ b/templates/partials/disbursements-filter.html
@@ -22,5 +22,5 @@ Filter disbursements
 {{ text.field('min_amount', 'Minimum expenditure') }}
 {{ text.field('max_amount', 'Maximum expenditure') }}
 {{ date.field('date', 'Disbursement date', dates ) }}
-<p>Disbursements are reported periodically, according to the filer's reporting schedule and may take additional time to process.</p>
+<p>Disbursements are reported periodically, according to the filer's reporting schedule. Disbursements are updated as they’re processed— that time can vary.</p>
 {% endblock %}

--- a/templates/partials/disbursements-filter.html
+++ b/templates/partials/disbursements-filter.html
@@ -22,5 +22,5 @@ Filter disbursements
 {{ text.field('min_amount', 'Minimum expenditure') }}
 {{ text.field('max_amount', 'Maximum expenditure') }}
 {{ date.field('date', 'Disbursement date', dates ) }}
-<p>Disbursements are reported periodically, according to the filer's filing schedule.</p>
+<p>Disbursements are reported periodically, according to the filer's reporting schedule and may take additional time to process.</p>
 {% endblock %}

--- a/templates/partials/disbursements-filter.html
+++ b/templates/partials/disbursements-filter.html
@@ -19,7 +19,8 @@ Filter disbursements
 {{ states.field('recipient_state')}}
 <h4 class="filters__subheader">Transaction information</h4>
 {{ text.field('disbursement_description', 'Purpose') }}
-{{ text.field('min_amount', 'Minimum Expenditure') }}
-{{ text.field('max_amount', 'Maximum Expenditure') }}
-{{ date.field('date', 'Disbursement Date', dates ) }}
+{{ text.field('min_amount', 'Minimum expenditure') }}
+{{ text.field('max_amount', 'Maximum expenditure') }}
+{{ date.field('date', 'Disbursement date', dates ) }}
+<p>Disbursements are reported periodically, according to the filer's filing schedule.</p>
 {% endblock %}

--- a/templates/partials/disbursements-table.html
+++ b/templates/partials/disbursements-table.html
@@ -4,7 +4,7 @@
       <th scope="col">Recipient Name</th>
       <th scope="col">State</th>
       <th scope="col">Amount</th>
-      <th scope="col">Date</th>
+      <th scope="col">Disbursement Date</th>
       <th scope="col">Purpose</th>
       <th scope="col">Committee</th>
       <th scope="col"></th>

--- a/templates/partials/disbursements-table.html
+++ b/templates/partials/disbursements-table.html
@@ -1,10 +1,10 @@
 <table id="results" class="data-table" data-type="expenditure">
   <thead>
     <tr>
-      <th scope="col">Recipient Name</th>
+      <th scope="col">Recipient name</th>
       <th scope="col">State</th>
       <th scope="col">Amount</th>
-      <th scope="col">Disbursement Date</th>
+      <th scope="col">Disbursement date</th>
       <th scope="col">Purpose</th>
       <th scope="col">Committee</th>
       <th scope="col"></th>

--- a/templates/partials/receipts-filter.html
+++ b/templates/partials/receipts-filter.html
@@ -45,17 +45,17 @@ Filter receipts
 {{ typeahead.field('committee_id', 'Committee') }}
 
 <h3 class="filters__subheader">Contributor information</h3>
-{{ typeahead.field('contributor_id', 'Contributor Name (committee)') }}
-{{ text.field('contributor_name', 'Contributor Name (non-committee)') }}
+{{ typeahead.field('contributor_id', 'Contributor name (committee)') }}
+{{ text.field('contributor_name', 'Contributor name (non-committee)') }}
 {{ text.field('contributor_city', 'City') }}
 {{ states.field('contributor_state') }}
 {{ text.field('contributor_employer', 'Employer') }}
 {{ text.field('contributor_occupation', 'Occupation') }}
 
 <h3 class="filters__subheader">Transaction information</h3>
-{{ text.field('min_amount', 'Minimum Contribution', {'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
-{{ text.field('max_amount', 'Maximum Contribution', {'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
-{{ date.field('date', 'Receipt Date', dates ) }}
+{{ text.field('min_amount', 'Minimum contribution', {'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
+{{ text.field('max_amount', 'Maximum contribution', {'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
+{{ date.field('date', 'Receipt date', dates ) }}
 <p>Receipts are reported periodically, according to the filer's filing schedule.</p>
 
 {% endblock %}

--- a/templates/partials/receipts-filter.html
+++ b/templates/partials/receipts-filter.html
@@ -12,6 +12,7 @@ Filter receipts
 
 {% block filters %}
 <div class="filter">
+  <p>Due to the large number of transactions, records begin in 2011.</p>
   <fieldset>
     <legend class="label">Show contributions from</legend>
     <ul>

--- a/templates/partials/receipts-filter.html
+++ b/templates/partials/receipts-filter.html
@@ -56,6 +56,6 @@ Filter receipts
 {{ text.field('min_amount', 'Minimum contribution', {'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
 {{ text.field('max_amount', 'Maximum contribution', {'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
 {{ date.field('date', 'Receipt date', dates ) }}
-<p>Receipts are reported periodically, according to the filer's reporting schedule and may take additional time to process.</p>
+<p>Receipts are reported periodically, according to the filer's reporting schedule. Receipts are updated as they’re processed— that time can vary.</p>
 
 {% endblock %}

--- a/templates/partials/receipts-filter.html
+++ b/templates/partials/receipts-filter.html
@@ -56,5 +56,6 @@ Filter receipts
 {{ text.field('min_amount', 'Minimum Contribution', {'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
 {{ text.field('max_amount', 'Maximum Contribution', {'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
 {{ date.field('date', 'Receipt Date', dates ) }}
+<p>Receipts are reported periodically, according to the filer's filing schedule.</p>
 
 {% endblock %}

--- a/templates/partials/receipts-filter.html
+++ b/templates/partials/receipts-filter.html
@@ -56,6 +56,6 @@ Filter receipts
 {{ text.field('min_amount', 'Minimum contribution', {'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
 {{ text.field('max_amount', 'Maximum contribution', {'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
 {{ date.field('date', 'Receipt date', dates ) }}
-<p>Receipts are reported periodically, according to the filer's filing schedule.</p>
+<p>Receipts are reported periodically, according to the filer's reporting schedule and may take additional time to process.</p>
 
 {% endblock %}

--- a/templates/partials/receipts-table.html
+++ b/templates/partials/receipts-table.html
@@ -1,11 +1,11 @@
 <table id="results" class="data-table" data-type="donation">
   <thead>
     <tr>
-      <th scope="col">Contributor Name</th>
+      <th scope="col">Contributor name</th>
       <th scope="col">State</th>
       <th scope="col">Employer</th>
       <th scope="col">Amount</th>
-      <th scope="col">Date</th>
+      <th scope="col">Receipt date</th>
       <th scope="col">Recipient</th>
       <th scope="col"></th>
     </tr>


### PR DESCRIPTION
- Add date disclaimer for schedule A and B 
- Add link to page of the record for Schedule A and B
- Standardize some capitalization: @emileighoutlaw asked for sentences case 
- We had "date" as a heading in cases were there were 2 kinds of dates so I added "disbursement date" or "receipt date" 
- Changed receipt date to filing date in the schedule A and B panel descriptions, because recipt date is confusing on the recipes page. 
- I moved description and memo text next to each other because the memo filed can sometimes flesh out the description.


fix #736
fix #726 