### PR TITLE
Use hidden field on home election search

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -19,10 +19,7 @@
           </div>
         </div>
         <form action="{{ url_for('election_lookup') }}" class="widget__content">
-          <div class="row u-visually-hidden">
-            <label class="label" for="cycle-select">Choose an election cycle</label>
-            {{ select.cycle_select(cycles, location='form', tooltip=False) }}
-          </div>
+          <input class="u-visually-hidden" type="hidden" value="{{cycles[0]}}" name="cycle">
           <div class="row">
             <div class="row">
               <label for="zip" class="label">Find by ZIP code</label>

--- a/templates/search.html
+++ b/templates/search.html
@@ -19,7 +19,7 @@
           </div>
         </div>
         <form action="{{ url_for('election_lookup') }}" class="widget__content">
-          <input class="u-visually-hidden" type="hidden" value="{{cycles[0]}}" name="cycle">
+          <input type="hidden" value="{{cycles[0]}}" name="cycle">
           <div class="row">
             <div class="row">
               <label for="zip" class="label">Find by ZIP code</label>


### PR DESCRIPTION
Instead of just hiding the cycle select, use a hidden field.

This way the hidden field doesn’t receive tab focus.

Resolves https://github.com/18F/openFEC-web-app/issues/908