### PR TITLE
Feature/cycle tooltips

### DIFF
--- a/templates/candidates-single.html
+++ b/templates/candidates-single.html
@@ -1,4 +1,5 @@
 {% extends 'layouts/main.html' %}
+{% import 'macros/cycle-select.html' as select %}
 
 {% block title %}
     {{ name }} - Candidate overview
@@ -14,9 +15,14 @@
   </header>
   <header class="entity__header entity__header--neutral">
     <div class="container">
-      <div class="entity__header__top">
-        <h1 class="entity__name">{{ name }}</h1>
-        <span class="t-data entity__type">Candidate for {{ office_full }}</span><span class="t-data">ID: {{ candidate_id }}</span>
+      <div class="entity__header__top row">
+        <div class="usa-width-three-fourths">
+          <h1 class="entity__name">{{ name }}</h1>
+          <span class="t-data entity__type">Candidate for {{ office_full }}</span><span class="t-data">ID: {{ candidate_id }}</span>
+        </div>
+        <div class="usa-width-one-fourth">
+          {{ select.cycle_select(cycles, cycle, id="cycle-1") }}
+        </div>
       </div>
       <div class="entity__header__bottom">
         <ul class="entity__info">

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -1,5 +1,6 @@
 {% extends 'layouts/main.html' %}
 {% import 'macros/null.html' as null %}
+{% import 'macros/cycle-select.html' as select %}
 
 {% block title %}
     {{ name }} - Committee overview
@@ -14,13 +15,18 @@
     </header>
     <header class="entity__header entity__header--primary">
       <div class="container">
-        <div class="entity__header__top">
+        <div class="entity__header__top row">
+          <div class="usa-width-three-fourths">
             <h1 class="entity__name">{{ name }}</h1>
             <span class="t-data entity__type">
               {{ committee_type_full }}
                - {{ designation_full }}
                {% if organization %} - {{ organization }}{% endif %}
             </span><span class="t-data">ID: {{ committee_id }}</span>
+          </div>
+          <div class="usa-width-one-fourth">
+            {{ select.cycle_select(cycles, cycle) }}
+          </div>
         </div>
         <div class="entity__header__bottom">
           <ul class="entity__info">

--- a/templates/election-lookup.html
+++ b/templates/election-lookup.html
@@ -15,7 +15,7 @@
       <form>
         <div class="search-controls__row">
           <label class="label" for="cycle-select">Choose an election cycle</label>
-          {{ select.cycle_select(cycles, location='form') }}
+          {{ select.cycle_select(cycles, location='form', tooltip='false') }}
         </div>
         <div class="search-controls__row">
           <div class="search-controls__either">

--- a/templates/election-lookup.html
+++ b/templates/election-lookup.html
@@ -15,7 +15,7 @@
       <form>
         <div class="search-controls__row">
           <label class="label" for="cycle-select">Choose an election cycle</label>
-          {{ select.cycle_select(cycles, location='form', tooltip='false') }}
+          {{ select.cycle_select(cycles, location='form', tooltip=False) }}
         </div>
         <div class="search-controls__row">
           <div class="search-controls__either">

--- a/templates/macros/cycle-select.html
+++ b/templates/macros/cycle-select.html
@@ -1,15 +1,15 @@
 {% macro cycle_select(cycles, cycle=none, location='query', id='cycle-select', tooltip='true') %}
 {% if cycles %}
-  {% if tooltip %}
-    <label for="{{ id }}" class="tooltip-trigger">Two-year period</label>
-    <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under">
-      <div class="tooltip__content">
-        <p>This site groups data in two-year periods— if a candidate or committee has been active more than two years, this page won't show all their data. We're working on a four-year view for presidential data and a six-year view for Senate data. But we need your feedback.</p>
-        <p>See the <a href="https://github.com/18f/fec/issues" target="_blank">latest designs on GitHub</a>, and let us know what you think. You can also leave comments using the feedback button at the bottom of this page.</p>
+  {% if tooltip == 'true' %}
+    <div class="tooltip__container">
+      <label for="{{ id }}" class="label tooltip__trigger">View data for:</label>
+      <div role="tooltip" class="tooltip tooltip--under">
+        <p class="tooltip__content">This site groups data in two-year periods — if a candidate or committee has been active more than two years, this page won't show all their data.</p>
+        <p class="tooltip__content">We're currently working to create additional views, but we need your help. See the <a href="https://github.com/18f/fec/issues" target="_blank">latest designs on GitHub</a>, and let us know what you think. You can also leave comments using the feedback button at the bottom of this page.</p>
       </div>
     </div>
   {% endif %}
