### PR TITLE
Allow cross-origin requests to feedback endpoint.

### DIFF
--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -5,6 +5,7 @@ import furl
 
 from flask.views import MethodView
 from flask import request, render_template, jsonify
+from flask.ext.cors import cross_origin
 
 from webargs import fields
 from webargs.flaskparser import use_kwargs
@@ -110,6 +111,8 @@ def validate_referer(referer):
         raise ValidationError('Invalid referer.')
 
 class GithubView(MethodView):
+
+    decorators = [cross_origin()]
 
     @cached_property
     def repo(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask==0.10.1
 Flask-BasicAuth==0.2.0
+Flask-Cors==2.1.0
 Flask-SSLify==0.1.5
 furl==0.4.5
 github3.py==0.9.4


### PR DESCRIPTION
Necessary for feedback submission via the CMS application. Going
forward, we may want to restrict the origin to beta.fec.gov, but this is
fine for now. This becomes moot if the feedback widget is exported to a
separate application.

Required for https://github.com/18F/fec-cms/pull/98.

cc @LindsayYoung @noahmanger 