### PR TITLE
Replace empty tables with placeholder text.

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -40,11 +40,6 @@ $.fn.DataTable.Api.register('seekIndex()', function(length, start, value) {
   }
 });
 
-// Only show table after draw
-$(document.body).on('draw.dt', function() {
-  $('.datatable__container').css('opacity', '1');
-});
-
 function yearRange(first, last) {
   if (first === last) {
     return first;

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -485,7 +485,7 @@ function hideEmpty(api, data, response) {
   if (!response.pagination.count) {
     api.destroy();
     var $table = $(api.table().node());
-    $table.before('No data found.');
+    $table.before('<div class="message message--alert">No data found.</div>');
     $table.remove();
   }
 }

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -17,9 +17,9 @@ var helpers = require('./helpers');
 var simpleDOM = 't<"results-info"ip>';
 
 // Only show table after draw
-$(document.body).on('draw.dt', function(){
+$(document.body).on('draw.dt', function() {
   $('.datatable__container').css('opacity', '1');
-})
+});
 
 $.fn.DataTable.Api.register('seekIndex()', function(length, start, value) {
   var settings = this.context[0];
@@ -41,9 +41,9 @@ $.fn.DataTable.Api.register('seekIndex()', function(length, start, value) {
 });
 
 // Only show table after draw
-$(document.body).on('draw.dt', function(){
+$(document.body).on('draw.dt', function() {
   $('.datatable__container').css('opacity', '1');
-})
+});
 
 function yearRange(first, last) {
   if (first === last) {
@@ -427,7 +427,6 @@ function initTable($table, $form, path, baseQuery, columns, callbacks, opts) {
       }
       var query = _.extend(
         callbacks.mapQuery(api, data),
-        {api_key: API_KEY},
         parsedFilters || {}
       );
       if (useHideNull) {
@@ -444,6 +443,9 @@ function initTable($table, $form, path, baseQuery, columns, callbacks, opts) {
         callbacks.handleResponse(api, data, response);
         callback(callbacks.preprocess(response));
         callbacks.afterRender(api, data, response);
+        if (opts.hideEmpty) {
+          hideEmpty(api, data, response);
+        }
       }).always(function() {
         $processing.hide();
       });
@@ -476,6 +478,20 @@ function initTable($table, $form, path, baseQuery, columns, callbacks, opts) {
   if ($form) {
     updateOnChange($form, api);
     $table.on('draw.dt', adjustFormHeight.bind(null, $table, $form));
+  }
+}
+
+/**
+ * Replace a `DataTable` with placeholder text if no results found. Should only
+ * be used with unfiltered tables, else tables may be destroyed on restrictive
+ * filtering.
+ */
+function hideEmpty(api, data, response) {
+  if (!response.pagination.count) {
+    api.destroy();
+    var $table = $(api.table().node());
+    $table.before('No data found.');
+    $table.remove();
   }
 }
 

--- a/static/js/pages/candidate-single.js
+++ b/static/js/pages/candidate-single.js
@@ -28,7 +28,8 @@ function initFilingsTable() {
     // Order by receipt date descending
     order: [[2, 'desc']],
     dom: tables.simpleDOM,
-    pagingType: 'simple'
+    pagingType: 'simple',
+    hideEmpty: true
   });
 }
 
@@ -43,7 +44,8 @@ function initExpendituresTable() {
     // Order by receipt date descending
     order: [[0, 'desc']],
     dom: tables.simpleDOM,
-    pagingType: 'simple'
+    pagingType: 'simple',
+    hideEmpty: true
   });
 }
 

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -19,7 +19,8 @@ var tableOpts = {
   pagingType: 'simple',
   lengthChange: false,
   pageLength: 10,
-  useHideNull: false
+  useHideNull: false,
+  hideEmpty: true
 };
 
 var sizeColumns = [

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -223,7 +223,8 @@ $(document).ready(function() {
           pagingType: 'simple',
           lengthChange: false,
           pageLength: 10,
-          useHideNull: false
+          useHideNull: false,
+          hideEmpty: true
         });
         break;
       case 'contribution-size':
@@ -234,7 +235,8 @@ $(document).ready(function() {
           pagingType: 'simple',
           lengthChange: false,
           pageLength: 10,
-          useHideNull: false
+          useHideNull: false,
+          hideEmpty: true
         });
         break;
       case 'receipts-by-state':
@@ -255,7 +257,7 @@ $(document).ready(function() {
         );
         events.on('state.map', function(params) {
           var $map = $('.state-map');
-          highlightRowAndState($map, $table, params.state, true)
+          highlightRowAndState($map, $table, params.state, true);
         });
         $table.on('click', 'tr', function(e) {
           events.emit('state.table', {state: $(this).find('span[data-state]').attr('data-state')});
@@ -274,9 +276,8 @@ $(document).ready(function() {
         }));
         break;
       case 'filing':
-        var $form = $('#category-filters');
         path = ['committee', committeeId, 'filings'];
-        tables.initTableDeferred($table, $form, path, query, filingsColumns,
+        tables.initTableDeferred($table, null, path, query, filingsColumns,
           _.extend({}, tables.offsetCallbacks, {
             afterRender: filings.renderModal
           }),
@@ -286,7 +287,8 @@ $(document).ready(function() {
             pagingType: 'simple',
             // Order by receipt date descending
             order: [[2, 'desc']],
-            useFilters: true
+            useFilters: true,
+            hideEmpty: true
           }
         );
         break;

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -429,7 +429,8 @@ function initSpendingTables() {
         pagingType: 'simple',
         lengthChange: false,
         pageLength: 10,
-        useHideNull: false
+        useHideNull: false,
+        hideEmpty: true
       });
     }
   });


### PR DESCRIPTION
On fetching results from tables without filters, destroy the `DataTable`
instance and add placeholder text if no results found. Note: this patch
uses a placeholder placeholder, which would probably benefit from style
and content review by @noahmanger and @emileighoutlaw.

[Resolves #512]