### PR TITLE
Adding link to candidates page from election

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -288,6 +288,7 @@ def elections(office, cycle, state=None, district=None):
     return render_template(
         'elections.html',
         office=office,
+        office_code=office[0],
         cycle=cycle,
         cycles=cycles,
         state=state,

--- a/templates/partials/elections/candidate-comparison-tab.html
+++ b/templates/partials/elections/candidate-comparison-tab.html
@@ -8,12 +8,12 @@
         <div class="row">
           <h3 class="results-info__title">Candidates in this election</h3>
         </div>
+        <div class="row u-padding--bottom">
+          <span>This page only shows candidates who have registered <em>and</em> filed a financial report. Looking for <a href="{{ url_for('candidates', office=office_code|upper, cycle=cycle, district=district, state=state|upper) }}">all candidates who filed</a>?</span>
+        </div>
         <div class="row">
-          <div class="t-block usa-width-three-fourths">
-            <p>This page only shows candidates who have registered <em>and</em> filed a financial report. Looking for all candidates who filed? <a href="{{ url_for('candidates', office=office_code|upper, cycle=cycle, district=district, state=state|upper) }}">Click here</a>.</p>
-            <p>Totals reflect the sum total reported by all of a candidate's authorized committees.</p>
-          </div>
-          <div class="usa-width-one-fourth is-right-aligned">
+          <span class="t-block usa-width-three-fourths">Totals reflect the sum reported by all of a candidate's authorized committees.</span>
+          <div class="usa-width-one-fourth t-right-aligned">
             <span class="is-incumbent t-sans t-note">Incumbent</span>
           </div>
         </div>

--- a/templates/partials/elections/candidate-comparison-tab.html
+++ b/templates/partials/elections/candidate-comparison-tab.html
@@ -5,9 +5,14 @@
     </div>
     <div class="content__section">
       <div class="results-info results-info--simple">
-        <h3 class="results-info__title">All candidates in this election</h3>
         <div class="row">
-          <span class="t-block usa-width-three-fourths">Totals reflect the sum total reported by all of a candidate's authorized committees.</span>
+          <h3 class="results-info__title">Candidates in this election</h3>
+        </div>
+        <div class="row">
+          <div class="t-block usa-width-three-fourths">
+            <p>This page only shows candidates who have registered <em>and</em> filed a financial report. Looking for all candidates who filed? <a href="{{ url_for('candidates', office=office_code|upper, cycle=cycle, district=district, state=state|upper) }}">Click here</a>.</p>
+            <p>Totals reflect the sum total reported by all of a candidate's authorized committees.</p>
+          </div>
           <div class="usa-width-one-fourth is-right-aligned">
             <span class="is-incumbent t-sans t-note">Incumbent</span>
           </div>


### PR DESCRIPTION
- Adds a `office_code` variable which can be used to build the link to
the candidates browse page
- Adds a link on election pages to view all candidates who’ve filed for
an election

Might make sense to merge until after we've made the "cycle" / "Election years" filter switch, as this will need to change then.

Also, @emileighoutlaw and @jenniferthibault what do you think of language and display as so:

![image](https://cloud.githubusercontent.com/assets/1696495/11965694/282d651e-a8ab-11e5-9f49-fe019f2cf67d.png)

Resolves https://github.com/18F/openFEC/issues/1408