### PR TITLE
Feature/fix receipts link

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "hbsfy": "2.2.1",
     "intl": "1.0.0-rc-4",
     "jquery": "2.1.4",
-    "jquery.inputmask": "3.1.63",
+    "jquery.inputmask": "3.2.2",
     "keyboardjs": "0.4.2",
     "leaflet": "0.7.3",
     "leaflet-providers": "1.1.1",

--- a/static/js/init.js
+++ b/static/js/init.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global window, document, BASE_PATH */
+/* global window, document, Inputmask, BASE_PATH */
 
 var KEYCODE_SLASH = 191;
 
@@ -21,8 +21,22 @@ var typeahead = require('fec-style/js/typeahead');
 var typeaheadFilter = require('fec-style/js/typeahead-filter');
 
 require('jquery.inputmask');
-require('jquery.inputmask/dist/inputmask/jquery.inputmask.date.extensions.js');
-require('jquery.inputmask/dist/inputmask/jquery.inputmask.numeric.extensions.js');
+require('jquery.inputmask/dist/inputmask/inputmask.date.extensions.js');
+require('jquery.inputmask/dist/inputmask/inputmask.numeric.extensions.js');
+
+// Remove extra padding in currency mask
+Inputmask.extendAliases({
+  currency: {
+    prefix: '$',
+    groupSeparator: ',',
+    alias: 'numeric',
+    placeholder: '0',
+    autoGroup: !0,
+    digits: 2,
+    digitsOptional: !1,
+    clearMaskOnLostFocus: !1
+  }
+});
 
 // Include vendor scripts
 require('./vendor/tablist');

--- a/static/js/init.js
+++ b/static/js/init.js
@@ -31,10 +31,10 @@ Inputmask.extendAliases({
     groupSeparator: ',',
     alias: 'numeric',
     placeholder: '0',
-    autoGroup: !0,
+    autoGroup: true,
     digits: 2,
-    digitsOptional: !1,
-    clearMaskOnLostFocus: !1
+    digitsOptional: true,
+    clearMaskOnLostFocus: false
   }
 });
 

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -19,10 +19,10 @@ var sizeInfo = {
 function getSizeParams(size) {
   var limits = sizeInfo[size].limits;
   var params = {is_individual: 'true'};
-  if (limits[0]) {
+  if (limits[0] !== null) {
     params.min_amount = helpers.currency(limits[0]);
   }
-  if (limits[1]) {
+  if (limits[1] !== null) {
     params.max_amount = helpers.currency(limits[1]);
   }
   return params;

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -16,6 +16,18 @@ var sizeInfo = {
   2000: {limits: [2000, null], label: 'Over $2000'},
 };
 
+function getSizeParams(size) {
+  var limits = sizeInfo[size].limits;
+  var params = {is_individual: 'true'};
+  if (limits[0]) {
+    params.min_amount = helpers.currency(limits[0]);
+  }
+  if (limits[1]) {
+    params.max_amount = helpers.currency(limits[1]);
+  }
+  return params;
+}
+
 var supportOpposeMap = {
   S: 'Support',
   O: 'Oppose',
@@ -89,6 +101,7 @@ module.exports = {
   filings: filings,
   sizeInfo: sizeInfo,
   getColumns: getColumns,
+  getSizeParams: getSizeParams,
   supportOpposeColumn: supportOpposeColumn,
   amendmentIndicatorColumn: amendmentIndicatorColumn
 };

--- a/static/js/modules/filters.js
+++ b/static/js/modules/filters.js
@@ -6,7 +6,6 @@ var $ = require('jquery');
 var _ = require('underscore');
 var URI = require('URIjs');
 
-var events = require('fec-style/js/events');
 var accordion = require('fec-style/js/accordion');
 var accessibility = require('fec-style/js/accessibility');
 
@@ -165,7 +164,7 @@ $('.js-clear-filters').on('click keypress', function(e){
     clearFilters();
     $(this).focus();
   }
-})
+});
 
 $('.button--remove').click(function(e){
     e.preventDefault();

--- a/static/js/modules/filters.js
+++ b/static/js/modules/filters.js
@@ -155,7 +155,7 @@ var clearFilters = function() {
     activateFilter({
       name: key,
       value: null
-    })
+    });
   });
 };
 

--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global require, module, Intl, BASE_PATH, API_LOCATION, API_VERSION, API_KEY */
+/* global Intl, BASE_PATH, API_LOCATION, API_VERSION, API_KEY */
 
 var URI = require('URIjs');
 var _ = require('underscore');
@@ -12,9 +12,10 @@ var intl = require('intl');
 var locale = require('intl/locale-data/json/en-US.json');
 intl.__addLocaleData(locale);
 
