### PR TITLE
Hide committee contributors on earmarked receipts.

### DIFF
--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -35,6 +35,14 @@ Handlebars.registerHelper({
   }
 });
 
+var globals = {
+  EARMARKED_CODE: '15E'
+};
+
+Handlebars.registerHelper('global', function(value) {
+  return globals[value];
+});
+
 function decodeAmendment(value) {
   return decoders.amendments[value];
 }
@@ -89,5 +97,6 @@ module.exports = {
   cycleDates: cycleDates,
   filterNull: filterNull,
   buildAppUrl: buildAppUrl,
-  buildUrl: buildUrl
+  buildUrl: buildUrl,
+  globals: globals
 };

--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -29,6 +29,12 @@ function datetime(value, options) {
   return parsed.isValid() ? parsed.format(format) : null;
 }
 
+Handlebars.registerHelper({
+  eq: function (v1, v2) {
+    return v1 === v2;
+  }
+});
+
 function decodeAmendment(value) {
   return decoders.amendments[value];
 }

--- a/static/js/pages/receipts.js
+++ b/static/js/pages/receipts.js
@@ -16,7 +16,7 @@ var columns = [
     className: 'all',
     width: '200px',
     render: function(data, type, row, meta) {
-      if (data) {
+      if (data && row.receipt_type !== '15E') {
         return tables.buildEntityLink(
           data.name,
           helpers.buildAppUrl(['committee', data.committee_id]),

--- a/static/js/pages/receipts.js
+++ b/static/js/pages/receipts.js
@@ -16,7 +16,7 @@ var columns = [
     className: 'all',
     width: '200px',
     render: function(data, type, row, meta) {
-      if (data && row.receipt_type !== '15E') {
+      if (data && row.receipt_type !== helpers.globals.EARMARKED_CODE) {
         return tables.buildEntityLink(
           data.name,
           helpers.buildAppUrl(['committee', data.committee_id]),

--- a/static/templates/receipts.hbs
+++ b/static/templates/receipts.hbs
@@ -4,11 +4,23 @@
     <tr>
       <td class="panel__term">Name</td>
       {{#if contributor}}
-        <td class="panel__data"><a href="{{basePath}}/committee/{{contributor.committee_id}}">{{contributor.name}}</a></td>
+        {{#if (eq receipt_type '15E')}}
+          <td class="panel__data">{{contributor_name}}</td>
+        {{else}}
+          <td class="panel__data"><a href="{{basePath}}/committee/{{contributor.committee_id}}">{{contributor.name}}</a></td>
+        {{/if}}
       {{else}}
         <td class="panel__data">{{contributor_name}}</td>
       {{/if}}
     </tr>
+    {{#if contributor}}
+      {{#if (eq receipt_type '15E')}}
+        <tr>
+          <td class="panel__term">Earmarked by</td>
+          <td class="panel__data"><a href="{{basePath}}/committee/{{contributor.committee_id}}">{{contributor.name}}</a></td>
+        </tr>
+      {{/if}}
+    {{/if}}
     <tr>
       <td class="panel__term">City and state</td>
       <td class="panel__data">{{ contributor_city }}, {{ contributor_state }}, {{ contributor_zip }}</td>

--- a/static/templates/receipts.hbs
+++ b/static/templates/receipts.hbs
@@ -25,14 +25,16 @@
       <td class="panel__term">City and state</td>
       <td class="panel__data">{{ contributor_city }}, {{ contributor_state }}, {{ contributor_zip }}</td>
     </tr>
-    <tr>
-      <td class="panel__term">Occupation</td>
-      <td class="panel__data">{{ contributor_occupation }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Employer</td>
-      <td class="panel__data">{{ contributor_employer }}</td>
-    </tr>
+    {{#if is_individual}}
+      <tr>
+        <td class="panel__term">Occupation</td>
+        <td class="panel__data">{{ contributor_occupation }}</td>
+      </tr>
+      <tr>
+        <td class="panel__term">Employer</td>
+        <td class="panel__data">{{ contributor_employer }}</td>
+      </tr>
+    {{/if}}
     <tr>
       <td class="panel__term">Year to date</td>
       <td class="panel__data">{{{ currency contributor_aggregate_ytd }}}</td>

--- a/static/templates/receipts.hbs
+++ b/static/templates/receipts.hbs
@@ -4,7 +4,7 @@
     <tr>
       <td class="panel__term">Name</td>
       {{#if contributor}}
-        {{#if (eq receipt_type '15E')}}
+        {{#if (eq receipt_type (global 'EARMARKED_CODE'))}}
           <td class="panel__data">{{contributor_name}}</td>
         {{else}}
           <td class="panel__data"><a href="{{basePath}}/committee/{{contributor.committee_id}}">{{contributor.name}}</a></td>
@@ -14,7 +14,7 @@
       {{/if}}
     </tr>
     {{#if contributor}}
-      {{#if (eq receipt_type '15E')}}
+      {{#if (eq receipt_type (global 'EARMARKED_CODE'))}}
         <tr>
           <td class="panel__term">Earmarked by</td>
           <td class="panel__data"><a href="{{basePath}}/committee/{{contributor.committee_id}}">{{contributor.name}}</a></td>


### PR DESCRIPTION
As @PaulClark2 explained, the `contbr_id` field for earmarked receipts
describes the earmarking committee and not the contributor. This patch
uses the `contbr_nm` field and hides the `contbr_id` field in these
cases.

[Resolves https://github.com/18F/openFEC/issues/1426]
[Resolves https://github.com/18F/openFEC/issues/1410]
[Resolves https://github.com/18F/openFEC/issues/1308]