-  <select id="{{ id }}" class="cycle-select select--neutral js-cycle" aria-label="Two-Year Period" name="cycle" data-cycle-location="{{ location }}">
+  <select id="{{ id }}" class="cycle-select select--neutral js-cycle" name="cycle" data-cycle-location="{{ location }}">
   {% for each in cycles | restrict_cycles | sort(reverse=True) %}
     <option
         value="{{ each }}"

--- a/templates/macros/cycle-select.html
+++ b/templates/macros/cycle-select.html
@@ -5,7 +5,7 @@
       <label for="{{ id }}" class="label tooltip__trigger">View data for:</label>
       <div role="tooltip" class="tooltip tooltip--under">
         <p class="tooltip__content">This site groups data in two-year periods — if a candidate or committee has been active more than two years, this page won't show all their data.</p>
-        <p class="tooltip__content">We're currently working to create additional views, but we need your help. See the <a href="https://github.com/18f/fec/issues" target="_blank">latest designs on GitHub</a>, and let us know what you think. You can also leave comments using the feedback button at the bottom of this page.</p>
+        <p class="tooltip__content">We're currently working to create additional views, but we need your help. See the <a href="https://github.com/18f/fec/issues/71" target="_blank">latest designs on GitHub</a>, and let us know what you think. You can also leave comments using the feedback button at the bottom of this page.</p>
       </div>
     </div>
   {% endif %}

--- a/templates/macros/cycle-select.html
+++ b/templates/macros/cycle-select.html
@@ -1,5 +1,14 @@
-{% macro cycle_select(cycles, cycle=none, location='query', id='cycle-select') %}
+{% macro cycle_select(cycles, cycle=none, location='query', id='cycle-select', tooltip='true') %}
 {% if cycles %}
+  {% if tooltip %}
+    <label for="{{ id }}" class="tooltip-trigger">Two-year period</label>
+    <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under">
+      <div class="tooltip__content">
+        <p>This site groups data in two-year periods— if a candidate or committee has been active more than two years, this page won't show all their data. We're working on a four-year view for presidential data and a six-year view for Senate data. But we need your feedback.</p>
+        <p>See the <a href="https://github.com/18f/fec/issues" target="_blank">latest designs on GitHub</a>, and let us know what you think. You can also leave comments using the feedback button at the bottom of this page.</p>
+      </div>
+    </div>
+  {% endif %}
   <select id="{{ id }}" class="cycle-select select--neutral js-cycle" aria-label="Two-Year Period" name="cycle" data-cycle-location="{{ location }}">
   {% for each in cycles | restrict_cycles | sort(reverse=True) %}
     <option

--- a/templates/macros/cycle-select.html
+++ b/templates/macros/cycle-select.html
@@ -1,6 +1,6 @@
-{% macro cycle_select(cycles, cycle=none, location='query', id='cycle-select', tooltip='true') %}
+{% macro cycle_select(cycles, cycle=none, location='query', id='cycle-select', tooltip=True) %}
 {% if cycles %}
-  {% if tooltip == 'true' %}
+  {% if tooltip %}
     <div class="tooltip__container">
       <label for="{{ id }}" class="label tooltip__trigger">View data for:</label>
       <div role="tooltip" class="tooltip tooltip--under">

--- a/templates/partials/candidate/financial-summary.html
+++ b/templates/partials/candidate/financial-summary.html
@@ -1,5 +1,4 @@
 {% import 'macros/missing.html' as missing %}
-{% import 'macros/cycle-select.html' as select %}
 {% import 'macros/null.html' as null %}
 
 <section class="main" id="section-1" role="tabpanel" aria-hidden="true" aria-labelledby="section-1-heading">
@@ -9,9 +8,6 @@
       <h2 class="heading__title">
         Financial summary
       </h2>
-      <div class="heading__cycle">
-        {{ select.cycle_select(cycles, cycle, id="cycle-1") }}
-      </div>
     </div>
     <p class="usa-width-two-thirds">Candidates receive and spend money through committees. These are the <strong>combined financial totals</strong> for all of this candidate's authorized committees. You can learn more about each committee's fundraising and spending on its page.</p>
   </div>

