### PR TITLE
Removing icons from breadcrumbs area

### DIFF
--- a/templates/candidates-single.html
+++ b/templates/candidates-single.html
@@ -9,7 +9,6 @@
 
 <div class="tab-interface">
   <header class="page-header page-header--primary">
-    <img class="page-header__icon" src="{{ url_for('static', filename='img/i-candidate--primary.svg') }}" alt="Candidate icon">
     <span class="page-header__title">Candidates</span>
     {{ search.search('page-header', 'candidates') }}
   </header>

--- a/templates/committees-single.html
+++ b/templates/committees-single.html
@@ -9,7 +9,6 @@
 {% block body %}
   <div class="tab-interface">
     <header class="page-header page-header--primary">
-    <img class="page-header__icon" src="{{ url_for('static', filename='img/i-committee--primary.svg') }}" alt="Candidate icon">
     <span class="page-header__title">Committees</span>
     {{ search.search('page-header', 'committees') }}
     </header>


### PR DESCRIPTION
Removes icons from the breadcrumb area on candidate and committee pages, since they felt out of place.

I had made this change a while ago, but I think it was overwritten.

