### PR TITLE
Feature/fix unit tests

### DIFF
--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -129,13 +129,13 @@ class GithubView(MethodView):
             location='headers',
         ),
         'action': fields.Str(),
-        'response': fields.Str(),
         'feedback': fields.Str(),
+        'about': fields.Str(),
     })
     def post(self, **kwargs):
-        if not any([kwargs['action'], kwargs['response'], kwargs['feedback']]):
+        if not any([kwargs['action'], kwargs['feedback'], kwargs['about']]):
             return jsonify({
-                'message': 'Must provide one of "action", "response", or "feedback".',
+                'message': 'Must provide one of "action", "feedback", or "about".',
             }), 422
         title = 'User feedback on {}'.format(kwargs['referer'])
         body = render_template('feedback.html', headers=request.headers, **kwargs)

--- a/templates/feedback.html
+++ b/templates/feedback.html
@@ -3,12 +3,12 @@
 {{ action }}
 {% endif %}
 
-{% if response %}
+{% if feedback %}
 ## General feedback?
 {{ feedback }}
 {% endif %}
 
-{% if feedback %}
+{% if about %}
 ## Tell us about yourself
 {{ about }}
 {% endif %}

--- a/tests/selenium/committees_list_page_test.py
+++ b/tests/selenium/committees_list_page_test.py
@@ -32,7 +32,7 @@ class CommitteesPageTests(SearchPageTestCase):
             self.assertIn('pork', row.text.lower())
 
     def testCommitteePartyFilter(self):
-        self.check_filter('party', 'REP', 3, 'Republican Party')
+        self.check_filter('party', 'REP', 3, 'REPUBLICAN PARTY')
 
     def testCommitteeStateFilter(self):
         self.check_filter('state', 'CA', 2, 'CA')

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -67,7 +67,8 @@ class TestGithub:
             url_for('issue'),
             {
                 'action': 'i tried to use it',
-                'response': 'but nothing happened',
+                'feedback': 'but nothing happened',
+                'about': 'i like data',
             },
             headers={'referer': referer},
         )
@@ -79,4 +80,5 @@ class TestGithub:
         assert referer in args[0]
         assert 'i tried to use it' in kwargs['body']
         assert 'but nothing happened' in kwargs['body']
+        assert 'i like data' in kwargs['body']
         assert res.json == {'body': 'it broke'}


### PR DESCRIPTION
* Fix variable names for GitHub feedback and associated tests. I should've noticed this earlier, but #949 introduced inconsistent variable names within the feedback template, and between the template and the view.
* Fix a failing Selenium test.