### PR TITLE
Skip basic auth unless credentials set.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -368,7 +368,7 @@ if config.environment in ['stage', 'prod']:
 
 # Note: Apply basic auth check after HTTPS redirect so that users aren't prompted
 # for credentials over HTTP; h/t @noahkunin.
-if not config.test:
+if config.username and config.password:
     app.config['BASIC_AUTH_USERNAME'] = config.username
     app.config['BASIC_AUTH_PASSWORD'] = config.password
     app.config['BASIC_AUTH_FORCE'] = True


### PR DESCRIPTION
Follow-up from taking the password down yesterday. We should use basic auth if credentials are found in the environment, not otherwise; no need to key on `FEC_WEB_TEST` or other envvars.

Note: this isn't urgent--I'm sending as a hotfix because it should be merged into master before the next deploy. Attention @LindsayYoung.