### PR TITLE
Miscellaneous updates to election map.

### DIFF
--- a/static/js/modules/election-lookup.js
+++ b/static/js/modules/election-lookup.js
@@ -133,7 +133,7 @@ function getDistrictPalette(scale) {
 
 var ElectionFormMixin = {
   handleZipChange: function() {
-    this.$state.val('');
+    this.$state.val('').change();
     this.$district.val('');
   },
 
@@ -165,6 +165,8 @@ _.extend(ElectionLookup.prototype, ElectionFormMixin);
 ElectionLookup.prototype.init = function() {
   this.districts = 0;
   this.serialized = {};
+  this.results = [];
+  this.xhr = null;
 
   this.$form = this.$elm.find('form');
   this.$zip = this.$form.find('[name="zip"]');
@@ -214,16 +216,27 @@ ElectionLookup.prototype.search = function(e, opts) {
   opts = _.extend({pushState: true}, opts || {});
   var self = this;
   var serialized = self.serialize();
-  if (self.shouldSearch(serialized) && !_.isEqual(serialized, self.serialized)) {
-    $.getJSON(self.getUrl(serialized)).done(function(response) {
-      // Note: Update district color map before rendering results
-      self.drawDistricts(response.results);
-      self.draw(response.results);
-    });
-    self.serialized = serialized;
-    if (opts.pushState) {
-      window.history.pushState(serialized, null, URI('').query(serialized).toString());
-      analytics.pageView();
+  if (self.shouldSearch(serialized)) {
+    if (!_.isEqual(serialized, self.serialized)) {
+      // Requested search options differ from saved options; request new data.
+      self.xhr && self.xhr.abort();
+      self.xhr = $.getJSON(self.getUrl(serialized)).done(function(response) {
+        // Note: Update district color map before rendering results
+        self.results = response.results;
+        self.drawDistricts(self.results);
+        self.draw(response.results);
+      });
+      self.serialized = serialized;
+      if (opts.pushState) {
+        window.history.pushState(serialized, null, URI('').query(serialized).toString());
+        analytics.pageView();
+      }
+    } else if (self.results) {
+      // Requested options match saved options; redraw cached results. This
+      // ensures that clicking on a state or district will highlight it when
+      // the search options don't match the state of the map, e.g. after the
+      // user has run a search, then zoomed out and triggered a map redraw.
+      self.drawDistricts(self.results);
     }
   }
 };
@@ -241,8 +254,7 @@ ElectionLookup.prototype.handlePopState = function() {
 ElectionLookup.prototype.drawDistricts = function(results) {
   var encoded = _.chain(results)
     .filter(function(result) {
-      return result.state && result.state !== 'US' &&
-        result.district && result.district !== '00';
+      return result.office === 'H';
     })
     .map(function(result) {
       return utils.encodeDistrict(result.state, result.district);

--- a/tests/unit/modules/election-lookup.js
+++ b/tests/unit/modules/election-lookup.js
@@ -72,17 +72,23 @@ describe('election lookup', function() {
 
   it('should disable the district select when state is not set', function() {
     this.el.$state.val('').change();
-    expect(this.el.$district.prop('disabled')).to.equal(true);
+    expect(this.el.$district.prop('disabled')).to.be.true;
   });
 
   it('should disable the district select when state is set and the state does not have districts', function() {
     this.el.$state.val('AS').change();
-    expect(this.el.$district.prop('disabled')).to.equal(true);
+    expect(this.el.$district.prop('disabled')).to.be.true;
   });
 
   it('should enable the district select when state is set and the state has districts', function() {
     this.el.$state.val('VA').change();
-    expect(this.el.$district.prop('disabled')).to.equal(false);
+    expect(this.el.$district.prop('disabled')).to.be.false;
+  });
+
+  it('should clear the state select and disable the district select when the zip select is set', function() {
+    this.el.$zip.val('19041').change();
+    expect(this.el.$state.val()).to.equal('');
+    expect(this.el.$district.prop('disabled')).to.be.true;
   });
 
   it('should serialize zip codes', function() {


### PR DESCRIPTION
* Correctly render ZIP codes in DC
* Cancel pending AJAX request on new search
* Fix bug such that maps didn't update on selecting a state without
  changing search criteria

This fixes a few minor bugs that I noticed on the election search widget. To test manually, verify that the relevant production bugs don't happen with this branch checked out: DC ZIP codes should render, and clicking a state after clicking and zooming out again should re-highlight the state. This one's a little tricky to replicate--you do it like this:

* Open the election search page
* Click on a state
* Zoom out until all states are rendered in color on the map
* Click on the same state again

In production, this *doesn't* re-highlight the state as it should; under this patch, it does.

cc @noahmanger @msecret 