### PR TITLE
Use top-level committee information.

### DIFF
--- a/static/js/pages/electioneering-communications.js
+++ b/static/js/pages/electioneering-communications.js
@@ -30,9 +30,14 @@ var columns = [
   },
   tables.currencyColumn({data: 'disbursement_amount', className: 'min-tablet'}),
   {
+    data: 'number_of_candidates',
+    className: 'min-tablet',
+  },
+  tables.currencyColumn({data: 'calculated_candidate_share', className: 'min-tablet'}),
+  {
     data: 'candidate_name',
     orderable: false,
-    className: 'min-desktop hide-panel',
+    className: 'min-desktop hide-panel hide-panel-tablet',
     render: function(data, type, row, meta) {
       return tables.buildEntityLink(
         data,
@@ -41,8 +46,7 @@ var columns = [
       );
     }
   },
-  tables.dateColumn({data: 'disbursement_date', className: 'min-tablet hide-panel-tablet'}),
-  tables.urlColumn('pdf_url', {data: 'purpose_description', className: 'all hide-panel', orderable: false}),
+  tables.dateColumn({data: 'disbursement_date', className: 'min-tablet hide-panel'}),
   {
     className: 'all u-no-padding',
     width: '20px',

--- a/static/js/pages/electioneering-communications.js
+++ b/static/js/pages/electioneering-communications.js
@@ -13,14 +13,14 @@ var electioneeringTemplate = require('../../templates/electioneering-communicati
 
 var columns = [
   {
-    data: 'committee',
+    data: 'committee_name',
     orderable: false,
     className: 'min-desktop',
     render: function(data, type, row, meta) {
       if (data) {
         return tables.buildEntityLink(
-          data.name,
-          helpers.buildAppUrl(['committee', data.committee_id]),
+          data,
+          helpers.buildAppUrl(['committee', row.committee_id]),
           'committee'
         );
       } else {

--- a/static/templates/communication-costs.hbs
+++ b/static/templates/communication-costs.hbs
@@ -13,6 +13,9 @@
     {{#panelRow "Transaction date"}}
       {{ datetime transaction_date format=pretty }}
     {{/panelRow}}
+    {{#panelRow "Transaction type"}}
+      {{transaction_type}}
+    {{/panelRow}}
     {{#panelRow "Communication class"}}
       {{ communication_class }}
     {{/panelRow}}

--- a/static/templates/communication-costs.hbs
+++ b/static/templates/communication-costs.hbs
@@ -25,9 +25,6 @@
     {{#panelRow "Purpose"}}
       {{ purpose }}
     {{/panelRow}}
-    {{#panelRow "Candidate"}}
-      <a href="{{basePath}}/candidate/{{ candidate_id }}/">{{ candidate_name }}</a> ({{ decodeSupportOppose support_oppose_indicator }})
-    {{/panelRow}}
   </table>
 </div>
 
@@ -35,7 +32,7 @@
   <h4 class="panel__title">Candidate information</h4>
   <table>
     {{#panelRow "Candidate"}}
-      <a href="{{basePath}}/candidate/{{ candidate_id }}/">{{ candidate_name }}</a>
+      <a href="{{basePath}}/candidate/{{candidate_id}}/">{{candidate_name}}</a> ({{decodeSupportOppose support_oppose_indicator}})
     {{/panelRow}}
     {{#panelRow "Party"}}
       {{ decodeParty candidate_party_affiliation }}

--- a/static/templates/electioneering-communications.hbs
+++ b/static/templates/electioneering-communications.hbs
@@ -1,9 +1,29 @@
 <div class="panel__row">
   <h4 class="panel__title">Disbursement information</h4>
   <table>
+    {{#panelRow "Spender"}}
+      <a href="{{basePath}}/committee/{{committee_id}}">{{committee_name}}</a>
+    {{/panelRow}}
     {{#panelRow "Amount"}}
       {{ currency disbursement_amount }}
     {{/panelRow}}
+    {{#panelRow "Number of candidates mentioned"}}
+      {{ number_of_candidates }}
+    {{/panelRow}}
+    <tr>
+      <td class="panel__term">
+        <div class="tooltip__container">
+          <span>Amount per candidate</span>
+          <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
+          <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under">
+            <p class="tooltip__content">To help users work with this data, we divide each itemized disbursement amount by the number of federal candidates named in connection with that disbursement. The resulting number is listed as the notional amount per candidate.</p>
+          </div>
+        </div>
+      </td>
+      <td class="panel__data">
+        {{ currency calculated_candidate_share }}
+      </td>
+    </tr>
     {{#panelRow "Report year"}}
       {{ report_year }}
     {{/panelRow}}
@@ -23,31 +43,10 @@
 </div>
 
 <div class="panel__row">
-  <h4 class="panel__title">Committee information</h4>
-  <table>
-    {{#panelRow "Committee name"}}
-      <a href="{{basePath}}/committee/{{committee_id}}">{{committee.name}}</a>
-    {{/panelRow}}
-    {{#panelRow "Committee type"}}
-      {{ committee.committee_type_full }}
-    {{/panelRow}}
-    {{#panelRow "Treasurer"}}
-      {{ committee.treasurer_name }}
-    {{/panelRow}}
-    {{#panelRow "City and state"}}
-      {{ committee.city }}, {{ committee.state }}
-    {{/panelRow}}
-  </table>
-</div>
-
-<div class="panel__row">
   <h4 class="panel__title">Candidate information</h4>
   <table>
     {{#panelRow "Candidate"}}
       <a href="{{basePath}}/candidate/{{ candidate_id }}/">{{ candidate_name }}</a>
-    {{/panelRow}}
-    {{#panelRow "Party"}}
-      {{ decodeParty candidate.party }}
     {{/panelRow}}
     {{#panelRow "Office"}}
       {{ decodeOffice candidate_office }}
@@ -57,10 +56,14 @@
         {{ decodeState candidate_office_state }}
       {{/panelRow}}
     {{/if}}
-    {{#unless (eq candidate.district '00') }}
+    {{#unless (eq candidate_district '00') }}
       {{#panelRow "District"}}
-        {{ candidate.district }}
+        {{ candidate_district }}
       {{/panelRow}}
     {{/unless}}
   </table>
+</div>
+
+<div class="message message--info message--small">
+  <span class="t-block">To help users work with this data, we divide each itemized disbursement amount by the number of federal candidates named in connection with that disbursement. The resulting number is listed as the notional amount per candidate.</span>
 </div>

--- a/static/templates/electioneering-communications.hbs
+++ b/static/templates/electioneering-communications.hbs
@@ -33,9 +33,6 @@
     {{#panelRow "Communication date"}}
       {{ datetime communication_date format=pretty }}
     {{/panelRow}}
-    {{#panelRow "Candidate"}}
-      <a href="{{basePath}}/candidate/{{ candidate_id }}/">{{ candidate_name }}</a>
-    {{/panelRow}}
     {{#panelRow "Purpose description"}}
       {{ purpose_description }}
     {{/panelRow}}
@@ -46,19 +43,19 @@
   <h4 class="panel__title">Candidate information</h4>
   <table>
     {{#panelRow "Candidate"}}
-      <a href="{{basePath}}/candidate/{{ candidate_id }}/">{{ candidate_name }}</a>
+      <a href="{{basePath}}/candidate/{{candidate_id}}/">{{candidate_name}}</a>
     {{/panelRow}}
     {{#panelRow "Office"}}
       {{ decodeOffice candidate_office }}
     {{/panelRow}}
-    {{#if candidate_office_state }}
+    {{#if candidate_state}}
       {{#panelRow "State"}}
-        {{ decodeState candidate_office_state }}
+        {{decodeState candidate_state}}
       {{/panelRow}}
     {{/if}}
     {{#unless (eq candidate_district '00') }}
       {{#panelRow "District"}}
-        {{ candidate_district }}
+        {{candidate_district}}
       {{/panelRow}}
     {{/unless}}
   </table>

--- a/static/templates/electioneering-communications.hbs
+++ b/static/templates/electioneering-communications.hbs
@@ -63,7 +63,3 @@
     {{/unless}}
   </table>
 </div>
-
-<div class="message message--info message--small">
-  <span class="t-block">To help users work with this data, we divide each itemized disbursement amount by the number of federal candidates named in connection with that disbursement. The resulting number is listed as the notional amount per candidate.</span>
-</div>

--- a/static/templates/independent-expenditures.hbs
+++ b/static/templates/independent-expenditures.hbs
@@ -68,7 +68,6 @@
   <h4 class="panel__title">Candidate information</h4>
   <table>
     {{#panelRow "Candidate"}}
-      <a href="{{basePath}}/candidate/{{candidate_id}}/">{{candidate_name}}</a>
       {{#if candidate_id}}
         <a href="{{basePath}}/candidate/{{candidate_id}}/">{{candidate_name}}</a>
       {{else}}

--- a/templates/electioneering-communications.html
+++ b/templates/electioneering-communications.html
@@ -18,11 +18,12 @@
       <table id="results" class="data-table" data-type="electioneering-communications">
         <thead>
           <tr>
-            <th scope="col">Committee</th>
-            <th scope="col">Amount</th>
+            <th scope="col">Spender</th>
+            <th scope="col">Disbursement amount</th>
+            <th scope="col">Number of candidates</th>
+            <th scope="col">Amount per candidate</th>
             <th scope="col">Candidate</th>
             <th scope="col">Disbursement date</th>
-            <th scope="col">Description</th>
             <th scope="col"></th>
           </tr>
         </thead>

--- a/templates/partials/candidate/other-spending-tab.html
+++ b/templates/partials/candidate/other-spending-tab.html
@@ -74,6 +74,9 @@
           </tr>
         </thead>
       </table>
+      <div class="datatable__note">
+        <p class="t-note">Note: to help users work with this data, we divide each itemized disbursement amount by the number of federal candidates named in connection with that disbursement. The resulting number is listed as the notional amount calculated for this candidate.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/partials/committee/electioneering-tab.html
+++ b/templates/partials/committee/electioneering-tab.html
@@ -19,6 +19,9 @@
           <th scope="col">Candidate</th>
         </thead>
       </table>
+      <div class="datatable__note">
+        <p class="t-note">Note: to help users work with this data, we divide each itemized disbursement amount by the number of federal candidates named in connection with that disbursement. The resulting number is listed as the notional amount calculated for this candidate.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/partials/elections/other-spending-tab.html
+++ b/templates/partials/elections/other-spending-tab.html
@@ -50,6 +50,9 @@
           <th scope="col">Candidate</th>
         </thead>
       </table>
+      <div class="datatable__note">
+        <p class="t-note">Note: to help users work with this data, we divide each itemized disbursement amount by the number of federal candidates named in connection with that disbursement. The resulting number is listed as the notional amount calculated for this candidate.</p>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Necessary to handle an update in the electioneering communication schema
such that nested committee information is removed and top-level
committee details added.

Review with https://github.com/18F/openFEC/pull/1518.
