### PR TITLE
Skip links on null employer and occupation.

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -104,20 +104,24 @@ function buildAggregateUrl(cycle) {
 function buildTotalLink(path, getParams) {
   return function(data, type, row, meta) {
     data = data || 0;
+    var params = getParams(data, type, row, meta);
     var span = document.createElement('div');
     span.setAttribute('data-value', data);
     span.setAttribute('data-row', meta.row);
-    var link = document.createElement('a');
-    link.textContent = helpers.currency(data);
-    link.setAttribute('title', 'View individual transactions');
-    var params = getParams(data, type, row, meta);
-    var uri = helpers.buildAppUrl(path, _.extend(
-      {committee_id: row.committee_id},
-      buildAggregateUrl(_.extend({}, row, params).cycle),
-      params
-    ));
-    link.setAttribute('href', uri);
-    span.appendChild(link);
+    if (params) {
+      var link = document.createElement('a');
+      link.textContent = helpers.currency(data);
+      link.setAttribute('title', 'View individual transactions');
+      var uri = helpers.buildAppUrl(path, _.extend(
+        {committee_id: row.committee_id},
+        buildAggregateUrl(_.extend({}, row, params).cycle),
+        params
+      ));
+      link.setAttribute('href', uri);
+      span.appendChild(link);
+    } else {
+      span.textContent = helpers.currency(data);
+    }
     return span.outerHTML;
   };
 }

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -101,10 +101,14 @@ var employerColumns = [
     orderable: false,
     orderSequence: ['desc', 'asc'],
     render: tables.buildTotalLink(['receipts'], function(data, type, row, meta) {
-      return {
-        contributor_employer: row.employer,
-        is_individual: 'true'
-      };
+      if (row.employer) {
+        return {
+          contributor_employer: row.employer,
+          is_individual: 'true'
+        };
+      } else {
+        return null;
+      }
     })
   }
 ];
@@ -117,10 +121,14 @@ var occupationColumns = [
     orderable: false,
     orderSequence: ['desc', 'asc'],
     render: tables.buildTotalLink(['receipts'], function(data, type, row, meta) {
-      return {
-        contributor_occupation: row.occupation,
-        is_individual: 'true'
-      };
+      if (row.occupation) {
+        return {
+          contributor_occupation: row.occupation,
+          is_individual: 'true'
+        };
+      } else {
+        return null;
+      }
     })
   }
 ];


### PR DESCRIPTION
Since we don't currently expose filters to restrict transctions by null
employer or occupation, we don't have a good way to build links to
itemized browse views for aggregates with null values. This patch omits
links for these aggregate rows.

To verify: browse to a committee detail page, receipts tab, employer or occupation aggregates; there should be the usual links to aggregates for non-null employers and occupations, but no links for null values.

h/t @noahmanger 
