### PR TITLE
Add block helper to reduce panel boilerplate.

### DIFF
--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -80,6 +80,14 @@ Handlebars.registerHelper('decodeReport', decodeReport);
 
 Handlebars.registerHelper('basePath', BASE_PATH);
 
+Handlebars.registerHelper('panelRow', function(label, options) {
+  return new Handlebars.SafeString(
+    '<tr>' +
+      '<td class="panel__term">' + label + '</td>' +
+      '<td class="panel__data">' + options.fn(this) + '</td>' +
+    '</tr>'
+  );
+});
 
 function cycleDates(year) {
   return {

--- a/static/templates/candidates.hbs
+++ b/static/templates/candidates.hbs
@@ -3,33 +3,27 @@
     <h4 class="panel__title"><a href="{{basePath}}/candidate/{{candidate_id}}">{{name}}</a></h4>
   </div>
   <table>
-    <tr>
-      <td class="panel__term">Office</td>
-      <td class="panel__data">{{office_full}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Election years</td>
-      <td class="panel__data">{{election_years}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Political party</td>
-      <td class="panel__data">{{party_full}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Status</td>
-      <td class="panel__data">{{incumbent_challenge_full}}</td>
-    </tr>
+    {{#panelRow "Office"}}
+      {{office_full}}
+    {{/panelRow}}
+    {{#panelRow "Election years"}}
+      {{election_years}}
+    {{/panelRow}}
+    {{#panelRow "Political party"}}
+      {{party_full}}
+    {{/panelRow}}
+    {{#panelRow "Status"}}
+      {{incumbent_challenge_full}}
+    {{/panelRow}}
     {{#if state}}
-    <tr>
-      <td class="panel__term">State</td>
-      <td class="panel__data">{{state}}</td>
-    </tr>
+      {{#panelRow "State"}}
+        {{state}}
+      {{/panelRow}}
     {{/if}}
     {{#if district}}
-    <tr>
-      <td class="panel__term">District</td>
-      <td class="panel__data">{{district}}</td>
-    </tr>
+      {{#panelRow "District"}}
+        {{district}}
+      {{/panelRow}}
     {{/if}}
   </table>
 </div>

--- a/static/templates/committees.hbs
+++ b/static/templates/committees.hbs
@@ -3,35 +3,28 @@
     <h4 class="panel__title"><a href="{{basePath}}/committee/{{committee_id}}">{{name}}</a></h4>
   </div>
   <table>
-    <tr>
-      <td class="panel__term">Treasurer</td>
-      <td class="panel__data">{{treasurer_name}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">State</td>
-      <td class="panel__data">{{state}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Political party</td>
-      <td class="panel__data">{{party_full}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">First file date</td>
-      <td class="panel__data">{{datetime first_file_date pretty=true}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Designation</td>
-      <td class="panel__data">{{designation_full}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Type</td>
-      <td class="panel__data">{{committee_type_full}}</td>
-    </tr>
+    {{#panelRow "Treasurer"}}
+      {{treasurer_name}}
+    {{/panelRow}}
+    {{#panelRow "State"}}
+      {{state}}
+    {{/panelRow}}
+    {{#panelRow "Political party"}}
+      {{party_full}}
+    {{/panelRow}}
+    {{#panelRow "First file date"}}
+      {{datetime first_file_date pretty=true}}
+    {{/panelRow}}
+    {{#panelRow "Designation"}}
+      {{designation_full}}
+    {{/panelRow}}
+    {{#panelRow "Type"}}
+      {{committee_type_full}}
+    {{/panelRow}}
     {{#if organization_type_full}}
-    <tr>
-      <td class="panel__term">Organization type</td>
-      <td class="panel__data">{{organization_type_full}}</td>
-    </tr>
+      {{#panelRow "Organization type"}}
+        {{organization_type_full}}
+      {{/panelRow}}
     {{/if}}
   </table>
 </div>

--- a/static/templates/committees.hbs
+++ b/static/templates/committees.hbs
@@ -13,7 +13,7 @@
       {{party_full}}
     {{/panelRow}}
     {{#panelRow "First file date"}}
-      {{datetime first_file_date pretty=true}}
+      {{datetime first_file_date format="pretty"}}
     {{/panelRow}}
     {{#panelRow "Designation"}}
       {{designation_full}}

--- a/static/templates/disbursements.hbs
+++ b/static/templates/disbursements.hbs
@@ -1,53 +1,44 @@
 <div class="panel__row">
   <h4 class="panel__title">Recipient information</h4>
   <table>
-    <tr>
-      <td class="panel__term">Recipient name</td>
+    {{#panelRow "Recipient name"}}
       {{#if recipient}}
-        <td class="panel__data"><a href="{{basePath}}/committee/{{recipient.committee_id}}">{{recipient.name}}</a></td>
+        <a href="{{basePath}}/committee/{{recipient.committee_id}}">{{recipient.name}}</a>
       {{else}}
-        <td class="panel__data">{{recipient_name}}</td>
+        {{recipient_name}}
       {{/if}}
-    </tr>
-    <tr>
-      <td class="panel__term">Recipient city and state</td>
-      <td class="panel__data">{{ recipient_city }}, {{ recipient_state }}, {{ recipient_zip }}</td>
-    </tr>
+    {{/panelRow}}
+    {{#panelRow "Recipient city and state"}}
+      {{recipient_city}}, {{recipient_state}}, {{recipient_zip}}
+    {{/panelRow}}
   </table>
 </div>
 
 <div class="panel__row">
   <h4 class="panel__title">Transaction information</h4>
   <table>
-    <tr>
-      <td class="panel__term">Amount</td>
-      <td class="panel__data">{{{ currency disbursement_amount }}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Disbursement date</td>
-      <td class="panel__data">{{{ datetime disbursement_date pretty=true }}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Filing date</td>
-      <td class="panel__data">{{{ datetime receipt_date pretty=true}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Purpose</td>
-      <td class="panel__data">{{ disbursement_description }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Memo</td>
-      <td class="panel__data">{{ memo_text }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Memo code</td>
-      <td class="panel__data">{{ memoed_subtotal }}</td>
-    </tr>
+    {{#panelRow "Amount"}}
+      {{{currency disbursement_amount}}}
+    {{/panelRow}}
+    {{#panelRow "Disbursement date"}}
+      {{{datetime disbursement_date format="pretty"}}}
+    {{/panelRow}}
+    {{#panelRow "Filing date"}}
+      {{{datetime receipt_date format="pretty"}}}
+    {{/panelRow}}
+    {{#panelRow "Purpose"}}
+      {{disbursement_description}}
+    {{/panelRow}}
+    {{#panelRow "Memo"}}
+      {{memo_text}}
+    {{/panelRow}}
+    {{#panelRow "Memo code"}}
+      {{memoed_subtotal}}
+    {{/panelRow}}
     {{#if election_type_full }}
-    <tr>
-      <td class="panel__term">Election type</td>
-      <td class="panel__data">{{ election_type_full }}</td>
-    </tr>
+      {{#panelRow "Election type"}}
+        {{election_type_full}}
+      {{/panelRow}}
     {{/if}}
   </table>
 </div>
@@ -55,27 +46,22 @@
 <div class="panel__row">
   <h4 class="panel__title">Committee information</h4>
   <table>
-    <tr>
-      <td class="panel__term">Name</td>
-      <td class="panel__data"><a href="{{basePath}}/committee/{{committee_id}}">{{committee.name}}</a></td>
-    </tr>
-    <tr>
-      <td class="panel__term">Designation</td>
-      <td class="panel__data">{{committee.designation_full}}</a></td>
-    </tr>
+    {{#panelRow "Name"}}
+      <a href="{{basePath}}/committee/{{committee_id}}">{{committee.name}}</a>
+    {{/panelRow}}
+    {{#panelRow "Designation"}}
+      {{committee.designation_full}}
+    {{/panelRow}}
     {{#if committee.type}}
-    <tr>
-      <td class="panel__term">Type</td>
-      <td class="panel__data">{{committee.type_full}}</a></td>
-    </tr>
+      {{#panelRow "Type"}}
+        {{committee.type_full}}
+      {{/panelRow}}
     {{/if}}
-    <tr>
-      <td class="panel__term">Treasurer</td>
-      <td class="panel__data">{{committee.treasurer_name}}</a></td>
-    </tr>
-    <tr>
-      <td class="panel__term">Committee city and state</td>
-      <td class="panel__data">{{ committee.city }}, {{ committee.state }}, {{ committee.zip }}</td>
-    </tr>
+    {{#panelRow "Treasurer"}}
+      {{committee.treasurer_name}}
+    {{/panelRow}}
+    {{#panelRow "Committee city and state"}}
+      {{committee.city}}, {{committee.state}}, {{committee.zip}}
+    {{/panelRow}}
   </table>
 </div>

--- a/static/templates/filings/candidate.hbs
+++ b/static/templates/filings/candidate.hbs
@@ -5,10 +5,10 @@
   </div>
   <table>
     {{#panelRow "Report coverage"}}
-      {{datetime coverage_start_date pretty=true}} - {{datetime coverage_end_date pretty=true}}
+      {{datetime coverage_start_date format="pretty"}} - {{datetime coverage_end_date format="pretty"}}
     {{/panelRow}}
     {{#panelRow "Receipt date"}}
-      {{datetime receipt_date pretty=true}}
+      {{datetime receipt_date format="pretty"}}
     {{/panelRow}}
     {{#panelRow "Amendment indicator"}}
       {{decodeAmendment amendment_indicator}}

--- a/static/templates/filings/candidate.hbs
+++ b/static/templates/filings/candidate.hbs
@@ -4,83 +4,66 @@
     <span class="panel__subtitle t-bold"><a href="{{basePath}}/committee/{{committee_id}}">{{ committee_name }}</a></span>
   </div>
   <table>
-    <tr>
-      <td class="panel__term" scope="row">Report coverage</td>
-      <td class="panel__data">{{datetime coverage_start_date pretty=true}} - {{datetime coverage_end_date pretty=true}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term" scope="row">Receipt date</td>
-      <td class="panel__data">{{ datetime receipt_date pretty=true }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term" scope="row">Amendment indicator</td>
-      <td class="panel__data">{{ decodeAmendment amendment_indicator }}</td>
-    </tr>
+    {{#panelRow "Report coverage"}}
+      {{datetime coverage_start_date pretty=true}} - {{datetime coverage_end_date pretty=true}}
+    {{/panelRow}}
+    {{#panelRow "Receipt date"}}
+      {{datetime receipt_date pretty=true}}
+    {{/panelRow}}
+    {{#panelRow "Amendment indicator"}}
+      {{decodeAmendment amendment_indicator}}
+    {{/panelRow}}
   </table>
 </div>
 <div class="panel__row">
   <table>
-    <tr>
-      <td class="panel__term">Total receipts</td>
-      <td class="panel__data">{{{currency total_receipts_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Total disbursements</td>
-      <td class="panel__data">{{{currency total_disbursements_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Transfers to authorized committees</td>
-      <td class="panel__data">{{{currency transfers_to_other_authorized_committee_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Individual contributions</td>
-      <td class="panel__data">{{{currency total_individual_contributions_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Itemized individual contributions</td>
-      <td class="panel__data">{{{currency individual_itemized_contributions_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Unitemized individual contributions</td>
-      <td class="panel__data">{{{currency individual_unitemized_contributions_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Loan repayments</td>
-      <td class="panel__data">{{{currency total_loan_repayments_made_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Beginning cash on hand</td>
-      <td class="panel__data">{{{currency cash_on_hand_beginning_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Ending cash on hand</td>
-      <td class="panel__data">{{{currency cash_on_hand_end_period}}}</td>
-    </tr>
+    {{#panelRow "Total receipts"}}
+      {{{currency total_receipts_period}}}
+    {{/panelRow}}
+    {{#panelRow "Total disbursements"}}
+      {{{currency total_disbursements_period}}}
+    {{/panelRow}}
+    {{#panelRow "Transfers to authorized committees"}}
+      {{{currency transfers_to_other_authorized_committee_period}}}
+    {{/panelRow}}
+    {{#panelRow "Individual contributions"}}
+      {{{currency total_individual_contributions_period}}}
+    {{/panelRow}}
+    {{#panelRow "Itemized individual contributions"}}
+      {{{currency individual_itemized_contributions_period}}}
+    {{/panelRow}}
+    {{#panelRow "Unitemized individual contributions"}}
+      {{{currency individual_unitemized_contributions_period}}}
+    {{/panelRow}}
+    {{#panelRow "Loan repayments"}}
+      {{{currency total_loan_repayments_made_period}}}
+    {{/panelRow}}
+    {{#panelRow "Beginning cash on hand"}}
+      {{{currency cash_on_hand_beginning_period}}}
+    {{/panelRow}}
+    {{#panelRow "Ending cash on hand"}}
+      {{{currency cash_on_hand_end_period}}}
+    {{/panelRow}}
     {{#if net_contributions_period}}
-    <tr>
-      <td class="panel__term">Net contributions period</td>
-      <td class="panel__data">{{{currency net_contributions_period}}}</td>
-    </tr>
+      {{#panelRow "Net contributions period"}}
+        {{{currency net_contributions_period}}}
+      {{/panelRow}}
     {{else}}
-    <tr>
-      <td class="panel__term">Net contributions cycle to date</td>
-      <td class="panel__data">{{{currency net_contributions_cycle_to_date}}}</td>
-    </tr>
+      {{#panelRow "Net contributions cycle to date"}}
+        {{{currency net_contributions_cycle_to_date}}}
+      {{/panelRow}}
     {{/if}}
     {{#if net_operating_expenditures_period}}
-    <tr>
-      <td class="panel__term">Net operating expenditures period</td>
-      <td class="panel__data">{{{currency net_operating_expenditures_period}}}</td>
-    </tr>
+      {{#panelRow "Net operating expenditures period"}}
+        {{{currency net_operating_expenditures_period}}}
+      {{/panelRow}}
     {{else}}
-    <tr>
-      <td class="panel__term">Net operating expenditures cycle to date</td>
-      <td class="panel__data">{{{currency net_operating_expenditures_cycle_to_date}}}</td>
-    </tr>
+      {{#panelRow "Net operating expenditures cycle to date"}}
+        {{{currency net_operating_expenditures_cycle_to_date}}}
+      {{/panelRow}}
     {{/if}}
-    <tr>
-      <td class="panel__term">Debts owed by committee</td>
-      <td class="panel__data">{{{currency debts_owed_by_committee}}}</td>
-    </tr>
+    {{#panelRow "Debts owed by committee"}}
+      {{{currency debts_owed_by_committee}}}
+    {{/panelRow}}
   </table>
 </div>

--- a/static/templates/filings/pac.hbs
+++ b/static/templates/filings/pac.hbs
@@ -5,10 +5,10 @@
   </div>
   <table>
     {{#panelRow "Report coverage"}}
-      {{datetime coverage_start_date pretty=true}} - {{datetime coverage_end_date pretty=true}}
+      {{datetime coverage_start_date format="pretty"}} - {{datetime coverage_end_date format="pretty"}}
     {{/panelRow}}
     {{#panelRow "Receipt date"}}
-      {{datetime receipt_date pretty=true}}
+      {{datetime receipt_date format="pretty"}}
     {{/panelRow}}
     {{#panelRow "Amendment indicator"}}
       {{decodeAmendment amendment_indicator}}

--- a/static/templates/filings/pac.hbs
+++ b/static/templates/filings/pac.hbs
@@ -4,61 +4,48 @@
     <span class="panel__subtitle t-bold"><a href="{{basePath}}/committee/{{committee_id}}">{{ committee_name }}</a></span>
   </div>
   <table>
-    <tr>
-      <td class="panel__term" scope="row">Report coverage</td>
-      <td class="panel__data">{{datetime coverage_start_date pretty=true}} - {{datetime coverage_end_date pretty=true}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term" scope="row">Receipt date</td>
-      <td class="panel__data">{{ datetime receipt_date pretty=true}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term" scope="row">Amendment indicator</td>
-      <td class="panel__data">{{ decodeAmendment amendment_indicator }}</td>
-    </tr>
+    {{#panelRow "Report coverage"}}
+      {{datetime coverage_start_date pretty=true}} - {{datetime coverage_end_date pretty=true}}
+    {{/panelRow}}
+    {{#panelRow "Receipt date"}}
+      {{datetime receipt_date pretty=true}}
+    {{/panelRow}}
+    {{#panelRow "Amendment indicator"}}
+      {{decodeAmendment amendment_indicator}}
+    {{/panelRow}}
   </table>
 </div>
 <div class="panel__row">
   <table>
-    <tr>
-      <td class="panel__term" scope="row">Total receipts</td>
-      <td class="panel__data">{{{currency total_receipts_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term" scope="row">Total disbursements</td>
-      <td class="panel__data">{{{currency total_disbursements_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term" scope="row">Individual contributions</td>
-      <td class="panel__data">{{{currency total_individual_contributions_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term" scope="row">Itemized individual contributions</td>
-      <td class="panel__data">{{{currency individual_itemized_contributions_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term" scope="row">Unitemized individual contributions</td>
-      <td class="panel__data">{{{currency individual_unitemized_contributions_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term" scope="row">Beginning cash on hand</td>
-      <td class="panel__data">{{{currency cash_on_hand_beginning_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term" scope="row">Ending cash on hand</td>
-      <td class="panel__data">{{{currency cash_on_hand_end_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term" scope="row">Net contributions</td>
-      <td class="panel__data">{{{currency net_contributions_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term" scope="row">Net operating expenditures</td>
-      <td class="panel__data">{{{currency net_operating_expenditures_period}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term" scope="row">Debts owed by committee</td>
-      <td class="panel__data">{{{currency debts_owed_by_committee}}}</td>
-    </tr>
+    {{#panelRow "Total receipts"}}
+      {{{currency total_receipts_period}}}
+    {{/panelRow}}
+    {{#panelRow "Total disbursements"}}
+      {{{currency total_disbursements_period}}}
+    {{/panelRow}}
+    {{#panelRow "Individual contributions"}}
+      {{{currency total_individual_contributions_period}}}
+    {{/panelRow}}
+    {{#panelRow "Itemized individual contributions"}}
+      {{{currency individual_itemized_contributions_period}}}
+    {{/panelRow}}
+    {{#panelRow "Unitemized individual contributions"}}
+      {{{currency individual_unitemized_contributions_period}}}
+    {{/panelRow}}
+    {{#panelRow "Beginning cash on hand"}}
+      {{{currency cash_on_hand_beginning_period}}}
+    {{/panelRow}}
+    {{#panelRow "Ending cash on hand"}}
+      {{{currency cash_on_hand_end_period}}}
+    {{/panelRow}}
+    {{#panelRow "Net contributions"}}
+      {{{currency net_contributions_period}}}
+    {{/panelRow}}
+    {{#panelRow "Net operating expenditures"}}
+      {{{currency net_operating_expenditures_period}}}
+    {{/panelRow}}
+    {{#panelRow "Debts owed by committee"}}
+      {{{currency debts_owed_by_committee}}}
+    {{/panelRow}}
   </table>
 </div>

--- a/static/templates/independent-expenditures.hbs
+++ b/static/templates/independent-expenditures.hbs
@@ -5,10 +5,10 @@
       {{currency expenditure_amount}}
     {{/panelRow}}
     {{#panelRow "Expenditure date"}}
-      {{datetime expenditure_date pretty=true}}
+      {{datetime expenditure_date format="pretty"}}
     {{/panelRow}}
     {{#panelRow "Dissemination date"}}
-      {{datetime dissemination_date pretty=true}}
+      {{datetime dissemination_date format="pretty"}}
     {{/panelRow}}
     {{#panelRow "Candidate"}}
       <a href="{{basePath}}/candidate/{{candidate_id}}/">{{candidate_name}}</a>
@@ -18,7 +18,7 @@
       {{expenditure_description}}
     {{/panelRow}}
     {{#panelRow "Payee"}}
-      {{payee_name}}<br />
+      {{payee_name}}<br>
       {{payee_city}}, {{payee_state}}
     {{/panelRow}}
   </table>
@@ -34,7 +34,7 @@
       {{decodeReport report_type}}
     {{/panelRow}}
     {{#panelRow "Receipt date"}}
-      {{datetime receipt_date pretty=true}}
+      {{datetime receipt_date format="pretty"}}
     {{/panelRow}}
   </table>
 </div>

--- a/static/templates/independent-expenditures.hbs
+++ b/static/templates/independent-expenditures.hbs
@@ -1,101 +1,83 @@
 <div class="panel__row">
   <h4 class="panel__title">Expenditure information</h4>
   <table>
-    <tr>
-      <td class="panel__term">Amount</td>
-      <td class="panel__data">{{ currency expenditure_amount }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Expenditure date</td>
-      <td class="panel__data">{{ datetime expenditure_date pretty=true }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Dissemination date</td>
-      <td class="panel__data">{{ datetime dissemination_date pretty=true }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Candidate</td>
-      <td class="panel__data"><a href="{{basePath}}/candidate/{{ candidate_id }}/">{{ candidate_name }}</a> ({{ decodeSupportOppose support_oppose_indicator }})</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Description</td>
-      <td class="panel__data">{{ expenditure_description }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Payee</td>
-      <td class="panel__data">
-        {{ payee_name }}<br>
-        {{ payee_city }}, {{ payee_state }}
-      </td>
-    </tr>
+    {{#panelRow "Amount"}}
+      {{currency expenditure_amount}}
+    {{/panelRow}}
+    {{#panelRow "Expenditure date"}}
+      {{datetime expenditure_date pretty=true}}
+    {{/panelRow}}
+    {{#panelRow "Dissemination date"}}
+      {{datetime dissemination_date pretty=true}}
+    {{/panelRow}}
+    {{#panelRow "Candidate"}}
+      <a href="{{basePath}}/candidate/{{candidate_id}}/">{{candidate_name}}</a>
+      ({{decodeSupportOppose support_oppose_indicator}})
+    {{/panelRow}}
+    {{#panelRow "Description"}}
+      {{expenditure_description}}
+    {{/panelRow}}
+    {{#panelRow "Payee"}}
+      {{payee_name}}<br />
+      {{payee_city}}, {{payee_state}}
+    {{/panelRow}}
   </table>
 </div>
 
 <div class="panel__row">
   <h4 class="panel__title">Filing information</h4>
   <table>
-    <tr>
-      <td class="panel__term">Form type</td>
-      <td class="panel__data">{{ decodeForm form_type }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Report type</td>
-      <td class="panel__data">{{ decodeReport report_type }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Receipt date</td>
-      <td class="panel__data">{{ datetime receipt_date pretty=true }}</td>
-    </tr>
+    {{#panelRow "Form type"}}
+      {{decodeForm form_type}}
+    {{/panelRow}}
+    {{#panelRow "Report type"}}
+      {{decodeReport report_type}}
+    {{/panelRow}}
+    {{#panelRow "Receipt date"}}
+      {{datetime receipt_date pretty=true}}
+    {{/panelRow}}
   </table>
 </div>
+
 <div class="panel__row">
   <h4 class="panel__title">Committee information</h4>
   <table>
-    <tr>
-      <td class="panel__term">Committee name</td>
-      <td class="panel__data"><a href="{{basePath}}/committee/{{committee_id}}">{{committee.name}}</a></td>
-    </tr>
-    <tr>
-      <td class="panel__term">Committee type</td>
-      <td class="panel__data">{{ committee.committee_type_full }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Treasurer</td>
-      <td class="panel__data">{{ committee.treasurer_name }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">City and state</td>
-      <td class="panel__data">{{ committee.city }}, {{ committee.state }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Total spent on office (year to date)</td>
-      <td class="panel__data">{{ currency office_total_ytd }}</td>
-    </tr>
+    {{#panelRow "Committee name"}}
+      <a href="{{basePath}}/committee/{{committee_id}}">{{committee.name}}</a>
+    {{/panelRow}}
+    {{#panelRow "Committee type"}}
+      {{committee.committee_type_full}}
+    {{/panelRow}}
+    {{#panelRow "Treasurer"}}
+      {{committee.treasurer_name}}
+    {{/panelRow}}
+    {{#panelRow "City and state"}}
+      {{committee.city}}, {{committee.state}}
+    {{/panelRow}}
+    {{#panelRow "Total spent on office (year to date)"}}
+      {{currency office_total_ytd}}
+    {{/panelRow}}
   </table>
 </div>
 
 <div class="panel__row">
   <h4 class="panel__title">Candidate information</h4>
   <table>
-    <tr>
-      <td class="panel__term">Candidate</td>
-      <td class="panel__data"><a href="{{basePath}}/candidate/{{ candidate_id }}/">{{ candidate_name }}</a></td>
-    </tr>
-    <tr>
-      <td class="panel__term">Office</td>
-      <td class="panel__data">{{ decodeOffice candidate_office }}</td>
-    </tr>
+    {{#panelRow "Candidate"}}
+      <a href="{{basePath}}/candidate/{{candidate_id}}/">{{candidate_name}}</a>
+    {{/panelRow}}
+    {{#panelRow "Office"}}
+      {{decodeOffice candidate_office}}
+    {{/panelRow}}
     {{#if candidate_state }}
-    <tr>
-      <td class="panel__term">State</td>
-      <td class="panel__data">{{ cand_office_state }}</td>
-    </tr>
+      {{#panelRow "State"}}
+        {{cand_office_state}}
+      {{/panelRow}}
     {{/if}}
     {{#if candidate_district}}
-    <tr>
-      <td class="panel__term">District</td>
-      <td class="panel__data">{{ cand_office_district }}</td>
-    </tr>
+      {{#panelRow "District"}}
+        {{cand_office_district}}
+      {{/panelRow}}
     {{/if}}
   </table>
 </div>

--- a/static/templates/receipts.hbs
+++ b/static/templates/receipts.hbs
@@ -53,7 +53,7 @@
     {{#panelRow "Memo"}}
       {{memo_text}}
     {{/panelRow}}
-    {{#panelRow "Electiontype"}}
+    {{#panelRow "Election type"}}
       {{election_type_full}}
     {{/panelRow}}
   </table>

--- a/static/templates/receipts.hbs
+++ b/static/templates/receipts.hbs
@@ -2,90 +2,77 @@
   <h4 class="panel__title">Contributor information</h4>
   <table>
     <tr>
-      <td class="panel__term">Name</td>
-      {{#if contributor}}
-        {{#if (eq receipt_type (global 'EARMARKED_CODE'))}}
-          <td class="panel__data">{{contributor_name}}</td>
+      {{#panelRow "Name"}}
+        {{#if contributor}}
+          {{#if (eq receipt_type (global 'EARMARKED_CODE'))}}
+            {{contributor_name}}
+          {{else}}
+            <a href="{{basePath}}/committee/{{contributor.committee_id}}">{{contributor.name}}</a>
+          {{/if}}
         {{else}}
-          <td class="panel__data"><a href="{{basePath}}/committee/{{contributor.committee_id}}">{{contributor.name}}</a></td>
+          {{contributor_name}}
         {{/if}}
-      {{else}}
-        <td class="panel__data">{{contributor_name}}</td>
-      {{/if}}
+      {{/panelRow}}
     </tr>
     {{#if contributor}}
       {{#if (eq receipt_type (global 'EARMARKED_CODE'))}}
-        <tr>
-          <td class="panel__term">Earmarked by</td>
-          <td class="panel__data"><a href="{{basePath}}/committee/{{contributor.committee_id}}">{{contributor.name}}</a></td>
-        </tr>
+        {{#panelRow "Earmarked by"}}
+          <a href="{{basePath}}/committee/{{contributor.committee_id}}">{{contributor.name}}</a>
+        {{/panelRow}}
       {{/if}}
     {{/if}}
-    <tr>
-      <td class="panel__term">City and state</td>
-      <td class="panel__data">{{ contributor_city }}, {{ contributor_state }}, {{ contributor_zip }}</td>
-    </tr>
+    {{#panelRow "City and state"}}
+      {{contributor_city}}, {{contributor_state}}, {{contributor_zip}}
+    {{/panelRow}}
     {{#if is_individual}}
-      <tr>
-        <td class="panel__term">Occupation</td>
-        <td class="panel__data">{{ contributor_occupation }}</td>
-      </tr>
-      <tr>
-        <td class="panel__term">Employer</td>
-        <td class="panel__data">{{ contributor_employer }}</td>
-      </tr>
+      {{#panelRow "Occupation"}}
+        {{contributor_occupation}}
+      {{/panelRow}}
+      {{#panelRow "Employer"}}
+        {{contributor_employer}}
+      {{/panelRow}}
     {{/if}}
-    <tr>
-      <td class="panel__term">Year to date</td>
-      <td class="panel__data">{{{ currency contributor_aggregate_ytd }}}</td>
-    </tr>
+    {{#panelRow "Year to date"}}
+      {{{currency contributor_aggregate_ytd}}}
+    {{/panelRow}}
   </table>
 </div>
 
 <div class="panel__row">
   <h4 class="panel__title">Contribution information</h4>
   <table>
-    <tr>
-      <td class="panel__term">Amount</td>
-      <td class="panel__data">{{{ currency contribution_receipt_amount }}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Receipt date</td>
-      <td class="panel__data">{{{ datetime contribution_receipt_date pretty=true }}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Filing date</td>
-      <td class="panel__data">{{{ datetime receipt_date pretty=true}}}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Memo</td>
-      <td class="panel__data">{{ memo_text }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Election type</td>
-      <td class="panel__data">{{ election_type_full }}</td>
-    </tr>
+    {{#panelRow "Amount"}}
+      {{{currency contribution_receipt_amount}}}
+    {{/panelRow}}
+    {{#panelRow "Receipt date"}}
+      {{{datetime contribution_receipt_date format="pretty"}}}
+    {{/panelRow}}
+    {{#panelRow "Filing date"}}
+      {{{datetime receipt_date format="pretty"}}}
+    {{/panelRow}}
+    {{#panelRow "Memo"}}
+      {{memo_text}}
+    {{/panelRow}}
+    {{#panelRow "Electiontype"}}
+      {{election_type_full}}
+    {{/panelRow}}
   </table>
 </div>
 
 <div class="panel__row">
   <h4 class="panel__title">Recipient information</h4>
   <table>
-    <tr>
-      <td class="panel__term">Committee</td>
-      <td class="panel__data"><a href="{{basePath}}/committee/{{ committee.committee_id }}/">{{ committee.name }}</a></td>
-    </tr>
-    <tr>
-      <td class="panel__term">Political party</td>
-      <td class="panel__data">{{ committee.party_full }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">Type</td>
-      <td class="panel__data">{{ committee.committee_type_full }}</td>
-    </tr>
-    <tr>
-      <td class="panel__term">State</td>
-      <td class="panel__data">{{ committee.state_full }}</td>
-    </tr>
+    {{#panelRow "Committee"}}
+      <a href="{{basePath}}/committee/{{ committee.committee_id }}/">{{ committee.name }}</a>
+    {{/panelRow}}
+    {{#panelRow "Political party"}}
+      {{committee.party_full}}
+    {{/panelRow}}
+    {{#panelRow "Type"}}
+      {{committee.committee_type_full}}
+    {{/panelRow}}
+    {{#panelRow "State"}}
+      {{committee.state_full}}
+    {{/panelRow}}
   </table>
 </div>


### PR DESCRIPTION
This reduces some of the boilerplate around table panel rows--we move the elements and classes to a block helper, and the person writing the templates only has to think about content. I didn't update every last row--I will if we agree that the change is worthwhile.

cc @noahmanger 