--- a/templates/partials/candidate/financial-summary.html
+++ b/templates/partials/candidate/financial-summary.html
@@ -8,8 +8,10 @@
     <div class="section__heading">
       <h2 class="heading__title">
         Financial summary
-        {{ select.cycle_select(cycles, cycle, id="cycle-1") }}
       </h2>
+      <div class="heading__cycle">
+        {{ select.cycle_select(cycles, cycle, id="cycle-1") }}
+      </div>
     </div>
     <p class="usa-width-two-thirds">Candidates receive and spend money through committees. These are the <strong>combined financial totals</strong> for all of this candidate's authorized committees. You can learn more about each committee's fundraising and spending on its page.</p>
   </div>

--- a/templates/partials/candidate/other-spending-tab.html
+++ b/templates/partials/candidate/other-spending-tab.html
@@ -5,7 +5,6 @@
     <div class="content__section">
       <h2 class="section__heading" id="section-2-heading">
         Other spending
-        {{ select.cycle_select(cycles, cycle, id="cycle-2") }}
       </h2>
     </div>
 

--- a/templates/partials/committee/between-committees-tab.html
+++ b/templates/partials/committee/between-committees-tab.html
@@ -1,11 +1,8 @@
-{% import 'macros/cycle-select.html' as select %}
-
 <section class="main" id="section-4" role="tabpanel" aria-hidden="true" aria-labelledby="section-4-heading">
   <div class="container">
     <div class="section__heading">
       <h2 class="heading__title" id="section-4-heading">
         Receipts and disbursements between committees
-        {{ select.cycle_select(cycles, cycle, id="cycle-4") }}
       </h2>
     </div>
     <div class="row filters--horizontal">

--- a/templates/partials/committee/disbursements-tab.html
+++ b/templates/partials/committee/disbursements-tab.html
@@ -1,4 +1,3 @@
-{% import 'macros/cycle-select.html' as select %}
 {% import 'macros/disclaimer.html' as disclaimer %}
 
 <section class="main" id="section-3" role="tabpanel" aria-hidden="true" aria-labelledby="section-3-heading">
@@ -6,7 +5,6 @@
     <div class="section__heading">
       <h2 class="heading__title" id="section-2-heading">
         Money spent by this committee
-        {{ select.cycle_select(cycles, cycle, id="cycle-3") }}
       </h2>
       <a class="heading__action button--neutral button--browse"
           href="{{ url_for(

--- a/templates/partials/committee/filings-tab.html
+++ b/templates/partials/committee/filings-tab.html
@@ -1,5 +1,3 @@
-{% import 'macros/cycle-select.html' as select %}
-
 <section class="main" id="section-5" role="tabpanel" aria-hidden="true" aria-labelledby="section-5-heading">
   <div class="container">
     <div class="section__heading">

--- a/templates/partials/committee/financial-summary.html
+++ b/templates/partials/committee/financial-summary.html
@@ -1,5 +1,4 @@
 {% import 'macros/missing.html' as missing %}
-{% import 'macros/cycle-select.html' as select %}
 
 <section class="main" id="section-1" role="tabpanel" aria-hidden="true" aria-labelledby="section-1-heading">
   <div class="container">
@@ -7,7 +6,6 @@
       <div class="section__heading">
         <h2 class="heading__title" id="section-1-heading">
           Financial summary
-          {{ select.cycle_select(cycles, cycle) }}
         </h2>
       </div>
       <p>Get the full picture of all of the money received and spent by this committee.</p>

--- a/templates/partials/committee/receipts-tab.html
+++ b/templates/partials/committee/receipts-tab.html
@@ -1,6 +1,5 @@
 {% import 'macros/null.html' as null %}
 {% import 'macros/charts.html' as charts %}
-{% import 'macros/cycle-select.html' as select %}
 {% import 'macros/disclaimer.html' as disclaimer %}
 
 <section class="main" id="section-2" role="tabpanel" aria-hidden="true" aria-labelledby="section-2-heading">
@@ -8,7 +7,6 @@
     <div class="section__heading">
       <h2 class="heading__title" id="section-2-heading">
         Money Received by the Committee
-        {{ select.cycle_select(cycles, cycle, id="cycle-2") }}
       </h2>
       <a class="heading__action button--neutral button--browse" href="{{ url_for('receipts', committee_id=committee_id, cycle=cycle, is_individual='true') }}">All receipts data</a>
     </div>
