### PR TITLE
Handle miscellaneous F3* forms.

### DIFF
--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -72,7 +72,7 @@ var filings = {
     width: '20px',
     orderable: false,
     render: function(data, type, row, meta) {
-      return row.form_type && row.form_type.match(/^F3/) ?
+      return row.form_type && ['F3', 'F3P', 'F3X'].indexOf(row.form_type) !== -1 ?
         tables.MODAL_TRIGGER_HTML :
         '';
     }


### PR DESCRIPTION
Only show detail panel trigger when form type is one of "F3", "F3P", and
"F3X". Fixes extraneous triggers on less common forms like "F3L".

h/t @noahmanger