### PR TITLE
Adds line about what this repo is

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@
 [![Dependencies](https://img.shields.io/gemnasium/18F/openFEC-web-app.svg)](https://gemnasium.com/18F/openFEC-web-app)
 
 ## Campaign finance for everyone
+
 The Federal Election Commission (FEC) releases information to the public about money that’s raised and spent in federal elections — that’s elections for US president, Senate, and House of Representatives. 
 
 Are you interested in seeing how much money a candidate raised? Or spent? How much debt they took on? Who contributed to their campaign? The FEC is the authoritative source for that information.
 
 betaFEC is a collaboration between [18F](http://18f.gsa.gov) and the FEC. It aims to make campaign finance information more accessible (and understandable) to all users. 
 
-## FEC repositories 
+## This repository
+[openFEC-web-app](https://github.com/18F/openFEC-web-app/) is home to the betaFEC web app for exploring campaign finance data.
+
+## All FEC repositories 
 We welcome you to explore our FEC repositories, make suggestions, and contribute to our code. Our repositories are:
 
 - [FEC](https://github.com/18F/fec): a general discussion forum. We [compile feedback](https://github.com/18F/fec/issues) from betaFEC’s feedback widget here, and this is the best place to submit general feedback.


### PR DESCRIPTION
Executing Lindsay's excellent suggestion that we add a specific section to explain the repo users are *currently visiting*. 

Will wait for this one to merge before I move on to other repos, in case anyone has questions/concerns.

@LindsayYoung @jmcarp


[ci skip]