### PR TITLE
Add URL of local instance of site to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Then start the server:
 
     $ python __init__.py
 
+To view the site, visit [http://localhost:3000/](http://localhost:3000/).
+
 To run the server in debug mode set:
 
     $ export FEC_WEB_DEBUG=true


### PR DESCRIPTION
I tracked down the default port of the local instances of the site and added it to the readme.