### PR TITLE
Temporarily fetch committee information from detail table.

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -4,6 +4,7 @@ from urllib import parse
 import requests
 import cachecontrol
 from flask import abort
+from werkzeug.exceptions import NotFound
 
 from openfecwebapp import utils
 from openfecwebapp import config
@@ -55,7 +56,12 @@ def load_nested_type(parent_type, c_id, nested_type, *path, **filters):
 
 def load_with_nested(primary_type, primary_id, secondary_type, cycle=None):
     path = ('history', str(cycle)) if cycle else ()
-    data = load_single_type(primary_type, primary_id, *path)
+    # Hack: If no history records are found, get the latest detail record
+    # TODO(jmcarp) Roll back once #875 is resolved
+    try:
+        data = load_single_type(primary_type, primary_id, *path)
+    except NotFound:
+        data = load_single_type(primary_type, primary_id)
     cycle = cycle or min(utils.current_cycle(), max(data['cycles']))
     path = ('history', str(cycle))
     nested_data = load_nested_type(primary_type, primary_id, secondary_type, *path)


### PR DESCRIPTION
When committee history information can't be found from the history
sub-endpoint, use the detail endpoint instead. This is a temporary fix
and should be reverted once the underlying issue described in
https://github.com/18F/openFEC-web-app/issues/875 is resolved.

Depends on https://github.com/18F/openFEC/pull/1295.