### PR TITLE
Other spending disclaimer

### DIFF
--- a/templates/partials/candidate/other-spending-tab.html
+++ b/templates/partials/candidate/other-spending-tab.html
@@ -5,7 +5,7 @@
   <div class="content__section">
     <div class="section__heading">
       <h2 class="heading__title">
-        Outside Spending
+        Other Spending
       </h2>
     </div>
     <p class="usa-width-two-thirds">This tab shows spending that opposes or supports this candidate. None of the funds are directly given to or spent by the candidate.</p>

--- a/templates/partials/candidate/other-spending-tab.html
+++ b/templates/partials/candidate/other-spending-tab.html
@@ -2,11 +2,14 @@
 
 <section class="main" id="section-2" role="tabpanel" aria-hidden="true" aria-labelledby="section-2-heading">
   <div class="container">
-    <div class="content__section">
-      <h2 class="section__heading" id="section-2-heading">
-        Other spending
+  <div class="content__section">
+    <div class="section__heading">
+      <h2 class="heading__title">
+        Outside Spending
       </h2>
     </div>
+    <p class="usa-width-two-thirds">Candidates receive and spend money through <span class="term" data-term="Committee">committees</span>. These are the <strong>combined financial totals</strong> for all of this candidate's <span class="term" data-term="Authorized committee">authorized committees</span>. You can learn more about each committee's fundraising and spending on its page.</p>
+  </div>
 
     <div class="content__section">
       <div class="results-info results-info--simple">

--- a/templates/partials/candidate/other-spending-tab.html
+++ b/templates/partials/candidate/other-spending-tab.html
@@ -8,7 +8,7 @@
         Outside Spending
       </h2>
     </div>
-    <p class="usa-width-two-thirds">Candidates receive and spend money through <span class="term" data-term="Committee">committees</span>. These are the <strong>combined financial totals</strong> for all of this candidate's <span class="term" data-term="Authorized committee">authorized committees</span>. You can learn more about each committee's fundraising and spending on its page.</p>
+    <p class="usa-width-two-thirds">This tab shows spending that opposes or supports this candidate. None of the funds are directly given to or spent by the candidate.</p>
   </div>
 
     <div class="content__section">


### PR DESCRIPTION
Adds introductory body text to the other spending tab that shows what the tab is and isn’t. Addresses @emileighoutlaw ’s https://github.com/18F/openFEC-web-app/issues/858

Review:
@noahmanger 
Question: I noticed that the header structure for the Financial Summary tab didn’t match the structure of this Other Spending tab. I made them consistent, but if there was a reason for, please advise :)