### PR TITLE
Add default text for aggregate labels.

### DIFF
--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -96,7 +96,7 @@ var stateColumns = [
 ];
 
 var employerColumns = [
-  {data: 'employer', className: 'all', orderable: false},
+  {data: 'employer', className: 'all', orderable: false, defaultContent: 'NOT REPORTED'},
   {
     data: 'total',
     className: 'all',
@@ -112,7 +112,7 @@ var employerColumns = [
 ];
 
 var occupationColumns = [
-  {data: 'occupation', className: 'all', orderable: false},
+  {data: 'occupation', className: 'all', orderable: false, defaultContent: 'NOT REPORTED'},
   {
     data: 'total',
     className: 'all',


### PR DESCRIPTION
This sets the default text for employer and occupation aggregates to "NOT REPORTED" (using all caps for consistency with the data).

h/t @jenniferthibault 