### PR TITLE
Feature/updating meta tags

### DIFF
--- a/templates/partials/meta-tags.html
+++ b/templates/partials/meta-tags.html
@@ -26,31 +26,31 @@
 <meta property="og:title" content="{{ title | trim }} - betaFEC" />
 <meta property="og:site_name" content="betaFEC" />
 <meta property="og:description" content="{{ description }}" />
-<meta property="og:image" content="{{ url_for('static', filename='img/beta-fec-fb.png') }}" />
+<meta property="og:image" content="{{ url_for('static', filename='img/beta-fec-fb.png', _external=True) }}" />
 
 <!-- Google
 ================================================== -->
-<link rel="canonical" href="">
+<link rel="canonical" href="https://beta.fec.gov/data">
 
 <!-- Favicons
 ================================================== -->
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="/static/img/favicon/apple-touch-icon-57x57.png" />
-<link rel="apple-touch-icon-precomposed" sizes="114x114" href="/static/img/favicon/apple-touch-icon-114x114.png" />
-<link rel="apple-touch-icon-precomposed" sizes="72x72" href="/static/img/favicon/apple-touch-icon-72x72.png" />
-<link rel="apple-touch-icon-precomposed" sizes="144x144" href="/static/img/favicon/apple-touch-icon-144x144.png" />
-<link rel="apple-touch-icon-precomposed" sizes="60x60" href="/static/img/favicon/apple-touch-icon-60x60.png" />
-<link rel="apple-touch-icon-precomposed" sizes="120x120" href="/static/img/favicon/apple-touch-icon-120x120.png" />
-<link rel="apple-touch-icon-precomposed" sizes="76x76" href="/static/img/favicon/apple-touch-icon-76x76.png" />
-<link rel="apple-touch-icon-precomposed" sizes="152x152" href="/static/img/favicon/apple-touch-icon-152x152.png" />
-<link rel="icon" type="image/png" href="/static/img/favicon/favicon-196x196.png" sizes="196x196" />
-<link rel="icon" type="image/png" href="/static/img/favicon/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/png" href="/static/img/favicon/favicon-32x32.png" sizes="32x32" />
-<link rel="icon" type="image/png" href="/static/img/favicon/favicon-16x16.png" sizes="16x16" />
-<link rel="icon" type="image/png" href="/static/img/favicon/favicon-128.png" sizes="128x128" />
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ url_for('static', filename='img/favicon/apple-touch-icon-57x57.png') }}" />
+<link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ url_for('static', filename='img/favicon/apple-touch-icon-114x114') }}" />
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ url_for('static', filename='img/favicon/apple-touch-icon-72x72.png') }}" />
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ url_for('static', filename='img/favicon/apple-touch-icon-144x144.png') }}" />
+<link rel="apple-touch-icon-precomposed" sizes="60x60" href="{{ url_for('static', filename='img/favicon/apple-touch-icon-60x60.png') }}" />
+<link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{ url_for('static', filename='img/favicon/apple-touch-icon-120x120.png') }}" />
+<link rel="apple-touch-icon-precomposed" sizes="76x76" href="{{ url_for('static', filename='img/favicon/apple-touch-icon-76x76.png') }}" />
+<link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ url_for('static', filename='img/favicon/apple-touch-icon-152x152.png') }}" />
+<link rel="icon" type="image/png" href="{{ url_for('static', filename='/static/img/favicon/favicon-196x196.png') }}" sizes="196x196" />
+<link rel="icon" type="image/png" href="{{ url_for('static', filename='/static/img/favicon/favicon-96x96.png') }}" sizes="96x96" />
+<link rel="icon" type="image/png" href="{{ url_for('static', filename='/static/img/favicon/favicon-32x32.png') }}" sizes="32x32" />
+<link rel="icon" type="image/png" href="{{ url_for('static', filename='/static/img/favicon/favicon-16x16.png') }}" sizes="16x16" />
+<link rel="icon" type="image/png" href="{{ url_for('static', filename='/static/img/favicon/favicon-128.png') }}" sizes="128x128" />
 <meta name="application-name" content="&nbsp;"/>
 <meta name="msapplication-TileColor" content="#FFFFFF" />
-<meta name="msapplication-TileImage" content="mstile-144x144.png" />
-<meta name="msapplication-square70x70logo" content="mstile-70x70.png" />
-<meta name="msapplication-square150x150logo" content="mstile-150x150.png" />
-<meta name="msapplication-wide310x150logo" content="mstile-310x150.png" />
-<meta name="msapplication-square310x310logo" content="mstile-310x310.png" />
+<meta name="msapplication-TileImage" href="{{ url_for('static', filename='/static/img/favicon/mstile-144x144.png') }}" />
+<meta name="msapplication-square70x70logo" href="{{ url_for('static', filename='/static/img/favicon/mstile-70x70.png') }}" />
+<meta name="msapplication-square150x150logo" href="{{ url_for('static', filename='/static/img/favicon/mstile-150x150.png') }}" />
+<meta name="msapplication-wide310x150logo" href="{{ url_for('static', filename='/static/img/favicon/mstile-310x150.png') }}" />
+<meta name="msapplication-square310x310logo" href="{{ url_for('static', filename='/static/img/favicon/mstile-310x310.png') }}" />

--- a/templates/partials/meta-tags.html
+++ b/templates/partials/meta-tags.html
@@ -15,8 +15,6 @@
 <!-- Twitter
 ================================================== -->
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:site" content="@18F">
-<meta name="twitter:creator" content="@18F">
 <meta name="twitter:title" content="{{ title | trim }} - betaFEC">
 <meta name="twitter:description" content="{{ description }}">
 <meta name="twitter:image" content="{{ url_for('static', filename='img/beta-fec-tw.png', _external=True) }}">

--- a/templates/search.html
+++ b/templates/search.html
@@ -3,7 +3,7 @@
 {% set hide_header_search = true %}
 
 {% block title %}
-    Campaign Finance Data
+    Campaign finance data
 {% endblock %}
 
 {% block body %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -3,7 +3,7 @@
 {% set hide_header_search = true %}
 
 {% block title %}
-    Home
+    Campaign Finance Data
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
- Removes references to 18F in the Twitter cards
- Replaces hard-coded URL's with template tags
- Changes the title of the web-app home page to "Campaign finance data" instead of "Home"