### PR TITLE
Adding other spending explanations

### DIFF
--- a/templates/macros/disclaimer.html
+++ b/templates/macros/disclaimer.html
@@ -1,4 +1,6 @@
 {% macro disclaimer(type, id, cycle) %}
-  <p class="text--note usa-width-three-fourths">Note: These totals are summed based on free text input as reported by this committee. Variations in spelling or abbreviation will produce multiple totals for the same category. For the most complete information, 
-  <a href="{{ url_for(type, committee_id=id, cycle=cycle) }}">click here to view the list of itemized transactions. &raquo;</a></p>
+  <div class="datatable__note">
+    <p class="t-note">Note: These totals are summed based on free text input as reported by this committee. Variations in spelling or abbreviation will produce multiple totals for the same category. For the most complete information, 
+    <a href="{{ url_for(type, committee_id=id, cycle=cycle) }}">click here to view the list of itemized transactions. &raquo;</a></p>
+  </div>
 {% endmacro %}

--- a/templates/partials/candidate/other-spending-tab.html
+++ b/templates/partials/candidate/other-spending-tab.html
@@ -22,6 +22,7 @@
           </tr>
         </thead>
       </table>
+      <p class="text--note usa-width-three-fourths">Note: These totals are drawn from quarterly, monthly and semi-annual reports. 24-hour and 48-hour independent expenditures reports are not included.</p>
     </div>
   </div>
 </section>

--- a/templates/partials/candidate/other-spending-tab.html
+++ b/templates/partials/candidate/other-spending-tab.html
@@ -22,7 +22,9 @@
           </tr>
         </thead>
       </table>
-      <p class="text--note usa-width-three-fourths">Note: These totals are drawn from quarterly, monthly and semi-annual reports. 24-hour and 48-hour independent expenditures reports are not included.</p>
+      <div class="datatable__note">
+        <p class="t-note">Note: These totals are drawn from quarterly, monthly and semi-annual reports. 24-hour and 48-hour independent expenditures reports are not included.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/partials/elections/other-spending-tab.html
+++ b/templates/partials/elections/other-spending-tab.html
@@ -21,6 +21,9 @@
           <th scope="col">Candidate</th>
         </thead>
       </table>
+      <div class="datatable__note">
+        <p class="t-note">Note: These totals are drawn from quarterly, monthly and semi-annual reports. 24-hour and 48-hour independent expenditures reports are not included.</p>
+      </div>
     </div>
 
     <div class="content__section--extra">

--- a/templates/partials/elections/other-spending-tab.html
+++ b/templates/partials/elections/other-spending-tab.html
@@ -11,7 +11,7 @@
 
     <div class="content__section">
       <div class="results-info results-info--simple">
-        <h3 class="results-info__title">Independent expenditures</h3>
+        <h3 class="results-info__title"><span class="term" data-term="independent expenditure">Independent expenditures</span></h3>
       </div>
       <table class="data-table scrollX" data-type="independent-expenditures">
         <thead>
@@ -25,7 +25,7 @@
 
     <div class="content__section--extra">
       <div class="results-info results-info--simple">
-        <h3 class="results-info__title">Communication costs</h3>
+        <h3 class="results-info__title"><span class="term" data-term="communication cost">Communication costs</span></h3>
       </div>
       <table class="data-table scrollX" data-type="communication-costs">
         <thead>
@@ -39,7 +39,7 @@
 
     <div class="content__section">
       <div class="results-info results-info--simple">
-        <h3 class="results-info__title">Electioneering</h3>
+        <h3 class="results-info__title"><span class="term" data-term="electioneering communication">Electioneering</span></h3>
       </div>
       <table class="data-table scrollX" data-type="electioneering">
         <thead>


### PR DESCRIPTION
- On election pages: Adds links to the glossary terms for the other spending table
- On the candidate and election pages: Adds a note explaining what reports are included in the independent expenditures table
- Adds some padding to the disclaimers below tables

Resolves https://github.com/18F/openFEC-web-app/issues/573