### PR TITLE
Feature/updating filings panel

### DIFF
--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -30,7 +30,7 @@ var supportOpposeColumn = {
 
 var amendmentIndicatorColumn = {
   data: 'amendment_indicator',
-  className: 'min-desktop',
+  className: 'hide-panel min-desktop',
   render: function(data) {
     return decoders.amendments[data] || '';
   },

--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -5,6 +5,7 @@
 var URI = require('URIjs');
 var _ = require('underscore');
 var moment = require('moment');
+var decoders = require('./decoders');
 var Handlebars = require('hbsfy/runtime');
 
 var intl = require('intl');
@@ -24,7 +25,21 @@ function datetime(value) {
   var parsed = moment(value, 'YYYY-MM-DDTHH:mm:ss');
   return parsed.isValid() ? parsed.format('MM-DD-YYYY') : null;
 }
+
+function prettyDatetime(value) {
+  var parsed = moment(value, 'YYYY-MM-DDTHH:mm:ss');
+  return parsed.isValid() ? parsed.format('MMM D, YYYY') : null;
+}
+
+function amendmentDecoder(value) {
+  return decoders.amendments[value];
+}
+
 Handlebars.registerHelper('datetime', datetime);
+
+Handlebars.registerHelper('amendmentDecoder', amendmentDecoder);
+
+Handlebars.registerHelper('prettyDatetime', prettyDatetime);
 
 Handlebars.registerHelper('basePath', BASE_PATH);
 
@@ -63,6 +78,8 @@ function buildUrl(path, query) {
 module.exports = {
   currency: currency,
   datetime: datetime,
+  prettyDatetime: prettyDatetime,
+  amendmentDecoder: amendmentDecoder,
   cycleDates: cycleDates,
   filterNull: filterNull,
   buildAppUrl: buildAppUrl,

--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -21,25 +21,19 @@ function currency(value) {
 }
 Handlebars.registerHelper('currency', currency);
 
-function datetime(value) {
+function datetime(value, pretty) {
+  var format = pretty ? 'MMM D, YYYY' : 'MM-DD-YYYY';
   var parsed = moment(value, 'YYYY-MM-DDTHH:mm:ss');
-  return parsed.isValid() ? parsed.format('MM-DD-YYYY') : null;
+  return parsed.isValid() ? parsed.format(format) : null;
 }
 
-function prettyDatetime(value) {
-  var parsed = moment(value, 'YYYY-MM-DDTHH:mm:ss');
-  return parsed.isValid() ? parsed.format('MMM D, YYYY') : null;
-}
-
-function amendmentDecoder(value) {
+function decodeAmendment(value) {
   return decoders.amendments[value];
 }
 
 Handlebars.registerHelper('datetime', datetime);
 
-Handlebars.registerHelper('amendmentDecoder', amendmentDecoder);
-
-Handlebars.registerHelper('prettyDatetime', prettyDatetime);
+Handlebars.registerHelper('decodeAmendment', decodeAmendment);
 
 Handlebars.registerHelper('basePath', BASE_PATH);
 
@@ -78,8 +72,7 @@ function buildUrl(path, query) {
 module.exports = {
   currency: currency,
   datetime: datetime,
-  prettyDatetime: prettyDatetime,
-  amendmentDecoder: amendmentDecoder,
+  decodeAmendment: decodeAmendment,
   cycleDates: cycleDates,
   filterNull: filterNull,
   buildAppUrl: buildAppUrl,

--- a/static/templates/candidates.hbs
+++ b/static/templates/candidates.hbs
@@ -5,30 +5,30 @@
   <table>
     <tr>
       <td class="panel__term">Office</td>
-      <td>{{office_full}}</td>
+      <td class="panel__data">{{office_full}}</td>
     </tr>
     <tr>
       <td class="panel__term">Election years</td>
-      <td>{{election_years}}</td>
+      <td class="panel__data">{{election_years}}</td>
     </tr>
     <tr>
       <td class="panel__term">Political party</td>
-      <td>{{party_full}}</td>
+      <td class="panel__data">{{party_full}}</td>
     </tr>
     <tr>
       <td class="panel__term">Status</td>
-      <td>{{incumbent_challenge_full}}</td>
+      <td class="panel__data">{{incumbent_challenge_full}}</td>
     </tr>
     {{#if state}}
     <tr>
       <td class="panel__term">State</td>
-      <td>{{state}}</td>
+      <td class="panel__data">{{state}}</td>
     </tr>
     {{/if}}
     {{#if district}}
     <tr>
       <td class="panel__term">District</td>
-      <td>{{district}}</td>
+      <td class="panel__data">{{district}}</td>
     </tr>
     {{/if}}
   </table>

--- a/static/templates/committees.hbs
+++ b/static/templates/committees.hbs
@@ -5,29 +5,29 @@
   <table>
     <tr>
       <td class="panel__term">Designation</td>
-      <td>{{designation_full}}</td>
+      <td class="panel__data">{{designation_full}}</td>
     </tr>
     <tr>
       <td class="panel__term">Type</td>
-      <td>{{committee_type_full}}</td>
+      <td class="panel__data">{{committee_type_full}}</td>
     </tr>
     <tr>
       <td class="panel__term">Political Party</td>
-      <td>{{party_full}}</td>
+      <td class="panel__data">{{party_full}}</td>
     </tr>
     {{#if organization_type_full}}
     <tr>
       <td class="panel__term">Organization Type</td>
-      <td>{{organization_type_full}}</td>
+      <td class="panel__data">{{organization_type_full}}</td>
     </tr>
     {{/if}}
     <tr>
       <td class="panel__term">Treasurer</td>
-      <td>{{treasurer_name}}</td>
+      <td class="panel__data">{{treasurer_name}}</td>
     </tr>
     <tr>
       <td class="panel__term">State</td>
-      <td>{{state}}</td>
+      <td class="panel__data">{{state}}</td>
     </tr>
   </table>
 </div>

--- a/static/templates/disbursements.hbs
+++ b/static/templates/disbursements.hbs
@@ -4,14 +4,14 @@
     <tr>
       <td class="panel__term">Recipient name</td>
       {{#if recipient}}
-        <td><a href="{{basePath}}/committee/{{recipient.committee_id}}">{{recipient.name}}</a></td>
+        <td class="panel__data"><a href="{{basePath}}/committee/{{recipient.committee_id}}">{{recipient.name}}</a></td>
       {{else}}
-        <td>{{recipient_name}}</td>
+        <td class="panel__data">{{recipient_name}}</td>
       {{/if}}
     </tr>
     <tr>
       <td class="panel__term">Recipient city and state</td>
-      <td>{{ recipient_city }}, {{ recipient_state }}, {{ recipient_zip }}</td>
+      <td class="panel__data">{{ recipient_city }}, {{ recipient_state }}, {{ recipient_zip }}</td>
     </tr>
   </table>
 </div>
@@ -21,32 +21,32 @@
   <table>
     <tr>
       <td class="panel__term">Amount</td>
-      <td>{{{ currency disbursement_amount }}}</td>
+      <td class="panel__data">{{{ currency disbursement_amount }}}</td>
     </tr>
     <tr>
       <td class="panel__term">Disbursement date</td>
-      <td>{{{ datetime disbursement_date }}}</td>
+      <td class="panel__data">{{{ datetime disbursement_date }}}</td>
     </tr>
     <tr>
       <td class="panel__term">Filing date</td>
-      <td>{{{ datetime receipt_date }}}</td>
+      <td class="panel__data">{{{ datetime receipt_date }}}</td>
     </tr>
     <tr>
       <td class="panel__term">Description</td>
-      <td>{{ disbursement_description }}</td>
+      <td class="panel__data">{{ disbursement_description }}</td>
     </tr>
     <tr>
       <td class="panel__term">Memo</td>
-      <td>{{ memo_text }}</td>
+      <td class="panel__data">{{ memo_text }}</td>
     </tr>
     <tr>
       <td class="panel__term">Memo code</td>
-      <td>{{ memoed_subtotal }}</td>
+      <td class="panel__data">{{ memoed_subtotal }}</td>
     </tr>
     {{#if election_type_full }}
     <tr>
       <td class="panel__term">Election type</td>
-      <td>{{ election_type_full }}</td>
+      <td class="panel__data">{{ election_type_full }}</td>
     </tr>
     {{/if}}
   </table>
@@ -63,25 +63,25 @@
   <table>
     <tr>
       <td class="panel__term">Name</td>
-      <td><a href="{{basePath}}/committee/{{committee_id}}">{{committee.name}}</a></td>
+      <td class="panel__data"><a href="{{basePath}}/committee/{{committee_id}}">{{committee.name}}</a></td>
     </tr>
     <tr>
       <td class="panel__term">Designation</td>
-      <td>{{committee.designation_full}}</a></td>
+      <td class="panel__data">{{committee.designation_full}}</a></td>
     </tr>
     {{#if committee.type}}
     <tr>
       <td class="panel__term">Type</td>
-      <td>{{committee.type_full}}</a></td>
+      <td class="panel__data">{{committee.type_full}}</a></td>
     </tr>
     {{/if}}
     <tr>
       <td class="panel__term">Treasurer</td>
-      <td>{{committee.treasurer_name}}</a></td>
+      <td class="panel__data">{{committee.treasurer_name}}</a></td>
     </tr>
     <tr>
       <td class="panel__term">Committee city and state</td>
-      <td>{{ committee.city }}, {{ committee.state }}, {{ committee.zip }}</td>
+      <td class="panel__data">{{ committee.city }}, {{ committee.state }}, {{ committee.zip }}</td>
     </tr>
   </table>
 </div>

--- a/static/templates/filings/candidate.hbs
+++ b/static/templates/filings/candidate.hbs
@@ -1,8 +1,24 @@
 <div class="panel__row">
   <div class="panel__heading">
-    <h4 class="panel__title">{{document_description}}</h4>
-    <span class="panel__subtitle">Report coverage: {{datetime coverage_start_date}} - {{datetime coverage_end_date}}</h5>
+    <h4 class="panel__title">{{document_description}} report</h4>
+    <span class="panel__subtitle t-bold"><a href="{{basePath}}/committee/{{committee_id}}">{{ committee_name }}</a></span>
   </div>
+  <table>
+    <tr>
+      <td class="panel__term" scope="row">Report coverage</td>
+      <td>{{prettyDatetime coverage_start_date}} - {{prettyDatetime coverage_end_date}}</td>
+    </tr>
+    <tr>
+      <td class="panel__term" scope="row">Receipt date</td>
+      <td>{{ prettyDatetime receipt_date }}</td>
+    </tr>
+    <tr>
+      <td class="panel__term" scope="row">Amendment indicator</td>
+      <td>{{ amendmentDecoder amendment_indicator }}</td>
+    </tr>
+  </table>
+</div>
+<div class="panel__row">
   <table>
     <tr>
       <td class="panel__term">Total receipts</td>

--- a/static/templates/filings/candidate.hbs
+++ b/static/templates/filings/candidate.hbs
@@ -6,15 +6,15 @@
   <table>
     <tr>
       <td class="panel__term" scope="row">Report coverage</td>
-      <td>{{prettyDatetime coverage_start_date}} - {{prettyDatetime coverage_end_date}}</td>
+      <td class="panel__data">{{prettyDatetime coverage_start_date}} - {{prettyDatetime coverage_end_date}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Receipt date</td>
-      <td>{{ prettyDatetime receipt_date }}</td>
+      <td class="panel__data">{{ prettyDatetime receipt_date }}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Amendment indicator</td>
-      <td>{{ amendmentDecoder amendment_indicator }}</td>
+      <td class="panel__data">{{ amendmentDecoder amendment_indicator }}</td>
     </tr>
   </table>
 </div>
@@ -22,51 +22,51 @@
   <table>
     <tr>
       <td class="panel__term">Total receipts</td>
-      <td>{{{currency total_receipts_period}}}</td>
+      <td class="panel__data">{{{currency total_receipts_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term">Total disbursements</td>
-      <td>{{{currency total_disbursements_period}}}</td>
+      <td class="panel__data">{{{currency total_disbursements_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term">Transfers to authorized committees</td>
-      <td>{{{currency transfers_to_other_authorized_committee_period}}}</td>
+      <td class="panel__data">{{{currency transfers_to_other_authorized_committee_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term">Individual contributions</td>
-      <td>{{{currency total_individual_contributions_period}}}</td>
+      <td class="panel__data">{{{currency total_individual_contributions_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term">Itemized individual contributions</td>
-      <td>{{{currency individual_itemized_contributions_period}}}</td>
+      <td class="panel__data">{{{currency individual_itemized_contributions_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term">Unitemized individual contributions</td>
-      <td>{{{currency individual_unitemized_contributions_period}}}</td>
+      <td class="panel__data">{{{currency individual_unitemized_contributions_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term">Loan repayments</td>
-      <td>{{{currency total_loan_repayments_made_period}}}</td>
+      <td class="panel__data">{{{currency total_loan_repayments_made_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term">Beginning cash on hand</td>
-      <td>{{{currency cash_on_hand_beginning_period}}}</td>
+      <td class="panel__data">{{{currency cash_on_hand_beginning_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term">Ending cash on hand</td>
-      <td>{{{currency cash_on_hand_end_period}}}</td>
+      <td class="panel__data">{{{currency cash_on_hand_end_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term">Net contributions</td>
-      <td>{{{currency net_contributions_period}}}</td>
+      <td class="panel__data">{{{currency net_contributions_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term">Net operating expenditures</td>
-      <td>{{{currency net_operating_expenditures_period}}}</td>
+      <td class="panel__data">{{{currency net_operating_expenditures_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term">Debts owed by committee</td>
-      <td>{{{currency debts_owed_by_committee}}}</td>
+      <td class="panel__data">{{{currency debts_owed_by_committee}}}</td>
     </tr>
   </table>
 </div>

--- a/static/templates/filings/candidate.hbs
+++ b/static/templates/filings/candidate.hbs
@@ -6,15 +6,15 @@
   <table>
     <tr>
       <td class="panel__term" scope="row">Report coverage</td>
-      <td class="panel__data">{{prettyDatetime coverage_start_date}} - {{prettyDatetime coverage_end_date}}</td>
+      <td class="panel__data">{{datetime coverage_start_date pretty=true}} - {{datetime coverage_end_date pretty=true}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Receipt date</td>
-      <td class="panel__data">{{ prettyDatetime receipt_date }}</td>
+      <td class="panel__data">{{ datetime receipt_date pretty=true }}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Amendment indicator</td>
-      <td class="panel__data">{{ amendmentDecoder amendment_indicator }}</td>
+      <td class="panel__data">{{ decodeAmendment amendment_indicator }}</td>
     </tr>
   </table>
 </div>

--- a/static/templates/filings/pac.hbs
+++ b/static/templates/filings/pac.hbs
@@ -6,15 +6,15 @@
   <table>
     <tr>
       <td class="panel__term" scope="row">Report coverage</td>
-      <td>{{prettyDatetime coverage_start_date}} - {{prettyDatetime coverage_end_date}}</td>
+      <td class="panel__data">{{prettyDatetime coverage_start_date}} - {{prettyDatetime coverage_end_date}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Receipt date</td>
-      <td>{{ prettyDatetime receipt_date }}</td>
+      <td class="panel__data">{{ prettyDatetime receipt_date }}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Amendment indicator</td>
-      <td>{{ amendmentDecoder amendment_indicator }}</td>
+      <td class="panel__data">{{ amendmentDecoder amendment_indicator }}</td>
     </tr>
   </table>
 </div>
@@ -22,43 +22,43 @@
   <table>
     <tr>
       <td class="panel__term" scope="row">Total receipts</td>
-      <td>{{{currency total_receipts_period}}}</td>
+      <td class="panel__data">{{{currency total_receipts_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Total disbursements</td>
-      <td>{{{currency total_disbursements_period}}}</td>
+      <td class="panel__data">{{{currency total_disbursements_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Individual contributions</td>
-      <td>{{{currency total_individual_contributions_period}}}</td>
+      <td class="panel__data">{{{currency total_individual_contributions_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Itemized individual contributions</td>
-      <td>{{{currency individual_itemized_contributions_period}}}</td>
+      <td class="panel__data">{{{currency individual_itemized_contributions_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Unitemized individual contributions</td>
-      <td>{{{currency individual_unitemized_contributions_period}}}</td>
+      <td class="panel__data">{{{currency individual_unitemized_contributions_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Beginning cash on hand</td>
-      <td>{{{currency cash_on_hand_beginning_period}}}</td>
+      <td class="panel__data">{{{currency cash_on_hand_beginning_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Ending cash on hand</td>
-      <td>{{{currency cash_on_hand_end_period}}}</td>
+      <td class="panel__data">{{{currency cash_on_hand_end_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Net contributions</td>
-      <td>{{{currency net_contributions_period}}}</td>
+      <td class="panel__data">{{{currency net_contributions_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Net operating expenditures</td>
-      <td>{{{currency net_operating_expenditures_period}}}</td>
+      <td class="panel__data">{{{currency net_operating_expenditures_period}}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Debts owed by committee</td>
-      <td>{{{currency debts_owed_by_committee}}}</td>
+      <td class="panel__data">{{{currency debts_owed_by_committee}}}</td>
     </tr>
   </table>
 </div>

--- a/static/templates/filings/pac.hbs
+++ b/static/templates/filings/pac.hbs
@@ -1,47 +1,63 @@
 <div class="panel__row">
   <div class="panel__heading">
-    <h4 class="panel__title">{{document_description}}</h4>
-    <span class="panel__subtitle">Report coverage: {{datetime coverage_start_date}} - {{datetime coverage_end_date}}</h5>
+    <h4 class="panel__title">{{document_description}} report</h4>
+    <span class="panel__subtitle t-bold"><a href="{{basePath}}/committee/{{committee_id}}">{{ committee_name }}</a></span>
   </div>
   <table>
     <tr>
-      <td class="panel__term">Total receipts</td>
+      <td class="panel__term" scope="row">Report coverage</td>
+      <td>{{prettyDatetime coverage_start_date}} - {{prettyDatetime coverage_end_date}}</td>
+    </tr>
+    <tr>
+      <td class="panel__term" scope="row">Receipt date</td>
+      <td>{{ prettyDatetime receipt_date }}</td>
+    </tr>
+    <tr>
+      <td class="panel__term" scope="row">Amendment indicator</td>
+      <td>{{ amendmentDecoder amendment_indicator }}</td>
+    </tr>
+  </table>
+</div>
+<div class="panel__row">
+  <table>
+    <tr>
+      <td class="panel__term" scope="row">Total receipts</td>
       <td>{{{currency total_receipts_period}}}</td>
     </tr>
     <tr>
-      <td class="panel__term">Total disbursements</td>
+      <td class="panel__term" scope="row">Total disbursements</td>
       <td>{{{currency total_disbursements_period}}}</td>
     </tr>
     <tr>
-      <td class="panel__term">Individual contributions</td>
+      <td class="panel__term" scope="row">Individual contributions</td>
       <td>{{{currency total_individual_contributions_period}}}</td>
     </tr>
     <tr>
-      <td class="panel__term">Itemized individual contributions</td>
+      <td class="panel__term" scope="row">Itemized individual contributions</td>
       <td>{{{currency individual_itemized_contributions_period}}}</td>
     </tr>
     <tr>
-      <td class="panel__term">Unitemized individual contributions</td>
+      <td class="panel__term" scope="row">Unitemized individual contributions</td>
       <td>{{{currency individual_unitemized_contributions_period}}}</td>
     </tr>
     <tr>
-      <td class="panel__term">Beginning cash on hand</td>
+      <td class="panel__term" scope="row">Beginning cash on hand</td>
       <td>{{{currency cash_on_hand_beginning_period}}}</td>
     </tr>
     <tr>
-      <td class="panel__term">Ending cash on hand</td>
+      <td class="panel__term" scope="row">Ending cash on hand</td>
       <td>{{{currency cash_on_hand_end_period}}}</td>
     </tr>
     <tr>
-      <td class="panel__term">Net contributions</td>
+      <td class="panel__term" scope="row">Net contributions</td>
       <td>{{{currency net_contributions_period}}}</td>
     </tr>
     <tr>
-      <td class="panel__term">Net operating expenditures</td>
+      <td class="panel__term" scope="row">Net operating expenditures</td>
       <td>{{{currency net_operating_expenditures_period}}}</td>
     </tr>
     <tr>
-      <td class="panel__term">Debts owed by committee</td>
+      <td class="panel__term" scope="row">Debts owed by committee</td>
       <td>{{{currency debts_owed_by_committee}}}</td>
     </tr>
   </table>

--- a/static/templates/filings/pac.hbs
+++ b/static/templates/filings/pac.hbs
@@ -6,15 +6,15 @@
   <table>
     <tr>
       <td class="panel__term" scope="row">Report coverage</td>
-      <td class="panel__data">{{prettyDatetime coverage_start_date}} - {{prettyDatetime coverage_end_date}}</td>
+      <td class="panel__data">{{datetime coverage_start_date pretty=true}} - {{datetime coverage_end_date pretty=true}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Receipt date</td>
-      <td class="panel__data">{{ prettyDatetime receipt_date }}</td>
+      <td class="panel__data">{{ datetime receipt_date pretty=true}}</td>
     </tr>
     <tr>
       <td class="panel__term" scope="row">Amendment indicator</td>
-      <td class="panel__data">{{ amendmentDecoder amendment_indicator }}</td>
+      <td class="panel__data">{{ decodeAmendment amendment_indicator }}</td>
     </tr>
   </table>
 </div>

--- a/static/templates/receipts.hbs
+++ b/static/templates/receipts.hbs
@@ -4,26 +4,26 @@
     <tr>
       <td class="panel__term">Name</td>
       {{#if contributor}}
-        <td><a href="{{basePath}}/committee/{{contributor.committee_id}}">{{contributor.name}}</a></td>
+        <td class="panel__data"><a href="{{basePath}}/committee/{{contributor.committee_id}}">{{contributor.name}}</a></td>
       {{else}}
-        <td>{{contributor_name}}</td>
+        <td class="panel__data">{{contributor_name}}</td>
       {{/if}}
     </tr>
     <tr>
       <td class="panel__term">City and state</td>
-      <td>{{ contributor_city }}, {{ contributor_state }}, {{ contributor_zip }}</td>
+      <td class="panel__data">{{ contributor_city }}, {{ contributor_state }}, {{ contributor_zip }}</td>
     </tr>
     <tr>
       <td class="panel__term">Occupation</td>
-      <td>{{ contributor_occupation }}</td>
+      <td class="panel__data">{{ contributor_occupation }}</td>
     </tr>
     <tr>
       <td class="panel__term">Employer</td>
-      <td>{{ contributor_employer }}</td>
+      <td class="panel__data">{{ contributor_employer }}</td>
     </tr>
     <tr>
       <td class="panel__term">Year to date</td>
-      <td>{{{ currency contributor_aggregate_ytd }}}</td>
+      <td class="panel__data">{{{ currency contributor_aggregate_ytd }}}</td>
     </tr>
   </table>
 </div>
@@ -33,23 +33,23 @@
   <table>
     <tr>
       <td class="panel__term">Amount</td>
-      <td>{{{ currency contribution_receipt_amount }}}</td>
+      <td class="panel__data">{{{ currency contribution_receipt_amount }}}</td>
     </tr>
     <tr>
       <td class="panel__term">Receipt date</td>
-      <td>{{{ datetime contribution_receipt_date }}}</td>
+      <td class="panel__data">{{{ datetime contribution_receipt_date }}}</td>
     </tr>
     <tr>
       <td class="panel__term">Filing date</td>
-      <td>{{{ datetime receipt_date }}}</td>
+      <td class="panel__data">{{{ datetime receipt_date }}}</td>
     </tr>
     <tr>
       <td class="panel__term">Memo</td>
-      <td>{{ memo_text }}</td>
+      <td class="panel__data">{{ memo_text }}</td>
     </tr>
     <tr>
       <td class="panel__term">Election type</td>
-      <td>{{ election_type_full }}</td>
+      <td class="panel__data">{{ election_type_full }}</td>
     </tr>
   </table>
 </div>
@@ -59,19 +59,19 @@
   <table>
     <tr>
       <td class="panel__term">Committee</td>
-      <td><a href="{{basePath}}/committee/{{ committee.committee_id }}/">{{ committee.name }}</a></td>
+      <td class="panel__data"><a href="{{basePath}}/committee/{{ committee.committee_id }}/">{{ committee.name }}</a></td>
     </tr>
     <tr>
       <td class="panel__term">Political party</td>
-      <td>{{ committee.party_full }}</td>
+      <td class="panel__data">{{ committee.party_full }}</td>
     </tr>
     <tr>
       <td class="panel__term">Type</td>
-      <td>{{ committee.committee_type_full }}</td>
+      <td class="panel__data">{{ committee.committee_type_full }}</td>
     </tr>
     <tr>
       <td class="panel__term">State</td>
-      <td>{{ committee.state_full }}</td>
+      <td class="panel__data">{{ committee.state_full }}</td>
     </tr>
   </table>
 </div>

--- a/templates/partials/committee/disbursements-tab.html
+++ b/templates/partials/committee/disbursements-tab.html
@@ -5,7 +5,7 @@
   <div class="container">
     <div class="section__heading">
       <h2 class="heading__title" id="section-2-heading">
-        Money Spent by this Committee
+        Money spent by this committee
         {{ select.cycle_select(cycles, cycle, id="cycle-3") }}
       </h2>
       <a class="heading__action button--neutral button--browse"

--- a/templates/partials/committee/disbursements-tab.html
+++ b/templates/partials/committee/disbursements-tab.html
@@ -4,6 +4,7 @@
 <section class="main" id="section-3" role="tabpanel" aria-hidden="true" aria-labelledby="section-3-heading">
   <div class="container">
     <div class="section__heading">
+      <h2 class="heading__title" id="section-2-heading">
         Money Spent by this Committee
         {{ select.cycle_select(cycles, cycle, id="cycle-3") }}
       </h2>

--- a/templates/partials/datatable-modal.html
+++ b/templates/partials/datatable-modal.html
@@ -1,7 +1,7 @@
 <div id="datatable-modal" class="panel__overlay" aria-hidden="true">
   <div class="panel">
     <div class="panel__row panel__navigation">
-      <a class="panel__link button--small button--neutral js-pdf_url">
+      <a class="panel__link button--small button--neutral js-pdf_url" target="_blank">
         View original image
       </a>
       <button class="js-hide js-panel-close panel__close button--small button"


### PR DESCRIPTION
Adds missing info to filings panels:
- Filer name
- Receipt date
- Amendment indicator

Also adds a more readable datetime helper. @emileighoutlaw what do you think about this format for dates in this situation: `Jan 1, 2015`? I think it makes sense to stick with `01-01-2015` format in the columns and in the filters, but if we're just displaying a date in a regular text area, I find the prettier version helpful.

Last, makes the pdf link a `target="_blank"` to make it consistent with the main url column in the table.

Resolves #789 and #778 

<img width="1042" alt="screen shot 2015-10-01 at 2 27 11 pm" src="https://cloud.githubusercontent.com/assets/1696495/10229920/88fb6ac4-6848-11e5-93a8-9d744fefedf1.png">
