### PR TITLE
Remove $'s from commands in readme for pastability

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Install client side dependencies:
 
 If you plan to do client side JS developent, you will want to install [Watchify](https://github.com/substack/watchify):
 ```
-$ npm install -g watchify
+npm install -g watchify
 ```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ It uses Python version 3.4. Its recommended that you create a [virtualenv](http:
 
 Install Python dependencies:
 
-    $ pip install -r requirements.txt
+    pip install -r requirements.txt
 
 Install client side dependencies:
 
-    $ npm install -g browserify
-    $ npm install
+    npm install -g browserify
+    npm install
 
 If you plan to do client side JS developent, you will want to install [Watchify](https://github.com/substack/watchify):
 ```
@@ -68,46 +68,46 @@ can set, but that have defaults. You can see those in `openfecwebapp/config.py`.
 ### Run server
 To make the site fully functional, you will need to compile the client side JS and CSS:
 
-    $ npm run build
+    npm run build
 
 Then start the server:
 
-    $ python __init__.py
+    python __init__.py
 
 To view the site, visit [http://localhost:3000/](http://localhost:3000/).
 
 To run the server in debug mode set:
 
-    $ export FEC_WEB_DEBUG=true
+    export FEC_WEB_DEBUG=true
 
 To use styles served from a custom location (e.g., if developing against a local `fec-style`):
 
-    $ export FEC_WEB_STYLE_URL=http://localhost:8080/css/styles.css
+    export FEC_WEB_STYLE_URL=http://localhost:8080/css/styles.css
 
 To be able to have links between this app and a local installation of the cms:
 
-    $ export FEC_CMS_URL=http://localhost:8000
+    export FEC_CMS_URL=http://localhost:8000
     
 If you'd like the app to cache API requests it makes, use the `--cached` flag:
 
-    $ python __init__.py --cached
+    python __init__.py --cached
 
 ### Development
 To compile client side JS once:
 
-    $ npm run build-js
+    npm run build-js
 
 Compile Sass once:
 
-    $ npm run build-sass
+    npm run build-sass
 
 Compile JS as changes are made:
 
-    $ npm run watch-js
+    npm run watch-js
 
 Compile Sass as changes are made:
 
-    $ npm run watch-sass
+    npm run watch-sass
 
 ### Deployment
 
@@ -124,29 +124,29 @@ be stale for up to the cache duration set by the API.
 ### Run Tests
 #### Unit Tests
 
-    $ py.test
+    py.test
 
 #### Browser Tests
 First, install [PhantomJS](http://phantomjs.org/).
 
 Configure development environment:
 
-    $ unset FEC_WEB_API_KEY
-    $ export FEC_WEB_API_URL=http://fec-dev-api.18f.gov
-    $ export FEC_WEB_TEST=true
+    unset FEC_WEB_API_KEY
+    export FEC_WEB_API_URL=http://fec-dev-api.18f.gov
+    export FEC_WEB_TEST=true
 
 Run development app server:
 
-    $ python __init__.py
+    python __init__.py
 
 While app is running, run tests:
 
-    $ py.test --selenium
+    py.test --selenium
 
 If the development API is down or for testing with feature branches of the API,
 a local API server can be used:
 
-    $ unset FEC_WEB_API_URL
+    unset FEC_WEB_API_URL
 
 #### Git Hooks
 
@@ -156,11 +156,11 @@ update Python and Node dependencies, and rebuild compiled JS and CSS files,
 on checking out or merging changes to `requirements.txt`, `package.json`,
 or source JS or SCSS files. To enable the hooks, run
 
-    $ invoke add_hooks
+    invoke add_hooks
 
 To disable, run
 
-    $ invoke remove_hooks
+    invoke remove_hooks
 
 
 ## Copyright and licensing


### PR DESCRIPTION
Now, if you copy a command from the readme with triple-click control-C,
you can paste it directly into a shell and run it.

Command:

    python - README.md <<EOF
    import re
    import sys

    fn = sys.argv[1]
    lines = None
    with open(fn) as f:
      lines = f.readlines()
    with sys.stdout as f:
      for line in lines:
        f.write(re.sub(r"^( +)\\$ ", r"\1", line))
    EOF