@@ -65,7 +63,7 @@
         <div id="by-contribution-size" class="panel-toggle-element" aria-hidden="true">
           <div class="results-info results-info--simple">
             <h3 class="results-info__title">Receipts by Size</h3>
-          </div>          
+          </div>
           <table
              class="data-table"
              data-type="contribution-size"
@@ -80,7 +78,7 @@
         <div id="by-employer" class="panel-toggle-element" aria-hidden="true">
           <div class="results-info results-info--simple">
             <h3 class="results-info__title">Receipts by Individual's Employer</h3>
-          </div>          
+          </div>
           <table
               class="data-table"
               data-type="receipts-by-employer"

--- a/templates/partials/elections/candidate-comparison-tab.html
+++ b/templates/partials/elections/candidate-comparison-tab.html
@@ -4,7 +4,7 @@
   <div class="container">
     <h2 class="content__section__heading" id="section-1-heading">
       Candidate comparison
-      {{ select.cycle_select(cycles, cycle, 'path', id="cycle-1") }}
+      {{ select.cycle_select(cycles, cycle, 'path', id='cycle-1', tooltip='false') }}
     </h2>
     <div class="content__section">
       <div class="results-info results-info--simple">

--- a/templates/partials/elections/other-spending-tab.html
+++ b/templates/partials/elections/other-spending-tab.html
@@ -5,7 +5,7 @@
     <div class="content__section">
       <h2 class="section__heading" id="section-2-heading">
         Other spending
-        {{ select.cycle_select(cycles, cycle, 'path', id="cycle-2") }}
+        {{ select.cycle_select(cycles, cycle, 'path', id='cycle-2', tooltip='false') }}
       </h2>
     </div>
 

--- a/templates/partials/receipts-filter.html
+++ b/templates/partials/receipts-filter.html
@@ -37,10 +37,12 @@ Filter receipts
     <legend class="label">Restrict contributions</legend>
     <ul>
       <li>
-        <input id="is-individual" name="is_individual" type="checkbox" value="true" class="tooltip-trigger" aria-describedby="unique-tooltip" checked>
-        <label for="is-individual" class="tooltip-trigger">Unique only</label>
-        <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under">
-          <p class="tooltip__content">Some transactions — such as earmarked contributions and partnership contributions — are reported more than once for clarity on the printed page but can lead to confusion when viewed as data online. Use the unique only filter to remove these extra transactions.</p>
+        <div class="tooltip__container">
+          <input id="is-individual" name="is_individual" type="checkbox" value="true" class="tooltip-trigger" aria-describedby="unique-tooltip" checked>
+          <label for="is-individual" class="tooltip__trigger">Unique only</label>
+          <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under">
+            <p class="tooltip__content">Some transactions — such as earmarked contributions and partnership contributions — are reported more than once for clarity on the printed page but can lead to confusion when viewed as data online. Use the unique only filter to remove these extra transactions.</p>
+          </div>
         </div>
       </li>
     </ul>

--- a/templates/search.html
+++ b/templates/search.html
@@ -97,7 +97,7 @@
           <form action="{{ url_for('election_lookup') }}" class="widget__content">
             <div class="row">
               <label class="label" for="cycle-select">Choose an election cycle</label>
-              {{ select.cycle_select(cycles, location='form', tooltip='false') }}
+              {{ select.cycle_select(cycles, location='form', tooltip=False) }}
             </div>
             <div class="row">
               <div class="row">

--- a/templates/search.html
+++ b/templates/search.html
@@ -97,7 +97,7 @@
           <form action="{{ url_for('election_lookup') }}" class="widget__content">
             <div class="row">
               <label class="label" for="cycle-select">Choose an election cycle</label>
-              {{ select.cycle_select(cycles, location='form') }}
+              {{ select.cycle_select(cycles, location='form', tooltip='false') }}
             </div>
             <div class="row">
               <div class="row">


### PR DESCRIPTION
- Moves the cycle select to the headers of the candidate and committee pages and removes it from the subtitle areas of each individual tab
- Adds a tooltip with an explanation and link to the GitHub issue

![screen shot 2015-10-14 at 6 31 41 pm](https://cloud.githubusercontent.com/assets/1696495/10502693/79a04634-72a3-11e5-9ecb-a7c063938d58.png)

Depends on https://github.com/18F/fec-style/pull/146
Resolves #824 