### PR TITLE
Update URLs and columns in top-level election table.

### DIFF
--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -70,7 +70,7 @@ var electionColumns = [
         }
       );
       var anchor = document.createElement('a');
-      anchor.textContent = 'Link';
+      anchor.textContent = 'View';
       anchor.setAttribute('href', url);
       anchor.setAttribute('target', '_blank');
       return anchor.outerHTML;

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -55,28 +55,29 @@ var electionColumns = [
     }
   },
   {data: 'party_full', className: 'all'},
-  {
-    data: 'total_receipts',
-    orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['receipts'], function(data, type, row, meta) {
-      return {
-        committee_id: row.committee_ids,
-        cycle: context.election.cycle
-      };
-    })
-  },
-  {
-    data: 'total_disbursements',
-    orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['disbursements'], function(data, type, row, meta) {
-      return {
-        committee_id: row.committee_ids,
-        cycle: context.election.cycle
-      };
-    })
-  },
+  tables.currencyColumn({data: 'total_receipts', orderSequence: ['desc', 'asc']}),
+  tables.currencyColumn({data: 'total_disbursements', orderSequence: ['desc', 'asc']}),
   tables.barCurrencyColumn({data: 'cash_on_hand_end_period'}),
-  tables.urlColumn('pdf_url', {data: 'document_description', className: 'all', orderable: false})
+  {
+    render: function(data, type, row, meta) {
+      var dates = helpers.cycleDates(context.election.cycle);
+      var url = helpers.buildAppUrl(
+        ['filings'],
+        {
+          committee_id: row.committee_ids,
+          min_receipt_date: dates.min,
+          max_receipt_date: dates.max
+        }
+      );
+      var anchor = document.createElement('a');
+      anchor.textContent = 'Link';
+      anchor.setAttribute('href', url);
+      anchor.setAttribute('target', '_blank');
+      return anchor.outerHTML;
+    },
+    className: 'all',
+    orderable: false,
+  }
 ];
 
 function makeCommitteeColumn(opts, factory) {

--- a/templates/partials/candidate/financial-summary.html
+++ b/templates/partials/candidate/financial-summary.html
@@ -53,7 +53,7 @@
                committee_id=committee_ids,
                cycle=cycle,
                ) }}">
-               View source forms
+               View source filings
              </a>
            {% endif %}
         </p>

--- a/templates/partials/elections/candidate-comparison-tab.html
+++ b/templates/partials/elections/candidate-comparison-tab.html
@@ -23,7 +23,7 @@
           <th role="col">Total receipts</th>
           <th role="col">Total disbursements</th>
           <th role="col">Cash on hand</th>
-          <th role="col">Financial reports</th>
+          <th role="col">Source filings</th>
         </thead>
       </table>
     </div>

--- a/templates/partials/elections/candidate-comparison-tab.html
+++ b/templates/partials/elections/candidate-comparison-tab.html
@@ -23,7 +23,7 @@
           <th role="col">Total receipts</th>
           <th role="col">Total disbursements</th>
           <th role="col">Cash on hand</th>
-          <th role="col">Most recent report</th>
+          <th role="col">Financial reports</th>
         </thead>
       </table>
     </div>


### PR DESCRIPTION
* Remove total receipts and disbursements links.
* Add links to source filings.

[Resolves #873]

This isn't quite ready for merge. Two outstanding questions:
* I've tentatively labeled the column that links to the base filings "Financial reports". @LindsayYoung and @emileighoutlaw, feel free to weigh in with a more precise name if this is too fuzzy.
* I'm not sure what text / icon to use for the new column linking to the F3 filings. Since we're now linking to a browse view of all relevant filings for a candidate, we can't use text like "May Quarterly 2016"--the text will be the same for each row. I'm using the placeholder text of "Link" for now, but that needs to change. Maybe a link-out icon would be useful here.

cc @jenniferthibault @noahmanger 

<img width="993" alt="screen shot 2015-10-21 at 6 24 30 pm" src="https://cloud.githubusercontent.com/assets/1633460/10652110/c10d1488-7821-11e5-827a-c74547c410ed.png">
