### PR TITLE
Remove `tabindex` from main section.

### DIFF
--- a/templates/layouts/main.html
+++ b/templates/layouts/main.html
@@ -61,7 +61,7 @@
   </header>
 
   {% block header %}{% endblock %}
-  <main id="main" {% if section %} data-section="{{section}}"{% endif %} tabindex="-1">
+  <main id="main" {% if section %} data-section="{{section}}"{% endif %}>
     {% block body %}{% endblock %}
   </main>
 


### PR DESCRIPTION
This fixes an interaction with dropdown toggles such that clicking
options within the dropdown panel didn't select the items. Thanks
@noahmanger for finding the fix.