### PR TITLE
Hotfix/fix disbursement columns

### DIFF
--- a/static/js/pages/disbursements.js
+++ b/static/js/pages/disbursements.js
@@ -14,7 +14,7 @@ var columns = [
     data: 'recipient_name',
     orderable: false,
     className: 'all',
-    width: '280px',
+    width: '200px',
     render: function(data, type, row, meta) {
       var committee = row.recipient_committee;
       if (committee) {
@@ -28,7 +28,7 @@ var columns = [
       }
     }
   },
-  {data: 'recipient_state', orderable: false, className: 'min-desktop hide-panel'},
+  {data: 'recipient_state', width: '80px', orderable: false, className: 'min-desktop hide-panel'},
   tables.currencyColumn({data: 'disbursement_amount', className: 'min-tablet hide-panel-tablet'}),
   tables.dateColumn({data: 'disbursement_date', className: 'min-tablet hide-panel-tablet'}),
   {data: 'disbursement_description', className: 'min-desktop hide-panel', orderable: false},
@@ -36,7 +36,6 @@ var columns = [
     data: 'committee',
     orderable: false,
     className: 'min-tablet hide-panel',
-    width: '30%',
     render: function(data, type, row, meta) {
       if (data) {
         return tables.buildEntityLink(

--- a/static/js/pages/receipts.js
+++ b/static/js/pages/receipts.js
@@ -35,7 +35,6 @@ var columns = [
     data: 'committee',
     orderable: false,
     className: 'min-desktop hide-panel',
-    width: '250px',
     render: function(data, type, row, meta) {
       if (data) {
         return tables.buildEntityLink(

--- a/static/templates/disbursements.hbs
+++ b/static/templates/disbursements.hbs
@@ -53,12 +53,6 @@
 </div>
 
 <div class="panel__row">
-  <h4 class="panel__title">Filing information</h4>
-  <table>
- </table>
-</div>
-
-<div class="panel__row">
   <h4 class="panel__title">Committee information</h4>
   <table>
     <tr>


### PR DESCRIPTION
The demo for tomorrow runs on a smaller width desktop screen, so it's painfully obvious how the disbursement and receipt columns ran into each other. This adjusts some column widths to mitigate the worst cases. It's not a complete fix for DataTables wonky column width rendering, but it should help.

Also, I found an unused part of the template in the disbursements.hbs file that was showing up. I think we just never implemented it. So I removed.