### PR TITLE
Removes "is-individual" from links

### DIFF
--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -63,10 +63,7 @@ var committeeColumns = [
     orderable: false,
     orderSequence: ['desc', 'asc'],
     render: tables.buildTotalLink('/receipts', function(data, type, row, meta) {
-      return {
-        contributor_id: row.contributor_id,
-        is_individual: 'true'
-      };
+      return {contributor_id: row.contributor_id};
     })
   }
 ];

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -71,7 +71,7 @@
                 <li role="presentation" class="page-tabs__item"><a role="tab" data-name="summary" tabindex="0" aria-controls="panel1" aria-selected="true" href="#section-1">Financial summary</a></li>
                 <li role="presentation" class="page-tabs__item"><a role="tab" data-name="receipts" tabindex="0" aria-controls="panel2" href="#section-2">Receipts from individuals</a></li>
                 <li role="presentation" class="page-tabs__item"><a role="tab" data-name="disbursements" tabindex="0" aria-controls="panel3" href="#section-3">Disbursements</a></li>
-                <li role="presentation" class="page-tabs__item"><a role="tab" data-name="transfers" tabindex="0" aria-controls="panel4" href="#section-4">Between committees</a></li>
+                <li role="presentation" class="page-tabs__item"><a role="tab" data-name="between-committees" tabindex="0" aria-controls="panel4" href="#section-4">Between committees</a></li>
                 <li role="presentation" class="page-tabs__item"><a role="tab" data-name="filings" tabindex="0" aria-controls="panel5" href="#section-5">Filings</a></li>
               {% endif %}
             </ul>


### PR DESCRIPTION
This removes the "Unique only" flag from links from "Receipts from committees" aggregates. 

Also changes the URL parameter of this tab from "Transfers" to "Between committees".

Resolves https://github.com/18F/openFEC-web-app/issues/751