### PR TITLE
Replace history on table initialization.

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -222,7 +222,7 @@ function compareQuery(first, second, keys) {
   return !different;
 }
 
-function pushQuery(params, push) {
+function nextUrl(params) {
   var query = URI.parseQuery(window.location.search);
   var fields = filters.getFields();
   if (!compareQuery(query, params, fields)) {
@@ -231,13 +231,24 @@ function pushQuery(params, push) {
       delete query[field];
     });
     params = _.extend(query, params);
-    var queryString = URI('').query(params).toString();
-    if (push) {
-      window.history.pushState(params, queryString, queryString || window.location.pathname);
-      analytics.pageView();
-    } else {
-      window.history.replaceState(params, queryString, queryString || window.location.pathname);
-    }
+    return URI('').query(params).toString();
+  } else {
+    return '';
+  }
+}
+
+function updateQuery(params) {
+  var queryString = nextUrl(params);
+  if (queryString) {
+    window.history.replaceState(params, queryString, queryString || window.location.pathname);
+  }
+}
+
+function pushQuery(params) {
+  var queryString = nextUrl(params);
+  if (queryString) {
+    window.history.pushState(params, queryString, queryString || window.location.pathname);
+    analytics.pageView();
   }
 }
 
@@ -420,7 +431,7 @@ function initTable($table, $form, path, baseQuery, columns, callbacks, opts) {
   callbacks = _.extend({}, defaultCallbacks, callbacks);
   if ($form) {
     var initialFilters = mapFilters($form.serializeArray());
-    pushQuery(initialFilters, false);
+    updateQuery(initialFilters);
   }
   opts = _.extend({
     serverSide: true,
@@ -439,7 +450,7 @@ function initTable($table, $form, path, baseQuery, columns, callbacks, opts) {
       if ($form) {
         var filters = $form.serializeArray();
         parsedFilters = mapFilters(filters);
-        pushQuery(parsedFilters, true);
+        pushQuery(parsedFilters);
       }
       var query = _.extend(
         callbacks.mapQuery(api, data),


### PR DESCRIPTION
This patch attempts to fix a longtime issue with permalinks for table
filters. On table initialization, we grab filter values from the query
string and set them in the filter fields. Because some fields change
their inputs (mostly fields with input masks, but potentially other
fields as well), this can trigger a change in the URL. In these cases,
the back button brings the user back to the initial URL, which again
triggers an immediate URL change when the input is changed by the filter
field. This patch sidesteps the issue by using `history.replaceState`
rather than `history.pushState` on load, meaning that we don't push a
new entry to this history.

To verify, enter a URL that will be automatically transformed on load,
such as http://localhost:3000/filings/?min_receipt_date=10/01/1985, and
verify that the back button works as expected.

cc @noahmanger

Note: this matters less once we stop using input masking, but it's theoretically a problem as long as any of our filters are capable of changing their values automatically. If we decide that we don't ever want filters to do this, we can roll back this change. Also, there's no need to include this in the launch--just wanted to make sure I got the proposal checked in before I forgot about it.