### PR TITLE
Hide district if 00.

### DIFF
--- a/templates/candidates-single.html
+++ b/templates/candidates-single.html
@@ -37,7 +37,7 @@
           <li class="entity__term">
             <span class="entity__term__label"><span class="term" data-term="District">District</span></span>
             <span class="entity__term__data">
-              {% if district %}
+              {% if district and district != '00' %}
               <a href="{{ election_url(context(), cycle) }}">{{ state }} - {{ district }}</a>
               {% else %}
               <a href="{{ election_url(context(), cycle) }}">{{ state }}</a>


### PR DESCRIPTION
Pending changes in https://github.com/18F/openFEC/pull/1278, some null
districts will be represented as "00" rather then `null`. This patch
hides both "00" and `null` districts.