### PR TITLE
Improve behavior on loading tabs by permalink.

### DIFF
--- a/templates/candidates-single.html
+++ b/templates/candidates-single.html
@@ -70,7 +70,7 @@
       <div class="container">
         <nav class="page-tabs">
           <ul class="page-tabs__list" role="tablist" data-name="tab">
-            <li role="presentation" class="page-tabs__item"><a role="tab" data-name="summary" tabindex="0" aria-controls="panel1" aria-selected="true" href="#section-1">Financial summary</a></li>
+            <li role="presentation" class="page-tabs__item"><a role="tab" data-name="summary" tabindex="0" aria-controls="panel1" href="#section-1">Financial summary</a></li>
             <li role="presentation" class="page-tabs__item"><a role="tab" data-name="other-spending" tabindex="0" aria-controls="panel2" href="#section-2">Other spending</a></li>
           </ul>
         </nav>
@@ -78,6 +78,7 @@
     </div>
   </div>
 
+  {% include 'partials/loading-tab.html' %}
   {% include 'partials/candidate/financial-summary.html' %}
   {% include 'partials/candidate/other-spending-tab.html' %}
 </div>

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -68,7 +68,7 @@
           <nav class="page-tabs">
             <ul class="page-tabs__list" role="tablist" data-name="tab">
               {% if committee_type not in ['C', 'E'] %}
-                <li role="presentation" class="page-tabs__item"><a role="tab" data-name="summary" tabindex="0" aria-controls="panel1" aria-selected="true" href="#section-1">Financial summary</a></li>
+                <li role="presentation" class="page-tabs__item"><a role="tab" data-name="summary" tabindex="0" aria-controls="panel1" href="#section-1">Financial summary</a></li>
                 <li role="presentation" class="page-tabs__item"><a role="tab" data-name="receipts" tabindex="0" aria-controls="panel2" href="#section-2">Receipts from individuals</a></li>
                 <li role="presentation" class="page-tabs__item"><a role="tab" data-name="disbursements" tabindex="0" aria-controls="panel3" href="#section-3">Disbursements</a></li>
                 <li role="presentation" class="page-tabs__item"><a role="tab" data-name="between-committees" tabindex="0" aria-controls="panel4" href="#section-4">Between committees</a></li>
@@ -125,6 +125,7 @@
 
     {% with committee=context() %}
       {% if committee_type not in ['C', 'E'] %}
+        {% include 'partials/loading-tab.html' %}
         {% include 'partials/committee/financial-summary.html' %}
         {% include 'partials/committee/receipts-tab.html' %}
         {% include 'partials/committee/disbursements-tab.html' %}

--- a/templates/elections.html
+++ b/templates/elections.html
@@ -42,7 +42,7 @@
       <div class="container">
         <nav class="page-tabs">
           <ul class="page-tabs__list" role="tablist" data-name="tab">
-            <li role="presentation" class="page-tabs__item"><a role="tab" data-name="comparison" tabindex="0" aria-controls="panel1" aria-selected="true" href="#section-1">Candidate comparison</a></li>
+            <li role="presentation" class="page-tabs__item"><a role="tab" data-name="comparison" tabindex="0" aria-controls="panel1" href="#section-1">Candidate comparison</a></li>
             <li role="presentation" class="page-tabs__item"><a role="tab" data-name="spending" tabindex="0" aria-controls="panel2" href="#section-2">Other spending</a></li>
           </ul>
         </nav>
@@ -50,6 +50,7 @@
     </div>
   </div>
 
+  {% include 'partials/loading-tab.html' %}
   {% include 'partials/elections/candidate-comparison-tab.html' %}
   {% include 'partials/elections/other-spending-tab.html' %}
 </div>

--- a/templates/partials/candidate/financial-summary.html
+++ b/templates/partials/candidate/financial-summary.html
@@ -2,7 +2,7 @@
 {% import 'macros/cycle-select.html' as select %}
 {% import 'macros/null.html' as null %}
 
-<section class="main" id="section-1" role="tabpanel" aria-hidden="false" aria-labelledby="section-1-heading">
+<section class="main" id="section-1" role="tabpanel" aria-hidden="true" aria-labelledby="section-1-heading">
   <div class="container">
   <div class="content__section">
     <div class="section__heading">

--- a/templates/partials/committee/financial-summary.html
+++ b/templates/partials/committee/financial-summary.html
@@ -1,7 +1,7 @@
 {% import 'macros/missing.html' as missing %}
 {% import 'macros/cycle-select.html' as select %}
 
-<section class="main" id="section-1" role="tabpanel" aria-hidden="false" aria-labelledby="section-1-heading">
+<section class="main" id="section-1" role="tabpanel" aria-hidden="true" aria-labelledby="section-1-heading">
   <div class="container">
     <div class="content__section">
       <div class="section__heading">

--- a/templates/partials/elections/candidate-comparison-tab.html
+++ b/templates/partials/elections/candidate-comparison-tab.html
@@ -1,6 +1,6 @@
 {% import 'macros/cycle-select.html' as select %}
 
-<section class="main" id="section-1" role="tabpanel" aria-hidden="false" aria-labelledby="section-1-heading">
+<section class="main" id="section-1" role="tabpanel" aria-hidden="true" aria-labelledby="section-1-heading">
   <div class="container">
     <h2 class="content__section__heading" id="section-1-heading">
       Candidate comparison

--- a/templates/partials/loading-tab.html
+++ b/templates/partials/loading-tab.html
@@ -1,3 +1,5 @@
 <section class="main" id="section-0" role="tabpanel" aria-hidden="false">
-  <div class="overlay is-loading"></div>
+  <div class="container overlay__container">
+    <div class="overlay overlay--neutral is-loading"></div>
+  </div>
 </section>

--- a/templates/partials/loading-tab.html
+++ b/templates/partials/loading-tab.html
@@ -1,0 +1,3 @@
+<section class="main" id="section-0" role="tabpanel" aria-hidden="false">
+  <div class="overlay is-loading"></div>
+</section>


### PR DESCRIPTION
Hide all tabs initially, showing the selected tab after parsing the
query parameters. Needs style fixes from @noahmanger--see
`templates/partials/loading-tab.html`.

h/t @konklone