### PR TITLE
Fix election title and link for off-year periods.

### DIFF
--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -92,6 +92,10 @@ def render_candidate(candidate, committees, cycle, election_full=True):
         key=lambda pair: pair[0],
         reverse=True,
     )
+    tmpl_vars['election_year'] = next(
+        (year for year in sorted(candidate['election_years']) if year >= cycle),
+        None,
+    )
 
     tmpl_vars['context_vars'] = {'cycles': candidate['cycles']}
 

--- a/templates/candidates-single.html
+++ b/templates/candidates-single.html
@@ -67,13 +67,13 @@
           <span class="entity__term__label">More information on this election</span>
           <a
             class="button card card--horizontal card--full-bleed card--neutral"
-            href="{{ election_url(context(), cycle) }}"
+            href="{{ election_url(context(), election_year) }}"
             >
             <div class="card__image__container">
               <img class="card__image icon--complex" src="/static/img/i-elections--primary.svg" alt="Icon representing elections">
             </div>
             <div class="card__content">
-              <h5 class="u-no-margin t-upper t-sans">{{cycle}} {% if office == 'P' %} Presidential election {% else %} {{office_full}} {% endif %}</h5>
+              <h5 class="u-no-margin t-upper t-sans">{{ election_year }} {% if office == 'P' %} Presidential election {% else %} {{office_full}} {% endif %}</h5>
               <span class="t-block">{% if district != '00' %}{{ constants.states[state] }} - {{ district }}{% else %}{{ constants.states[state] }}{% endif %}</span>
             </div>
           </a>

--- a/templates/partials/candidate/financial-summary.html
+++ b/templates/partials/candidate/financial-summary.html
@@ -6,7 +6,7 @@
   <div class="section__heading">
     <h2 class="heading__title">Financial summary: {{ format_election_years(cycle, election_full, duration) }}</h2>
   </div>
-  {% if committees_authorized %}
+  {% if aggregate %}
   <div class="content__section">
     <figure class="candidate__totals">
       <h3 class="t-ruled--bottom">Combined financial totals</h3>


### PR DESCRIPTION
Currently, viewing off-year periods builds incorrect election titles and
links: for example, viewing Barack Obama in 2010 builds a link called
"2010 Presidential Election". This patch builds the correct election
year and uses it for both the title and link.