### PR TITLE
Handle multiple null values for state and district.

### DIFF
--- a/static/js/modules/election-lookup.js
+++ b/static/js/modules/election-lookup.js
@@ -54,7 +54,7 @@ function formatResult(result, lookup) {
 
 function formatName(result) {
   var parts = [result.state, officeMap[result.office]];
-  if (result.district) {
+  if (result.district && result.district !== '00') {
     parts = parts.concat('District ' + result.district.toString());
   }
   return parts.join(' ');
@@ -241,7 +241,8 @@ ElectionLookup.prototype.handlePopState = function() {
 ElectionLookup.prototype.drawDistricts = function(results) {
   var encoded = _.chain(results)
     .filter(function(result) {
-      return result.state && result.district;
+      return result.state && result.state !== 'US' &&
+        result.district && result.district !== '00';
     })
     .map(function(result) {
       return utils.encodeDistrict(result.state, result.district);


### PR DESCRIPTION
Following a recent change in the API, missing values for `state` and
`district` have mostly changed from `null` to "US" and "00",
respectively. This patch checks for all possible missing values upon
receiving data from the API.

To check, verify that searching for elections by zip, state, and district work as expected.

h/t @noahmanger