### PR TITLE
Link candidate committees to most recent applicable cycle.

### DIFF
--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -69,7 +69,6 @@ def render_candidate(candidate, committees, cycle, election_full=True):
     tmpl_vars = candidate
 
     tmpl_vars['cycle'] = cycle
-    tmpl_vars['cycle_loaded'] = candidate['two_year_period']
     tmpl_vars['result_type'] = 'candidates'
     tmpl_vars['duration'] = election_durations.get(candidate['office'], 2)
     tmpl_vars['election_full'] = election_full
@@ -78,6 +77,14 @@ def render_candidate(candidate, committees, cycle, election_full=True):
         if election_full
         else [cycle]
     )
+
+    # Annotate committees with most recent available cycle
+    for committee in committees:
+        committee['related_cycle'] = (
+            max(cycle for cycle in tmpl_vars['aggregate_cycles'] if cycle in committee['cycles'])
+            if election_full
+            else candidate['two_year_period']
+        )
 
     committee_groups = groupby(committees, lambda each: each['designation'])
     committees_authorized = committee_groups.get('P', []) + committee_groups.get('A', [])

--- a/templates/candidates-single.html
+++ b/templates/candidates-single.html
@@ -45,7 +45,7 @@
           </span>
           {% for c in committee_groups['P'] %}
           <p class="entity__term__data">
-            <a href="{{ url_for('committee_page', c_id=c.committee_id, cycle=cycle_loaded) }}">{{ c.name }}</a>
+            <a href="{{ url_for('committee_page', c_id=c.committee_id, cycle=c.related_cycle) }}">{{ c.name }}</a>
           </span>
           {% endfor %}
         </li>


### PR DESCRIPTION
Currently, candidate detail pages link to related committees at the
current cycle. On full election views, related committees may have no
data for the selected cycle, leading to a 404. This patch resolves the
404 issue by linking to each related primary committee using the most
recent applicable cycle.

[Resolves https://github.com/18F/FEC/issues/195]

To verify: as described in https://github.com/18F/FEC/issues/195, browse to /data/candidate/P00003392/, and check that both primary committee links resolve. Because "Hillary Clinton for President" last reported in 2014, that link should go to the 2014 cycle; the more recently active "Hillary for America" should go to the 2016 cycle.

cc @LindsayYoung @noahmanger 