### PR TITLE
Adding query parameter to link to browse pages

### DIFF
--- a/templates/search-results.html
+++ b/templates/search-results.html
@@ -51,7 +51,7 @@
         <div class="sidebar-container">
           <aside class="sidebar">
             <div class="card">
-              <a class="button--neutral" href="{{ url_for(result_type) }}">Filter these results &raquo;</a>
+              <a class="button--neutral" href="{{ url_for(result_type, name=query) }}">Filter these results &raquo;</a>
               <div class="card__content card__content--small">
                 <p>Trying to sort through a lot of results? Want to explore
                   similar {{ result_type }}? Try exploring all {{ result_type }}.


### PR DESCRIPTION
The tiniest little patch to add the query parameter to the "filter these results" link from search results to browse pages:

![image](https://cloud.githubusercontent.com/assets/1696495/11968518/05dc4e50-a8c2-11e5-849c-394b09f85092.png)
 