### PR TITLE
Tooltips now triggered by button

### DIFF
--- a/templates/macros/cycle-select.html
+++ b/templates/macros/cycle-select.html
@@ -2,10 +2,11 @@
 {% if cycles %}
   {% if tooltip %}
     <div class="tooltip__container">
-      <label for="{{ id }}" class="label tooltip__trigger">View data for:</label>
+      <label for="{{ id }}" class="label tooltip__trigger-text">View data for:</label>
+      <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
       <div role="tooltip" class="tooltip tooltip--under">
         <p class="tooltip__content">This site groups data in two-year periods — if a candidate or committee has been active more than two years, this page won't show all their data.</p>
-        <p class="tooltip__content">We're currently working to create additional views, but we need your help. See the <a href="https://github.com/18f/fec/issues/73" target="_blank">latest designs on GitHub</a>, and let us know what you think. You can also leave comments using the feedback button at the bottom of this page.</p>
+        <p class="tooltip__content">We're currently working to create additional views, but we need your help. See the <a href="https://github.com/18f/fec/issues/73" tabindex="-1" target="_blank">latest designs on GitHub</a>, and let us know what you think. You can also leave comments using the feedback button at the bottom of this page.</p>
       </div>
     </div>
   {% endif %}

--- a/templates/partials/receipts-filter.html
+++ b/templates/partials/receipts-filter.html
@@ -39,7 +39,8 @@ Filter receipts
       <li>
         <div class="tooltip__container">
           <input id="is-individual" name="is_individual" type="checkbox" value="true" class="tooltip-trigger" aria-describedby="unique-tooltip" checked>
-          <label for="is-individual" class="tooltip__trigger">Unique only</label>
+          <label for="is-individual" class="tooltip__trigger-text">Unique only</label>
+          <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
           <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under">
             <p class="tooltip__content">Some transactions — such as earmarked contributions and partnership contributions — are reported more than once for clarity on the printed page but can lead to confusion when viewed as data online. Use the unique only filter to remove these extra transactions.</p>
           </div>


### PR DESCRIPTION
Changing markup so tooltips are now controlled by a trigger button instead of hovering over a label.

Requires https://github.com/18F/fec-style/pull/187