### PR TITLE
Miscellaneous manifest updates.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -360,10 +360,6 @@ if config.force_https:
     sslify = SSLify(app, permanent=True, age=31536000, subdomains=True)
 
 
-if config.server_name:
-    app.config['SERVER_NAME'] = config.server_name
-
-
 if config.production:
     app.config['PREFERRED_URL_SCHEME'] = 'https'
 

--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -1,6 +1,8 @@
 ---
 path: .
 memory: 512M
+timeout: 180
+domain: 18f.gov
 stack: cflinuxfs2
 buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
 env:

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -16,7 +16,6 @@ env:
   NEW_RELIC_APP_NAME: OpenFEC Web (production)
   FEC_WEB_API_URL: https://api.open.fec.gov/
   FEC_CMS_URL: https://beta.fec.gov
-  FEC_WEB_SERVER_NAME: open.fec.gov
   FEC_WEB_GOOGLE_ANALYTICS: true
   FEC_FORCE_HTTPS: true
   FEC_WEB_CACHE: true

--- a/openfecwebapp/config.py
+++ b/openfecwebapp/config.py
@@ -8,7 +8,6 @@ host = os.getenv('FEC_WEB_HOST', '0.0.0.0')
 port = os.getenv('FEC_WEB_PORT', '3000')
 api_key = os.getenv('FEC_WEB_API_KEY', '')
 api_key_public = os.getenv('FEC_WEB_API_KEY_PUBLIC', '')
-server_name = os.getenv('FEC_WEB_SERVER_NAME')
 cache = os.getenv('FEC_WEB_CACHE')
 cache_size = int(os.getenv('FEC_WEB_CACHE_SIZE', 1000))
 

--- a/tasks.py
+++ b/tasks.py
@@ -84,10 +84,7 @@ def _detect_apps(blue, green):
 SPACE_URLS = {
     'dev': [('18f.gov', 'fec-dev-web')],
     'stage': [('18f.gov', 'fec-stage-web')],
-    'prod': [
-        ('18f.gov', 'fec-prod-web'),
-        ('open.fec.gov', None),
-    ],
+    'prod': [('18f.gov', 'fec-prod-web')],
 }
 
 


### PR DESCRIPTION
* Remove unnecessary `server_name` configuration (now set by proxy)
* Increase timeout (minification can be slow)
* Set default domain to 18f.gov
* Remove open.api.gov route