### PR TITLE
Handle null tick dates.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -373,7 +373,10 @@ def _unique(values):
 
 
 def _fmt_chart_tick(value):
-    return parse_date(value).strftime('%m/%d/%y')
+    try:
+        return parse_date(value).strftime('%m/%d/%y')
+    except (AttributeError, ValueError):
+        return '?'
 
 
 @app.template_filter('fmt_chart_ticks')

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -66,9 +66,10 @@ def load_with_nested(primary_type, primary_id, secondary_type, cycle=None,
 
 def load_cmte_financials(committee_id, **filters):
     filters.update({
+        'is_amended': 'false',
         'per_page': MAX_FINANCIALS_COUNT,
         'report_type': filters.get('report_type', []) + ['-TER'],
-        'is_amended': 'false',
+        'sort_hide_null': 'true',
     })
 
     reports = _call_api('committee', committee_id, 'reports', **filters)


### PR DESCRIPTION
Some reports have null coverage start dates, which cause the tick
formatter to crash and throw a 500. This patch replaces null or invalid
dates with "?".

[Resolves https://github.com/18F/openFEC/issues/1488]
