### PR TITLE
Feature/fix grouped charts

### DIFF
--- a/templates/macros/charts.html
+++ b/templates/macros/charts.html
@@ -1,3 +1,5 @@
+{% import 'macros/null.html' as null %}
+
 {% macro tooltip_wrap(content) %}
 <div class="chart-series__bar__tooltip">
   {{ content }}
@@ -19,7 +21,7 @@
 {% endif %}
 {% endmacro %}
 
-{% macro chart_series_grouped(groups, value_keys, label_key='label',orient='vertical',
+{% macro chart_series_grouped(groups, value_keys, label_key='label', orient='vertical',
                               tooltip=default_tooltip, labels=(), attr={}) %}
 {% if series_group_has_data(groups, value_keys) %}
 <div class="js-chart-series chart-series chart-series--grouped chart-series--{{ orient }} {{ attr.class|default('') }}">
@@ -37,4 +39,11 @@
   {% endfor %}
 </div>
 {% endif %}
+{% endmacro %}
+
+{% macro group_bar_tooltip(value, key) %}
+<div class="chart-series__bar__tooltip">
+  <h5 class="chart-series__bar__tooltip__title">{{ key|replace('_', ' ') | capitalize }}</h5>
+  <span class="chart-series__bar__tooltip__value">{{ null.null( value | currency )}}</span>
+</div>
 {% endmacro %}

--- a/templates/macros/charts.html
+++ b/templates/macros/charts.html
@@ -8,36 +8,26 @@
   {{ tooltip_wrap(value|currency) }}
 {% endmacro %}
 
-{% macro chart_bar(value, key, tooltip=default_tooltip, attr={}) %}
+{% macro chart_bar(value, key, tooltip=default_tooltip, label='', attr={}) %}
 {% if value is not none %}
-<div class="chart-series__bar data--{{ key }} {{ attr.class|default('') }}"
+<div class="chart-series__bar {{ attr.class|default('') }}"
   data-key="{{ key }}"
   data-value="{{ value }}"
   tabindex="0">
-  {% if tooltip %}{{ tooltip(value, key) }}{% endif %}
+  {% if tooltip %}{{ tooltip(value, label or key) }}{% endif %}
 </div>
 {% endif %}
 {% endmacro %}
 
-{% macro chart_series(bars, value_key, orient='vertical', tooltip=default_tooltip, attr={}) %}
-{% if series_has_data(bars, value_key) %}
-<div class="chart-series chart-series--{{ orient }} {{ attr.class|default('') }} value-bar">
-  {% for bar in bars %}
-    {{ chart_bar(bar[value_key], value_key, tooltip=tooltip, attr={}) }}
-  {% endfor %}
-</div>
-{% endif %}
-{% endmacro %}
-
-{% macro chart_series_grouped(groups, value_keys,
-    label_key='label', orient='vertical', tooltip=default_tooltip, attr={}) %}
+{% macro chart_series_grouped(groups, value_keys, label_key='label',orient='vertical',
+                              tooltip=default_tooltip, labels=(), attr={}) %}
 {% if series_group_has_data(groups, value_keys) %}
 <div class="js-chart-series chart-series chart-series--grouped chart-series--{{ orient }} {{ attr.class|default('') }}">
   {% for group in groups %}
   {% if group_has_data(group, value_keys) %}
   <div class="chart-series__group">
     {% for key in value_keys %}
-      {{ chart_bar(group[key], key, tooltip=tooltip, attr={}) }}
+      {{ chart_bar(group[key], key, tooltip=tooltip, label=labels[loop.index0], attr={}) }}
     {% endfor %}
     <div class="chart-series__group__label">
       {{ group | fmt_chart_ticks(label_key) }}

--- a/templates/partials/committee-charts.html
+++ b/templates/partials/committee-charts.html
@@ -2,13 +2,6 @@
 {% set reports = committee.reports  %}
 {% set totals = committee.totals  %}
 {% import 'macros/charts.html' as charts %}
-{% import 'macros/null.html' as null %}
-{% macro group_bar_tooltip(value, key) %}
-<div class="chart-series__bar__tooltip">
-  <h5 class="chart-series__bar__tooltip__title">{{ key|replace('_', ' ')|title }}</h5>
-  <span class="chart-series__bar__tooltip__value">{{ null.null( value | currency )}}</span>
-</div>
-{% endmacro %}
 
 {% if series_group_has_data(reports, ('total_receipts_period', 'total_disbursements_period')) %}
 <div class="content__section--extra">
@@ -20,8 +13,13 @@
         <li class="chart__key__item"><span class="swatch data--disbursements"></span>Total disbursements</li>
       </ul>
     </div>
-    {{ charts.chart_series_grouped(reports | reverse | list, ('total_receipts_period', 'total_disbursements_period'),
-       label_key=('coverage_start_date', 'coverage_end_date'), tooltip=group_bar_tooltip) }}
+    {{ charts.chart_series_grouped(
+      reports | reverse | list,
+      ('total_receipts_period', 'total_disbursements_period'),
+      label_key=('coverage_start_date', 'coverage_end_date'),
+      labels=('Total receipts', 'Total disbursements'),
+      tooltip=charts.group_bar_tooltip,
+    ) }}
   </figure>
 </div>
 {% endif %}
@@ -35,8 +33,13 @@
         <li class="chart__key__item"><span class="swatch data--debt"></span>Debt</li>
       </ul>
     </div>
-    {{ charts.chart_series_grouped(reports | reverse | list, ('cash_on_hand_end_period', 'debts_owed_by_committee'),
-       label_key=('coverage_end_date'), tooltip=group_bar_tooltip) }}
+    {{ charts.chart_series_grouped(
+      reports | reverse | list,
+      ('cash_on_hand_end_period', 'debts_owed_by_committee'),
+      label_key=('coverage_end_date'),
+      labels=('Ending cash on hand', 'Debt'),
+      tooltip=charts.group_bar_tooltip,
+    ) }}
   </figure>
 </div>
 {% endif %}

--- a/templates/partials/committee-charts.html
+++ b/templates/partials/committee-charts.html
@@ -9,8 +9,8 @@
     <div class="chart__header">
       <h3 class="chart__title">Receipts and disbursements</h3>
       <ul class="chart__key list--flat">
-        <li class="chart__key__item"><span class="swatch data--receipts"></span>Total receipts</li>
-        <li class="chart__key__item"><span class="swatch data--disbursements"></span>Total disbursements</li>
+        <li class="chart__key__item"><span class="swatch"></span>Total receipts</li>
+        <li class="chart__key__item"><span class="swatch"></span>Total disbursements</li>
       </ul>
     </div>
     {{ charts.chart_series_grouped(

--- a/templates/partials/committee-totals-ie-only.html
+++ b/templates/partials/committee-totals-ie-only.html
@@ -1,6 +1,6 @@
 {% with committee=context() %}
 
-{{ totals_table('Independent contributions', totals.0.total_independent_contributions) }}
+{{ totals_table('Contributions received', totals.0.total_independent_contributions) }}
 {{ totals_table('Independent expenditures', totals.0.total_independent_expenditures) }}
 
 {% endwith %}

--- a/templates/partials/ie-chart.html
+++ b/templates/partials/ie-chart.html
@@ -7,16 +7,16 @@
 <div class="row">
   <figure class="chart-container chart--r-d">
     <div class="chart__header">
-      <h4 class="chart__title">Independent contributions and independent expenditures</h4>
+      <h4 class="chart__title"> Contributions received and independent expenditures</h4>
       <ul class="chart__key list--flat">
-        <li class="chart__key__item"><span class="swatch"></span> Contributions received</li>
-        <li class="chart__key__item"><span class="swatch"></span> Independent expenditures</li>
+        <li class="chart__key__item"><span class="swatch"></span> Total contributions received</li>
+        <li class="chart__key__item"><span class="swatch"></span> Total independent expenditures</li>
       </ul>
     </div>
     {{ charts.chart_series_grouped(
       reports | reverse | list,
       ('independent_contributions_period', 'independent_expenditures_period'),
-      labels=('Contributions received', 'Independent expenditures'),
+      labels=('Total contributions received', 'Total independent expenditures'),
       label_key=('coverage_start_date', 'coverage_end_date'),
       tooltip=charts.group_bar_tooltip,
     ) }}

--- a/templates/partials/ie-chart.html
+++ b/templates/partials/ie-chart.html
@@ -16,12 +16,17 @@
     <div class="chart__header">
       <h4 class="chart__title">Independent contributions and independent expenditures</h4>
       <ul class="chart__key list--flat">
-        <li class="chart__key__item"><span class="swatch data--receipts"></span> Total independent contributions</li>
-        <li class="chart__key__item"><span class="swatch data--disbursements"></span> Total independent expenditures</li>
+        <li class="chart__key__item"><span class="swatch"></span> Contributions received</li>
+        <li class="chart__key__item"><span class="swatch"></span> Independent expenditures</li>
       </ul>
     </div>
-    {{ charts.chart_series_grouped(reports | reverse | list, ('independent_contributions_period', 'independent_expenditures_period'),
-       label_key=('coverage_start_date', 'coverage_end_date'), tooltip=group_bar_tooltip) }}
+    {{ charts.chart_series_grouped(
+      reports | reverse | list,
+      ('independent_contributions_period', 'independent_expenditures_period'),
+      labels=('Contributions received', 'Independent expenditures'),
+      label_key=('coverage_start_date', 'coverage_end_date'),
+      tooltip=group_bar_tooltip,
+    ) }}
   </figure>
 </div>
 {% endif %}

--- a/templates/partials/ie-chart.html
+++ b/templates/partials/ie-chart.html
@@ -2,13 +2,6 @@
 {% set reports = committee.reports  %}
 {% set totals = committee.totals  %}
 {% import 'macros/charts.html' as charts %}
-{% import 'macros/null.html' as null %}
-{% macro group_bar_tooltip(value, key) %}
-<div class="chart-series__bar__tooltip">
-  <h5 class="chart-series__bar__tooltip__title">{{ key|replace('_', ' ')|title }}</h5>
-  <span class="chart-series__bar__tooltip__value">{{ null.null( value | currency )}}</span>
-</div>
-{% endmacro %}
 
 {% if series_group_has_data(reports, ('independent_contributions_period', 'independent_expenditures_period')) %}
 <div class="row">
@@ -25,7 +18,7 @@
       ('independent_contributions_period', 'independent_expenditures_period'),
       labels=('Contributions received', 'Independent expenditures'),
       label_key=('coverage_start_date', 'coverage_end_date'),
-      tooltip=group_bar_tooltip,
+      tooltip=charts.group_bar_tooltip,
     ) }}
   </figure>
 </div>


### PR DESCRIPTION
This patch fixes issues around labels, tooltip text, and chart bar colors for independent expenditure committees, as described in https://github.com/18F/FEC/issues/134 and https://github.com/18F/FEC/issues/135. It includes language changes from @emileighoutlaw in #931. Note: this does *not* add itemized independent expenditures, so we shouldn't close https://github.com/18F/FEC/issues/134 after merging.

Depends on https://github.com/18F/fec-style/pull/175.

To verify:
* Check out https://github.com/18F/fec-style/pull/175
* Visit the committee detail page for an independent expenditure committee (e.g.  https://beta.fec.gov/data/committee/C90015579/?cycle=2016)
* Verify that chart labels, tooltip text, and colors are correct, as described in https://github.com/18F/FEC/issues/134
* Verify that candidate committee charts are still correct

cc @noahmanger 