### PR TITLE
Content only: Copyedit to ZIP code autotext

### DIFF
--- a/templates/election-lookup.html
+++ b/templates/election-lookup.html
@@ -21,7 +21,7 @@
             <div class="row">
               <label for="zip" class="label">Find by ZIP code</label>
               <div class="search-controls__zip">
-                <input type="text" inputmode="numeric" id="zip" name="zip" placeholder="e.g. 10001">
+                <input type="text" inputmode="numeric" id="zip" name="zip" placeholder="Example: 10001">
               </div>
               <div class="search-controls__submit">
                 <button type="submit" class="button--search--text button--neutral">Search</button>

--- a/templates/election-lookup.html
+++ b/templates/election-lookup.html
@@ -21,7 +21,7 @@
             <div class="row">
               <label for="zip" class="label">Find by ZIP code</label>
               <div class="search-controls__zip">
-                <input type="text" inputmode="numeric" id="zip" name="zip" placeholder="Example: 10001">
+                <input type="text" inputmode="numeric" id="zip" name="zip" placeholder="Example: 90210">
               </div>
               <div class="search-controls__submit">
                 <button type="submit" class="button--search--text button--neutral">Search</button>


### PR DESCRIPTION
Eliminates `e.g.` which users don't often understand
Adds a more flavorful ZIP

