### PR TITLE
Adds new footer items for feedback and github

### DIFF
--- a/templates/layouts/main.html
+++ b/templates/layouts/main.html
@@ -78,7 +78,9 @@
       <p class="address__title">Federal Election Commission</p>
       <p>999 E Street, NW, Washington, DC 20463</p>
       <p>(800) 424-9530</p>
-      <p><a href="mailto:{{ contact_email }}">{{ contact_email }}</a></p>
+      <p class="address__subtitle">betaFEC feedback</p> 
+      <p><a href="mailto:{{ contact_email }}">{{ contact_email }}</a><img src="img/i-email--inverse.svg" alt="Icon of email being sent"></p>
+      <p><a href="https://github.com/18F/fec">github.com/18F/FEC</a><img src="img/i-github--inverse.svg" alt="Icon of GitHub logo"></p>
     </div>
   </div>
 </footer>

--- a/templates/layouts/main.html
+++ b/templates/layouts/main.html
@@ -78,9 +78,9 @@
       <p class="address__title">Federal Election Commission</p>
       <p>999 E Street, NW, Washington, DC 20463</p>
       <p>(800) 424-9530</p>
-      <p class="address__subtitle">betaFEC feedback</p> 
-      <p><a href="mailto:{{ contact_email }}">{{ contact_email }}</a><img src="img/i-email--inverse.svg" alt="Icon of email being sent"></p>
-      <p><a href="https://github.com/18F/fec">github.com/18F/FEC</a><img src="img/i-github--inverse.svg" alt="Icon of GitHub logo"></p>
+      <p class="address__subtitle">betaFEC feedback</p>
+      <p><a href="mailto:{{ contact_email }}">{{ contact_email }}</a><img class="icon--inline--right" src="{{ url_for('static', filename='img/i-email--inverse.svg') }}" alt="Icon of email being sent"></p>
+      <p><a href="https://github.com/18F/fec">GitHub repository</a><img class="icon--inline--right" src="{{ url_for('static', filename='img/i-github--inverse.svg') }}" alt="Icon of GitHub logo"></p>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
## Changes
Adds contact copy for email and github, as determined in https://github.com/18F/openFEC-web-app/issues/866#issuecomment-154172692

## Notes: 
Goes with https://github.com/18F/fec-style/pull/174

I can’t seem to get the image code quite right here, and would appreciate help!

Might have to add an image class afterwards for image positioning?

## Review: 
@noahmanger 

