### PR TITLE
Revert "Temporarily fetch committee information from detail table."

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -4,7 +4,6 @@ from urllib import parse
 import requests
 import cachecontrol
 from flask import abort
-from werkzeug.exceptions import NotFound
 
 from openfecwebapp import utils
 from openfecwebapp import config
@@ -56,12 +55,7 @@ def load_nested_type(parent_type, c_id, nested_type, *path, **filters):
 
 def load_with_nested(primary_type, primary_id, secondary_type, cycle=None):
     path = ('history', str(cycle)) if cycle else ()
-    # Hack: If no history records are found, get the latest detail record
-    # TODO(jmcarp) Roll back once #875 is resolved
-    try:
-        data = load_single_type(primary_type, primary_id, *path)
-    except NotFound:
-        data = load_single_type(primary_type, primary_id)
+    data = load_single_type(primary_type, primary_id, *path)
     cycle = cycle or min(utils.current_cycle(), max(data['cycles']))
     path = ('history', str(cycle))
     nested_data = load_nested_type(primary_type, primary_id, secondary_type, *path)


### PR DESCRIPTION
This reverts commit 5758386055e3ded018ea6236978947e585d70fb0.

Note: depends on https://github.com/18F/openFEC/pull/1325, which resolves the underlying issue and obviates the temporary hack we were using in the meantime.