### PR TITLE
Adding a statutory candidate check box

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -211,3 +211,10 @@ amendment_indicators_extended = OrderedDict([
 candidate_status = OrderedDict([
     ('C', 'Statutory candidate'),
 ])
+candidate_status_extended = OrderedDict([
+    ('C', 'Statutory candidate'),
+    ('F', 'Future candidate'),
+    ('N', 'Not yet a candidate'),
+    ('P', 'Statutory candidate in prior cycle'),
+
+])

--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -212,7 +212,6 @@ candidate_status = OrderedDict([
     ('C', 'Statutory candidate'),
 ])
 candidate_status_extended = OrderedDict([
-    ('C', 'Statutory candidate'),
     ('F', 'Future candidate'),
     ('N', 'Not yet a candidate'),
     ('P', 'Statutory candidate in prior cycle'),

--- a/templates/partials/filters/candidate_status.html
+++ b/templates/partials/filters/candidate_status.html
@@ -1,0 +1,7 @@
+{% import 'macros/filters/checkbox.html' as checkbox %}
+
+{{ checkbox.checkbox_dropdown(
+  'candidate_status',
+  'Candidates raising more than $5,000',
+  selected=constants.candidate_status,
+) }}

--- a/templates/partials/filters/candidate_status.html
+++ b/templates/partials/filters/candidate_status.html
@@ -4,4 +4,5 @@
   'candidate_status',
   'Candidates raising more than $5,000',
   selected=constants.candidate_status,
+  options=constants.candidate_status_extended,
 ) }}

--- a/templates/search.html
+++ b/templates/search.html
@@ -20,11 +20,11 @@
         <div class="card__content">
           <h2 class="card__title">Candidate data</h2>
           <ul class="card__links list--bulleted">
-            <li><a href="{{ url_for('candidates', cycle=2016, office='P') }}">All 2016 presidential candidates &raquo;</a></li>
-            <li><a href="{{ url_for('candidates', cycle=2016, office='S') }}">All 2016 Senate candidates &raquo;</a></li>
-            <li><a href="{{ url_for('candidates', cycle=2016, office='H') }}">All 2016 House candidates &raquo;</a></li>
+            <li><a href="{{ url_for('candidates', cycle=2016, office='P', candidate_status=['C', 'P', 'F']) }}">2016 presidential candidates &raquo;</a></li>
+            <li><a href="{{ url_for('candidates', cycle=2016, office='S', candidate_status=['C', 'P', 'F']) }}">2016 Senate candidates &raquo;</a></li>
+            <li><a href="{{ url_for('candidates', cycle=2016, office='H', candidate_status=['C', 'P', 'F']) }}">2016 House candidates &raquo;</a></li>
           </ul>
-          <a class="button--neutral button--browse" href="{{ url_for('candidates', cycle=default_cycles) }}">All candidate data</a>
+          <a class="button--neutral button--browse" href="{{ url_for('candidates', cycle=default_cycles, candidate_status=['C', 'P', 'F']) }}">Candidate data</a>
         </div>
       </div>
       <div class="card card--wide">


### PR DESCRIPTION
The statutory candidate data is much cleaner, so it makes a good default.

We can just add 'candidate_status=C' to all the links to that page. Is there a better way to handle that default?

I am simplifying this a bit, the full list of codes codes is:

C = Statutory candidate
F = Statutory candidate for future election
N = Not yet a statutory candidate
P = Statutory candidate in prior cycle