### PR TITLE
Update "looking for" link from "FEC.gov" to "fec.gov"

### DIFF
--- a/templates/layouts/main.html
+++ b/templates/layouts/main.html
@@ -45,7 +45,7 @@
 
   <header class="site-header">
     <div class="disclaimer">
-      <span class="disclaimer__left">Looking for <a href="http://www.fec.gov">FEC.gov?</a></span>
+      <span class="disclaimer__left">Looking for <a href="http://www.fec.gov">fec.gov?</a></span>
       <span class="disclaimer__center">
         An official website of the United States Government
         <img src="{{ url_for('static', filename='img/us_flag_small.png') }}" alt="US flag signifying that this is a United States Federal Government website">


### PR DESCRIPTION
This makes it consistent with the beta.fec.gov homepage capitalization