+var currencyFormatter = Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD'});
 function currency(value) {
   if (!isNaN(parseInt(value))) {
-    return '$' + Intl.NumberFormat().format(value);
+    return currencyFormatter.format(value);
   } else {
     return null;
   }

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -207,11 +207,8 @@ function ensureArray(value) {
   return _.isArray(value) ? value : [value];
 }
 
-function compareQuery(first, second) {
-  var keys = _.keys(first);
-  if (!_.isEqual(keys.sort(), _.keys(second).sort())) {
-    return false;
-  }
+function compareQuery(first, second, keys) {
+  keys = keys || _.union(_.keys(first), _.keys(second));
   var different = _.find(keys, function(key) {
     return !_.isEqual(
       ensureArray(first[key]).sort(),
@@ -223,9 +220,10 @@ function compareQuery(first, second) {
 
 function pushQuery(params) {
   var query = URI.parseQuery(window.location.search);
-  if (!compareQuery(query, params)) {
+  var fields = filters.getFields();
+  if (!compareQuery(query, params, fields)) {
     // Clear and update filter fields
-    _.each(filters.getFields(), function(field) {
+    _.each(fields, function(field) {
       delete query[field];
     });
     params = _.extend(query, params);

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -1,9 +1,8 @@
 'use strict';
 
-/* global require, module, document */
+/* global document */
 
 var $ = require('jquery');
-var URI = require('URIjs');
 var _ = require('underscore');
 
 var events = require('fec-style/js/events');
@@ -38,12 +37,7 @@ var sizeColumns = [
     className: 'all',
     orderSequence: ['desc', 'asc'],
     render: tables.buildTotalLink(['receipts'], function(data, type, row, meta) {
-      var info = columns.sizeInfo[row.size];
-      return {
-        min_amount: info.limits[0],
-        max_amount: info.limits[1],
-        is_individual: 'true'
-      };
+      return columns.getSizeParams(row.size);
     })
   }
 ];

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -83,22 +83,17 @@ function makeCommitteeColumn(opts, factory) {
   return _.extend({}, {
     orderSequence: ['desc', 'asc'],
     render: tables.buildTotalLink(['receipts'], function(data, type, row, meta) {
+      row.cycle = context.election.cycle;
       var column = meta.settings.aoColumns[meta.col].data;
       return _.extend({
-        committee_id: (context.candidates[row.candidate_id] || {}).committee_ids,
-        cycle: context.election.cycle
+        committee_id: (context.candidates[row.candidate_id] || {}).committee_ids
       }, factory(data, type, row, meta, column));
     })
   }, opts);
 }
 
 var makeSizeColumn = _.partial(makeCommitteeColumn, _, function(data, type, row, meta, column) {
-  var limits = columns.sizeInfo[column].limits;
-  return {
-    min_amount: limits[0],
-    max_amount: limits[1],
-    is_individual: 'true'
-  };
+  return columns.getSizeParams(column);
 });
 
 var sizeColumns = [
@@ -267,7 +262,8 @@ function drawStateMap($container, candidateId, cached) {
     var results = _.reduce(
       data.results,
       function(acc, val) {
-        var row = fips.fipsByState[val.state.toUpperCase()] || {};
+        var state = val.state ? val.state.toUpperCase() : val.state;
+        var row = fips.fipsByState[state] || {};
         var code = row.STATE ? parseInt(row.STATE) : null;
         acc[code] = val.total;
         return acc;

--- a/templates/partials/committee/receipts-tab.html
+++ b/templates/partials/committee/receipts-tab.html
@@ -8,7 +8,14 @@
       <h2 class="heading__title" id="section-2-heading">
         Money received by the <span class="term" data-term="Committee">committee</span>
       </h2>
-      <a class="heading__action button--neutral button--browse" href="{{ url_for('receipts', committee_id=committee_id, cycle=cycle, is_individual='true') }}">All receipts data</a>
+      <a class="heading__action button--neutral button--browse"
+          href="{{ url_for(
+            'receipts',
+            committee_id=committee_id,
+            min_date=cycle_start(cycle) | date(fmt='%m-%d-%Y'),
+            max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y'),
+            is_individual='true'
+          ) }}">All receipts data</a>
     </div>
     <div class="content__section">
       <div class="row filters--horizontal">

--- a/tests/selenium/test_itemized.py
+++ b/tests/selenium/test_itemized.py
@@ -6,7 +6,7 @@ from tests.selenium.base_test_class import SearchPageTestCase
 
 
 def parse_amount(value):
-    cleaned = value.lstrip('$').replace(',', '')
+    cleaned = value.replace('$', '').replace(',', '')
     return float(cleaned)
 
 


### PR DESCRIPTION
Adds a few improvements related to https://github.com/18F/FEC/issues/72. It turned out that the receipts link on the committee detail page included a "cycle" parameter, which isn't one of the filters for the browse receipts page. This caused an immediate URL change upon loading the browse page.

* Fix link to receipts per cycle from the committee detail page
* Don't change URL based on irrelevant query parameters

cc @noahmanger

Note: looking at this code reminds me that it's kind of hairy in places and definitely in need of tests. I'm going to take a crack at refactoring the filter logic later this week--planning to add the missing tests there.