### PR TITLE
[dontmerge] Hotfix/browse candidates election year

### DIFF
--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -55,7 +55,7 @@ var filings = {
     className: 'all',
     orderable: false,
     render: function(data, type, row, meta) {
-      var cycle = tables.getCycle(row, meta);
+      var cycle = tables.getCycle([row.cycle], meta);
       if (row.candidate_name) {
         return tables.buildEntityLink(
           row.candidate_name,

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -32,13 +32,13 @@ function yearRange(first, last) {
   }
 }
 
-function getCycle(datum, meta) {
+function getCycle(value, meta) {
   var dataTable = DataTable.registry[meta.settings.sTableId];
   var filters = dataTable && dataTable.filters;
   if (filters && filters.cycle) {
     var cycles = _.intersection(
       _.map(filters.cycle, function(cycle) { return parseInt(cycle); }),
-      datum.cycles
+      value
     );
     return {cycle: _.max(cycles)};
   } else {

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -40,7 +40,9 @@ function getCycle(value, meta) {
       _.map(filters.cycle, function(cycle) { return parseInt(cycle); }),
       value
     );
-    return {cycle: _.max(cycles)};
+    return cycles.length ?
+      {cycle: _.max(cycles)} :
+      {};
   } else {
     return {};
   }

--- a/static/js/pages/candidates.js
+++ b/static/js/pages/candidates.js
@@ -19,14 +19,17 @@ var columns = [
     render: function(data, type, row, meta) {
       return tables.buildEntityLink(
         data,
-        helpers.buildAppUrl(['candidate', row.candidate_id], tables.getCycle(row, meta)),
+        helpers.buildAppUrl(
+          ['candidate', row.candidate_id],
+          tables.getCycle(row.election_years, meta)
+        ),
         'candidate'
       );
     }
   },
   {data: 'office_full', className: 'min-tablet hide-panel'},
   {
-    data: 'cycles',
+    data: 'election_years',
     className: 'min-tablet',
     render: function(data, type, row, meta) {
       return tables.yearRange(_.first(data), _.last(data));

--- a/static/js/pages/committees.js
+++ b/static/js/pages/committees.js
@@ -18,7 +18,10 @@ var columns = [
     render: function(data, type, row, meta) {
       return tables.buildEntityLink(
         data,
-        helpers.buildAppUrl(['committee', row.committee_id], tables.getCycle(row, meta)),
+        helpers.buildAppUrl(
+          ['committee', row.committee_id],
+          tables.getCycle(row.cycles, meta)
+        ),
         'committee'
       );
     }


### PR DESCRIPTION
Use election years for election years column.

Use the `election_years` field to populate the "Election years" column
in the browse candidates table, and to build the "cycle" query parameter
for links to candidates. This resolves a bug that was discovered during
the latest release such that candidate links pointed to the most recent
matching cycle, which in many cases was later than the most recent
election year, leading to a large number of effectively dead links.

h/t @leahbannon for spotting this