### PR TITLE
Customize linter configuration.

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+javascript:
+  config_file: .jshintrc

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,23 @@
+{
+  "asi": false,
+  "bitwise": true,
+  "browser": true,
+  "camelcase": true,
+  "curly": true,
+  "forin": true,
+  "immed": true,
+  "latedef": "nofunc",
+  "maxlen": 100,
+  "newcap": true,
+  "noarg": true,
+  "noempty": true,
+  "nonew": true,
+  "predef": [
+    "require",
+    "module"
+  ],
+  "quotmark": true,
+  "trailing": true,
+  "undef": true,
+  "unused": true
+}

--- a/static/js/init.js
+++ b/static/js/init.js
@@ -1,11 +1,10 @@
 'use strict';
 
-/* global require, window, document, BASE_PATH */
+/* global window, document, BASE_PATH */
 
 var KEYCODE_SLASH = 191;
 
 var $ = require('jquery');
-var _ = require('underscore');
 var keyboard = require('keyboardjs');
 
 // Hack: Append jQuery to `window` for use by legacy libraries


### PR DESCRIPTION
* Set longer max length.
* Update pre-defined globals.

This also reminds me: are we all using jshint locally? Consider this my passive-aggressive reminder to @LindsayYoung and @noahmanger to grab the sublime plugin if you don't already have it. And if you think the linter is being too strict, feel free to update .jshintrc.