### PR TITLE
Skip phantomjs install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ before_script:
   - travis_retry pip install -r requirements.txt
   - travis_retry npm install
   - travis_retry npm install -g gulp
+  - travis_retry npm install karma-phantomjs-launcher karma-phantomjs-shim
   - npm run build
   - python __init__.py &
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
     "karma-chrome-launcher": "^0.2.1",
     "karma-coverage": "^0.5.3",
     "karma-mocha": "^0.2.0",
-    "karma-phantomjs-launcher": "^0.2.1",
-    "karma-phantomjs-shim": "^1.1.2",
     "mocha": "^2.2.5",
     "preprocessify": "0.0.3",
     "sinon": "^1.15.4",


### PR DESCRIPTION
Installing karma-phantomjs-launcher and its peer dependency, phantomjs,
cause deploys to Cloud Foundry to fail. This patch removes the phantomjs
launcher from the dependencies and manually installs within Travis.