### PR TITLE
Load aggregated candidate totals from API.

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -84,6 +84,16 @@ def load_cmte_financials(committee_id, **filters):
     }
 
 
+def load_candidate_totals(candidate_id, cycle):
+    response = _call_api(
+        'candidate', candidate_id, 'totals',
+        cycle=cycle,
+    )
+    if response['results']:
+        return response['results'][0]
+    return {}
+
+
 def result_or_404(data):
     if not data.get('results'):
         abort(404)

--- a/templates/partials/candidate/financial-summary.html
+++ b/templates/partials/candidate/financial-summary.html
@@ -27,20 +27,12 @@
         </div>
         <div>
           <h5 class="term t-data-header" data-term="Ending Cash on Hand">Ending cash on hand</h5>
-          <span class="t-big-data">{{ null.null( aggregate.cash | currency ) }}</span>
+          <span class="t-big-data">{{ null.null( aggregate.cash_on_hand_end_period | currency ) }}</span>
         </div>
         <div>
           <h5 class="term t-data-header" data-term="Debt">Debt</h5>
-          <span class="t-big-data">{{ null.null( aggregate.debt | currency ) }}</span>
+          <span class="t-big-data">{{ null.null( aggregate.debts_owed_by_committee | currency ) }}</span>
         </div>
-        <p>
-          Coverage period:
-          {% if aggregate.start_date and aggregate.end_date %}
-          {{ aggregate.start_date | date }}–{{ aggregate.end_date | date }}
-          {% else %}
-          <a class='term' data-term='None'>None</a>
-          {% endif %}
-        </p>
         <p>
           {% if aggregate.receipts != 0 or
             aggregate.disbursements != 0 or


### PR DESCRIPTION
Instead of making potentially many separate API calls and aggregating
the results manually, this patch uses the new candidate aggregate totals
endpoint to fetch the desired results in a single request. Note: this
removes the coverage dates under the totals values, since they aren't
part of the new endpoint. We can restore them if necessary, but I think
the link to the relevant filings under the values is sufficient.

Depends on https://github.com/18F/openFEC/pull/1352.

Once this and the corresponding API patch are merged, this work will be the basis of four- and six-year totals aggregates on the candidate page.