### PR TITLE
Fixing candidate comparison order

### DIFF
--- a/static/templates/comparison.hbs
+++ b/static/templates/comparison.hbs
@@ -1,7 +1,7 @@
-<div class="row">
+<div class="content__section">
   <fieldset class="js-dropdown">
-  <legend class="label" for="candidate-list">Candidates to compare:</legend>
-    <ul class="dropdown__selected list--flat">
+  <legend class="label" for="candidate-list">Candidates to compare (listed by amount raised):</legend>
+    <ul class="dropdown__selected list--columns">
       {{#each this.selected}}
       <li class="dropdown__item">
         <input id="checkbox-{{ this.candidate_id }}" name="candidate-list" type="checkbox" data-id="{{this.candidate_id}}" data-name="{{this.candidate_name}}" checked>


### PR DESCRIPTION
I just realized I never put this patch in to add the text explaining that candidates on the eleciton comparison tool are ordered by amount raised.

And then with https://github.com/18F/fec-style/pull/120 they will be ordered in columns, instead of rows.

Also adds padding to the controls.

Resolves https://github.com/18F/openFEC-web-app/issues/649
Resolves https://github.com/18F/openFEC-web-app/issues/648
Resolve https://github.com/18F/fec-style/issues/84