### PR TITLE
Feature/more accessibility

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -121,19 +121,16 @@ monthly_reports = OrderedDict([
     ('M10', 'October monthly'),
     ('M11', 'November monthly'),
     ('M12', 'December monthly'),
-    ('YE', 'Year end'),
 ])
 
 quarterly_reports = OrderedDict([
     ('Q1', 'April quarterly'),
     ('Q2', 'July quarterly'),
     ('Q3', 'October quarterly'),
-    ('YE', 'Year end'),    
 ])
 
 semiannual_reports = OrderedDict([
     ('MY', 'Mid-year report'),
-    ('YE', 'Year end'),    
 ])
 
 election_sensitive_reports = OrderedDict([

--- a/static/js/modules/election-lookup.js
+++ b/static/js/modules/election-lookup.js
@@ -170,8 +170,8 @@ ElectionLookup.prototype.init = function() {
   this.$state = this.$form.find('[name="state"]');
   this.$district = this.$form.find('[name="district"]').prop('disabled', true);
   this.$cycle = this.$form.find('[name="cycle"]');
-  this.$resultsItems = this.$elm.find('.results-items');
-  this.$resultsTitle = this.$elm.find('.results-title');
+  this.$resultsItems = this.$elm.find('.js-results-items');
+  this.$resultsTitle = this.$elm.find('.js-results-title');
 
   this.$zip.on('change', this.handleZipChange.bind(this));
   this.$state.on('change', this.handleStateChange.bind(this));

--- a/static/js/modules/filters.js
+++ b/static/js/modules/filters.js
@@ -15,7 +15,7 @@ var open = false;
 
 var openFilterPanel = function() {
   $('body').addClass('is-showing-filters');
-  $('.filters').addClass('is-open').attr('tabindex','0');
+  $('.filters').addClass('is-open');
   $('#filter-toggle').addClass('is-active')
     .find('.filters__toggle__text').html('Hide filters');
   accessibility.restoreTabindex($('#category-filters'));

--- a/static/js/modules/filters.js
+++ b/static/js/modules/filters.js
@@ -8,15 +8,17 @@ var URI = require('URIjs');
 
 var events = require('fec-style/js/events');
 var accordion = require('fec-style/js/accordion');
+var accessibility = require('fec-style/js/accessibility');
 
 // are the panels open?
 var open = false;
 
 var openFilterPanel = function() {
   $('body').addClass('is-showing-filters');
-  $('.filters').addClass('is-open');
+  $('.filters').addClass('is-open').attr('tabindex','0');
   $('#filter-toggle').addClass('is-active')
     .find('.filters__toggle__text').html('Hide filters');
+  accessibility.restoreTabindex($('#category-filters'));
   open = true;
 };
 
@@ -26,6 +28,7 @@ var closeFilterPanel = function() {
   $('#filter-toggle').removeClass('is-active')
     .find('.filters__toggle__text').html('Show filters');
   $('#results tr:first-child').focus();
+  accessibility.removeTabindex($('#category-filters'));
   open = false;
 };
 

--- a/static/js/modules/maps.js
+++ b/static/js/modules/maps.js
@@ -200,7 +200,7 @@ DistrictMap.prototype.load = function(election) {
     var encoded = utils.encodeDistrict(election.state, election.district);
     feature = utils.findDistrict(encoded);
   } else {
-    feature = fipsByState[parseInt(election.state)];
+    feature = fips.fipsByState[parseInt(election.state)];
   }
   feature && this.render(feature);
 };

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -7,6 +7,7 @@ var URI = require('URIjs');
 var _ = require('underscore');
 var moment = require('moment');
 var tabs = require('../vendor/tablist');
+var accessibility = require('fec-style/js/accessibility');
 
 require('datatables');
 require('drmonty-datatables-responsive');
@@ -43,6 +44,7 @@ $.fn.DataTable.Api.register('seekIndex()', function(length, start, value) {
 // Only show table after draw
 $(document.body).on('draw.dt', function(){
   $('.datatable__container').css('opacity', '1');
+  $('.dataTable tbody td:first-child').attr('scope','row');
 })
 
 function yearRange(first, last) {
@@ -275,6 +277,7 @@ function modalRenderFactory(template, fetch) {
     var $main = $table.closest('.panel__main');
     // Move the modal to the results div.
     $modal.appendTo($main);
+    $modal.css('display', 'block');
 
     $table.on('click keypress', '.js-panel-toggle tr.' + MODAL_TRIGGER_CLASS, function(e) {
       if (e.which === 13 || e.type === 'click') {
@@ -293,6 +296,7 @@ function modalRenderFactory(template, fetch) {
             $row.siblings().toggleClass('row-active', false);
             $row.toggleClass('row-active', true);
             $('body').toggleClass('panel-active', true);
+            accessibility.restoreTabindex($modal);
             var hideColumns = api.columns('.hide-panel');
             hideColumns.visible(false);
 
@@ -343,6 +347,8 @@ function hidePanel(api, $modal) {
     if ($(document).width() > 980) {
       api.columns('.hide-panel').visible(true);
     }
+
+    accessibility.removeTabindex($modal);
 }
 
 function barsAfterRender(template, api, data, response) {

--- a/static/js/vendor/tablist.js
+++ b/static/js/vendor/tablist.js
@@ -12,37 +12,6 @@ var events = require('fec-style/js/events');
 
 var $container = '.tab-interface';
 
-// Change focus between tabs with arrow keys
-
-$('[role="tab"]').on('keydown', function(e) {
-
-  // define current, previous and next (possible) tabs
-
-  var $original = $(this);
-  var $prev = $(this).parents('li').prev().children('[role="tab"]');
-  var $next = $(this).parents('li').next().children('[role="tab"]');
-  var $target;
-
-  // find the direction (prev or next)
-
-  switch (e.keyCode) {
-    case 37:
-      $target = $prev;
-      break;
-    case 39:
-      $target = $next;
-      break;
-    default:
-      $target = false;
-      break;
-  }
-
-  if ($target && $target.length) {
-    show($target, true);
-    $target.focus();
-  }
-});
-
 // Handle click on tab to show + focus tabpanel
 
 $('[role="tab"]').on('click', function(e) {
@@ -53,12 +22,10 @@ $('[role="tab"]').on('click', function(e) {
 function show($target, push) {
   // Toggle tabs
   $('[role="tab"]').attr({
-    'tabindex': '-1',
     'aria-selected': null
   });
   $target.attr({
     'aria-selected': 'true',
-    'tabindex': '0'
   });
 
   // Toggle panels

--- a/static/templates/candidateStateMap.hbs
+++ b/static/templates/candidateStateMap.hbs
@@ -1,5 +1,5 @@
 <div class="state-map">
-  <select class="candidate-select">
+  <select class="candidate-select" aria-label="Select a candidate">
   {{#each this}}
     <option value="{{ this.candidate_id }}">
       {{ this.candidate_name }}

--- a/templates/candidates-single.html
+++ b/templates/candidates-single.html
@@ -71,7 +71,7 @@
         <nav class="page-tabs">
           <ul class="page-tabs__list" role="tablist" data-name="tab">
             <li role="presentation" class="page-tabs__item"><a role="tab" data-name="summary" tabindex="0" aria-controls="panel1" aria-selected="true" href="#section-1">Financial summary</a></li>
-            <li role="presentation" class="page-tabs__item"><a role="tab" data-name="other-spending" tabindex="-1" aria-controls="panel2" href="#section-2">Other spending</a></li>
+            <li role="presentation" class="page-tabs__item"><a role="tab" data-name="other-spending" tabindex="0" aria-controls="panel2" href="#section-2">Other spending</a></li>
           </ul>
         </nav>
       </div>

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block body %}
-  <div id="main" class="tab-interface">
+  <div class="tab-interface">
     <header class="page-header page-header--primary">
     <img class="page-header__icon" src="/static/img/i-committee--primary.svg" alt="Candidate icon">
     <span class="page-header__title">Committees</span>

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -69,10 +69,10 @@
             <ul class="page-tabs__list" role="tablist" data-name="tab">
               {% if committee_type not in ['C', 'E'] %}
                 <li role="presentation" class="page-tabs__item"><a role="tab" data-name="summary" tabindex="0" aria-controls="panel1" aria-selected="true" href="#section-1">Financial summary</a></li>
-                <li role="presentation" class="page-tabs__item"><a role="tab" data-name="receipts" tabindex="-1" aria-controls="panel2" href="#section-2">Receipts from individuals</a></li>
-                <li role="presentation" class="page-tabs__item"><a role="tab" data-name="disbursements" tabindex="-1" aria-controls="panel3" href="#section-3">Disbursements</a></li>
-                <li role="presentation" class="page-tabs__item"><a role="tab" data-name="transfers" tabindex="-1" aria-controls="panel4" href="#section-4">Between committees</a></li>
-                <li role="presentation" class="page-tabs__item"><a role="tab" data-name="filings" tabindex="-1" aria-controls="panel5" href="#section-5">Filings</a></li>
+                <li role="presentation" class="page-tabs__item"><a role="tab" data-name="receipts" tabindex="0" aria-controls="panel2" href="#section-2">Receipts from individuals</a></li>
+                <li role="presentation" class="page-tabs__item"><a role="tab" data-name="disbursements" tabindex="0" aria-controls="panel3" href="#section-3">Disbursements</a></li>
+                <li role="presentation" class="page-tabs__item"><a role="tab" data-name="transfers" tabindex="0" aria-controls="panel4" href="#section-4">Between committees</a></li>
+                <li role="presentation" class="page-tabs__item"><a role="tab" data-name="filings" tabindex="0" aria-controls="panel5" href="#section-5">Filings</a></li>
               {% endif %}
             </ul>
           </nav>

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -107,7 +107,9 @@
           <span>{{ null.null( value | currency ) }}</span>
         </div>
         {% if accordion %}
-          <button class="button button--primary accordion__button js-accordion_button"><span class="js-accordion_text u-visually-hidden"></span></button>
+          <button class="button button--primary accordion__button js-accordion_button">
+            <span class="js-accordion_text u-visually-hidden" data-show="Show {{ pretty_name }}" data-hide="Hide {{ pretty_name }}"></span>
+          </button>
         {% endif %}
       </div>
     {% endmacro %}

--- a/templates/election-lookup.html
+++ b/templates/election-lookup.html
@@ -31,28 +31,30 @@
           </div>
           <div class="search-controls__or search-controls__or--vertical">or</div>
           <div class="search-controls__either">
-            <span class="label">Find by state and district</span>
-            <div class="search-controls__state">
-              <select id="state" name="state" aria-label="Select a state">
-                <option value="">Select state</option>
-                {% for value, label in constants.states.items() %}
-                <option value="{{ value }}">{{ label }}</option>
-                {% endfor %}
-              </select>
-            </div>
-            <div class="search-controls__district">
-              <select id="district" name="district" aria-label="Select a district">
-                <option value="">Select district</option>
-                {% for value in range(1, 100) %}
-                {% with formatted = '{0:02d}'.format(value) %}
-                <option value="{{ formatted }}">{{ formatted }}</option>
-                {% endwith %}
-                {% endfor %}
-              </select>
-            </div>
-            <div class="search-controls__submit">
-              <button type="submit" class="button--search--text button--neutral">Search</button>
-            </div>
+            <fieldset>
+              <legend class="label">Find by state and district</span></legend>
+              <div class="search-controls__state">
+                <select id="state" name="state" aria-label="Select a state">
+                  <option value="">Select state</option>
+                  {% for value, label in constants.states.items() %}
+                  <option value="{{ value }}">{{ label }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+              <div class="search-controls__district">
+                <select id="district" name="district" aria-label="Select a district">
+                  <option value="">Select district</option>
+                  {% for value in range(1, 100) %}
+                  {% with formatted = '{0:02d}'.format(value) %}
+                  <option value="{{ formatted }}">{{ formatted }}</option>
+                  {% endwith %}
+                  {% endfor %}
+                </select>
+              </div>
+              <div class="search-controls__submit">
+                <button type="submit" class="button--search--text button--neutral">Search</button>
+              </div>
+            </fieldset>
           </div>
         </div>
       </form>

--- a/templates/election-lookup.html
+++ b/templates/election-lookup.html
@@ -63,10 +63,10 @@
           <div class="row">
             <h2 class="heading__title">Results:</h2>
           </div>
-          <h3 class="heading__subtitle results-title"></h3>
+          <span class="h3 heading__subtitle js-results-title"></span>
         </div>
         <div class="results">
-          <div class="results-items"></div>
+          <div class="js-results-items"></div>
         </div>
       </div>
       <div class="election-map usa-width-one-half"></div>

--- a/templates/elections.html
+++ b/templates/elections.html
@@ -43,7 +43,7 @@
         <nav class="page-tabs">
           <ul class="page-tabs__list" role="tablist" data-name="tab">
             <li role="presentation" class="page-tabs__item"><a role="tab" data-name="comparison" tabindex="0" aria-controls="panel1" aria-selected="true" href="#section-1">Candidate comparison</a></li>
-            <li role="presentation" class="page-tabs__item"><a role="tab" data-name="spending" tabindex="-1" aria-controls="panel2" href="#section-2">Other spending</a></li>
+            <li role="presentation" class="page-tabs__item"><a role="tab" data-name="spending" tabindex="0" aria-controls="panel2" href="#section-2">Other spending</a></li>
           </ul>
         </nav>
       </div>

--- a/templates/layouts/main.html
+++ b/templates/layouts/main.html
@@ -40,7 +40,7 @@
 {% import 'macros/search.html' as search %}
 {% include 'partials/browser-warning.html' %}
 {% include 'partials/javascript-warning.html' %}
-<a class="skip-nav" tabindex="0">skip navigation</a>
+<a href="#main" class="skip-nav" tabindex="0">skip navigation</a>
 
   <header class="site-header">
     <div class="disclaimer">

--- a/templates/macros/filters/checkbox.html
+++ b/templates/macros/filters/checkbox.html
@@ -16,7 +16,7 @@
 {% macro checkbox_options(name, options) %}
 <div class="dropdown">
   <button type="button" class="dropdown__button button--neutral">More</button>
-  <div id="{{ name }}-dropdown" class="dropdown__panel" aria-hidden="true">
+  <div class="dropdown__panel" aria-hidden="true">
     {{ checkbox_list(name, options) }}
   </div>
 </div>

--- a/templates/macros/filters/date.html
+++ b/templates/macros/filters/date.html
@@ -1,31 +1,33 @@
 {% macro field(name, label, dates) %}
 
 <div class="filter date-choice-field" id="{{ name }}">
-  <label for="{{ name }}" class="label">{{ label }}</label>
-  <ul>
-    <li>
-      <input id="radio-2" name="{{ name }}" type="radio" data-min-date={{ dates['month'][0] | date(fmt='%m-%d-%Y') }} data-max-date={{ dates['month'][1] | date(fmt='%m-%d-%Y') }}>
-      <label for="radio-2">This month</label>
-    </li>
-    <li>
-      <input id="radio-3" name="{{ name }}" type="radio" data-min-date={{ dates['quarter'][0] | date(fmt='%m-%d-%Y') }} data-max-date={{ dates['quarter'][1] | date(fmt='%m-%d-%Y') }}>
-      <label for="radio-3">This quarter</label>
-    </li>
-    <li>
-      <input id="radio-4" name="{{ name }}" type="radio" data-min-date={{ dates['year'][0] | date(fmt='%m-%d-%Y') }} data-max-date={{ dates['year'][1] | date(fmt='%m-%d-%Y') }}>
-      <label for="radio-4">This year</label>
-    </li>
-    <li>
-      <input id="radio-5" name="{{ name }}" type="radio">
-      <label for="radio-5">Custom</label>
-    </li>
-  </ul>
-  <div class="date-range-input">
-    <label for="min_{{ name }}">From</label>
-    <input type="text" id="min_{{ name }}" name="min_{{ name }}" class="js-min-date" data-inputmask="'alias': 'mm-dd-yyyy'">
-    <label for="max_{{ name }}">To</label>
-    <input type="text" id="max_{{ name }}" name="max_{{ name }}" class="js-max-date" data-inputmask="'alias': 'mm-dd-yyyy'">
-  </div>
+  <fieldset>
+    <legend for="{{ name }}" class="label">{{ label }}</legend>
+    <ul>
+      <li>
+        <input id="radio-2" name="{{ name }}" type="radio" data-min-date={{ dates['month'][0] | date(fmt='%m-%d-%Y') }} data-max-date={{ dates['month'][1] | date(fmt='%m-%d-%Y') }}>
+        <label for="radio-2">This month</label>
+      </li>
+      <li>
+        <input id="radio-3" name="{{ name }}" type="radio" data-min-date={{ dates['quarter'][0] | date(fmt='%m-%d-%Y') }} data-max-date={{ dates['quarter'][1] | date(fmt='%m-%d-%Y') }}>
+        <label for="radio-3">This quarter</label>
+      </li>
+      <li>
+        <input id="radio-4" name="{{ name }}" type="radio" data-min-date={{ dates['year'][0] | date(fmt='%m-%d-%Y') }} data-max-date={{ dates['year'][1] | date(fmt='%m-%d-%Y') }}>
+        <label for="radio-4">This year</label>
+      </li>
+      <li>
+        <input id="radio-5" name="{{ name }}" type="radio">
+        <label for="radio-5">Custom</label>
+      </li>
+    </ul>
+    <div class="date-range-input">
+      <label for="min_{{ name }}">From</label>
+      <input type="text" id="min_{{ name }}" name="min_{{ name }}" class="js-min-date" data-inputmask="'alias': 'mm-dd-yyyy'">
+      <label for="max_{{ name }}">To</label>
+      <input type="text" id="max_{{ name }}" name="max_{{ name }}" class="js-max-date" data-inputmask="'alias': 'mm-dd-yyyy'">
+    </div>
+  </fieldset>
 </div>
 
 {% endmacro %}

--- a/templates/macros/filters/text.html
+++ b/templates/macros/filters/text.html
@@ -2,7 +2,7 @@
 <div class="filter" id="{{ name }}-field">
   <label class="label" for="{{ name }}">{{ title }}</label>
   <div class="input--removable">
-    <input type="text" name="{{ name }}"
+    <input id="{{ name }}" type="text" name="{{ name }}"
       {% for attr, value in attrs.items() %}
         {{ attr }}="{{ value }}"
       {% endfor %}

--- a/templates/macros/filters/typeahead-filter.html
+++ b/templates/macros/filters/typeahead-filter.html
@@ -2,7 +2,7 @@
 <div class="filter js-typeahead-filter" id="{{ name }}-field" data-dataset="{{ dataset }}">
   <label class="label" for="{{ name }}">{{ title }}</label>
   <ul class="dropdown__selected"></ul>
-  <input type="text" class="search-input--mini" name="{{ name }}" data-temp="_temp_{{ name }}">
+  <input id="{{ name }}" type="text" class="search-input--mini" name="{{ name }}" data-temp="_temp_{{ name }}">
   <input type="hidden" id="_temp_{{ name }}" />
 </div>
 {% endmacro %}

--- a/templates/macros/search.html
+++ b/templates/macros/search.html
@@ -4,7 +4,7 @@
 {% endif %}
 <form id="{{ location }}-search" action="/" autocomplete="off" class="search__container js-search">
   <div class="combo combo--search {{ size }}">
-    <select class="search__select js-search-type" name="search_type">
+    <select class="search__select js-search-type" name="search_type" aria-label="Select a search type">
       <option value="candidates"
         {% if result_type != 'committees' %}
           selected
@@ -17,11 +17,11 @@
       >Committees</option>
     </select>
     <input class="js-search-input combo__input tst-search-input" type="text" name="search"
-    aria-label="Search {{ result_type }}"
-    placeholder="Search {{ result_type }}" autocomplete="off"
+    aria-label="Search for {{ result_type }}"
+    placeholder="Search for {{ result_type }}" autocomplete="off"
     autocorrect="off" autocapitalize="off" spellcheck="false"
     value="{{ query or '' }}">
-    <button class="combo__button button--search tst-search-submit {{ button_color }}">
+    <button type="submit" class="combo__button button--search tst-search-submit {{ button_color }}">
       <span class="u-visually-hidden">Search</span>
     </button>
   </div>

--- a/templates/partials/elections/candidate-comparison-tab.html
+++ b/templates/partials/elections/candidate-comparison-tab.html
@@ -73,7 +73,7 @@
               <h3 class="results-info__title">Contributions by location</h3>
               <span class="t-block">The total amount of contributions from individuals received from each state.</span>
             </div>
-            <fieldset class="toggles toggles--small map-toggles" aria-label="Toggle view">
+            <div class="toggles toggles--small map-toggles" aria-label="Toggle view">
               <label for="toggle-table">
                 <input id="toggle-table" type="radio" class="panel-toggle-control" name="state-view" value="state-table" checked>
                 <span class="button--empty button--small button--table">Table</span>
@@ -82,7 +82,7 @@
                 <input id="toggle-map" type="radio" class="panel-toggle-control" name="state-view" value="state-maps">
                 <span class="button--empty button--small button--map">Map</span>
               </label>
-            </fieldset>
+            </div>
           </div>
           <div id="state-table">
             <table class="data-table scrollX panel-toggle-element" data-type="by-state" aria-hidden="false">

--- a/templates/partials/filters/filter-buttons.html
+++ b/templates/partials/filters/filter-buttons.html
@@ -1,4 +1,4 @@
 <div class="filter">
-  <button class="button--sm button--primary-contrast" type="button">Apply filters</button>
+  <button class="button--sm button--primary-contrast" type="submit">Apply filters</button>
   <button class="button--sm button--neutral js-clear-filters" type="button">Clear filters</button>
 </div>

--- a/templates/partials/filters/report-type.html
+++ b/templates/partials/filters/report-type.html
@@ -1,5 +1,8 @@
 {% import 'macros/filters/checkbox.html' as checkbox %}
 
+<input id="report_type-YE" name="report_type" type="checkbox" value="YE">
+<label for="report_type-YE">Year end</label>
+
 {{ checkbox.checkbox_dropdown(
   'report_type',
   'Monthly Reports',

--- a/templates/partials/hero.html
+++ b/templates/partials/hero.html
@@ -4,7 +4,7 @@
     <h1 id="hero-heading" class="t-display tst-page-title">Explore campaign finance data</h1>
     <h2 class="t-ruled">See how money is raised and spent in federal elections</h2>
     <div class="hero__content">
-      {{ search.search('hero') }}
+      {{ search.search('hero', 'candidates') }}
     </div>
     <script type="application/javascript">
       trackMetric('large_search_loaded', '#large-search .js-search_img');

--- a/templates/search.html
+++ b/templates/search.html
@@ -112,28 +112,30 @@
             </div>
             <div class="search-controls__or">or</div>
             <div class="row">
-              <span class="label">Find by state and district</span>
-              <div class="search-controls__state">
-                <select id="state" name="state" aria-label="Select a state">
-                  <option value="">Select state</option>
-                  {% for value, label in constants.states.items() %}
-                  <option value="{{ value }}">{{ label }}</option>
-                  {% endfor %}
-                </select>
-              </div>
-              <div class="search-controls__district">
-                <select id="district" name="district" aria-label="Select a district">
-                  <option value="">Select district</option>
-                  {% for value in range(1, 100) %}
-                  {% with formatted = '{0:02d}'.format(value) %}
-                  <option value="{{ formatted }}">{{ formatted }}</option>
-                  {% endwith %}
-                  {% endfor %}
-                </select>
-              </div>
-              <div class="search-controls__submit">
-                <button type="submit" class="button--search--text button--primary-contrast">Search</button>
-              </div>
+              <fieldset>
+                <legend class="label">Find by state and district</legend>
+                <div class="search-controls__state">
+                  <select id="state" name="state" aria-label="Select a state">
+                    <option value="">Select state</option>
+                    {% for value, label in constants.states.items() %}
+                    <option value="{{ value }}">{{ label }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+                <div class="search-controls__district">
+                  <select id="district" name="district" aria-label="Select a district">
+                    <option value="">Select district</option>
+                    {% for value in range(1, 100) %}
+                    {% with formatted = '{0:02d}'.format(value) %}
+                    <option value="{{ formatted }}">{{ formatted }}</option>
+                    {% endwith %}
+                    {% endfor %}
+                  </select>
+                </div>
+                <div class="search-controls__submit">
+                  <button type="submit" class="button--search--text button--primary-contrast">Search</button>
+                </div>
+              </fieldset>
             </div>
           </form>
         </div>


### PR DESCRIPTION
- Removes duplicate ID on the form-type filter by separating Year-End checkbox into it's own thing, instead of repeating it in three places
- Switches the page tabs to be toggled with tabbing instead of arrow keys
- Uses the accessibility helpers from https://github.com/18F/fec-style/pull/115 to improve tabbing on the glossary, details panel and filters
- Adds necessary form markup like fieldsets and legends where necessary

Addresses a lot of what was in here https://github.com/18F/openFEC-web-app/issues/755