### PR TITLE
Rearranges elements on data landing page for testing

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -8,7 +8,84 @@
 
 {% block body %}
 {% include "partials/hero.html" %}
-<section class="main">
+<section class="main" style="padding-top: 0">
+  <div class="slab slab--neutral">
+    <div class="container">
+      <div id="election-preview" class="widget widget--neutral">
+        <div class="row">
+          <div class="icon-heading">
+            <img class="icon-heading__image" src="{{ url_for('static', filename='img/i-elections--primary.svg') }}" alt="Icon representing filings">
+            <h2 class="icon-heading__title widget__title"><span class="t-short">Find candidates running near you</span></h2>
+          </div>
+        </div>
+        <form action="{{ url_for('election_lookup') }}" class="widget__content">
+          <div class="row u-visually-hidden">
+            <label class="label" for="cycle-select">Choose an election cycle</label>
+            {{ select.cycle_select(cycles, location='form') }}
+          </div>
+          <div class="row">
+            <div class="row">
+              <label for="zip" class="label">Find by ZIP code</label>
+              <div class="search-controls__zip">
+                <input type="text" inputmode="numeric" id="zip" name="zip" placeholder="e.g. 10001">
+              </div>
+              <div class="search-controls__submit">
+                <button type="submit" class="button--search--text button--primary-contrast">Search</button>
+              </div>
+            </div>
+          </div>
+          <div class="search-controls__or">or</div>
+          <div class="row">
+            <fieldset>
+              <legend class="label">Find by state and district</legend>
+              <div class="search-controls__state">
+                <select id="state" name="state" aria-label="Select a state">
+                  <option value="">Select state</option>
+                  {% for value, label in constants.states.items() %}
+                  <option value="{{ value }}">{{ label }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+              <div class="search-controls__district">
+                <select id="district" name="district" aria-label="Select a district">
+                  <option value="">Select district</option>
+                  {% for value in range(1, 100) %}
+                  {% with formatted = '{0:02d}'.format(value) %}
+                  <option value="{{ formatted }}">{{ formatted }}</option>
+                  {% endwith %}
+                  {% endfor %}
+                </select>
+              </div>
+              <div class="search-controls__submit">
+                <button type="submit" class="button--search--text button--primary-contrast">Search</button>
+              </div>
+            </fieldset>
+          </div>
+        </form>
+      </div>
+
+      <div id="election-summary" class="widget widget--neutral">
+        <h2 class="widget__title"><span class="t-short">So far in the 2016 presidential election:</span></h2>
+        <div class="widget__content">
+          <div>
+            <h5 class="t-data-header">Funds raised</h5>
+            <span class="t-big-data js-receipts"></span>
+          </div>
+          <div>
+            <h5 class="t-data-header">Funds spent</h5>
+            <span class="t-big-data js-disbursements"></span>
+          </div>
+          <div>
+            <h5 class="t-data-header">Independent expenditures</h5>
+            <span class="t-big-data js-expenditures"></span>
+          </div>
+          <a class="button--election button--neutral js-election-url">Compare candidates in this election</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+<div class="content__section--extra">
   <div class="container">
     <h2 class="h1 t-no-rules">How to view the data</h2>
     <div class="row tiled-cards--2-wide">
@@ -84,83 +161,7 @@
       </div>
     </div>
   </div>
-  <div class="content__section--extra">
-    <div class="slab slab--neutral">
-      <div class="container">
-        <div id="election-preview" class="widget widget--neutral">
-          <div class="row">
-            <div class="icon-heading">
-              <img class="icon-heading__image" src="{{ url_for('static', filename='img/i-elections--primary.svg') }}" alt="Icon representing filings">
-              <h2 class="icon-heading__title widget__title"><span class="t-short">Find candidates running near you</span></h2>
-            </div>
-          </div>
-          <form action="{{ url_for('election_lookup') }}" class="widget__content">
-            <div class="row">
-              <label class="label" for="cycle-select">Choose an election cycle</label>
-              {{ select.cycle_select(cycles, location='form') }}
-            </div>
-            <div class="row">
-              <div class="row">
-                <label for="zip" class="label">Find by ZIP code</label>
-                <div class="search-controls__zip">
-                  <input type="text" inputmode="numeric" id="zip" name="zip" placeholder="e.g. 10001">
-                </div>
-                <div class="search-controls__submit">
-                  <button type="submit" class="button--search--text button--primary-contrast">Search</button>
-                </div>
-              </div>
-            </div>
-            <div class="search-controls__or">or</div>
-            <div class="row">
-              <fieldset>
-                <legend class="label">Find by state and district</legend>
-                <div class="search-controls__state">
-                  <select id="state" name="state" aria-label="Select a state">
-                    <option value="">Select state</option>
-                    {% for value, label in constants.states.items() %}
-                    <option value="{{ value }}">{{ label }}</option>
-                    {% endfor %}
-                  </select>
-                </div>
-                <div class="search-controls__district">
-                  <select id="district" name="district" aria-label="Select a district">
-                    <option value="">Select district</option>
-                    {% for value in range(1, 100) %}
-                    {% with formatted = '{0:02d}'.format(value) %}
-                    <option value="{{ formatted }}">{{ formatted }}</option>
-                    {% endwith %}
-                    {% endfor %}
-                  </select>
-                </div>
-                <div class="search-controls__submit">
-                  <button type="submit" class="button--search--text button--primary-contrast">Search</button>
-                </div>
-              </fieldset>
-            </div>
-          </form>
-        </div>
-
-        <div id="election-summary" class="widget widget--neutral">
-          <h2 class="widget__title"><span class="t-short">So far in the 2016 presidential election:</span></h2>
-          <div class="widget__content">
-            <div>
-              <h5 class="t-data-header">Funds raised</h5>
-              <span class="t-big-data js-receipts"></span>
-            </div>
-            <div>
-              <h5 class="t-data-header">Funds spent</h5>
-              <span class="t-big-data js-disbursements"></span>
-            </div>
-            <div>
-              <h5 class="t-data-header">Independent expenditures</h5>
-              <span class="t-big-data js-expenditures"></span>
-            </div>
-            <a class="button--election button--neutral js-election-url">Compare candidates in this election</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+</div>
 
   <div class="container">
     <div class="content__section--extra">


### PR DESCRIPTION
This is a quick and dirty re-arranging of the cards and election lookup tool on the data landing page to test it out for testing tomorrow. 

Includes an inline style because it wasn’t worth writing new css for a temporary change :)

Also visually hides the cycle select for now.