### PR TITLE
Fix cycle labels and query parameters.

### DIFF
--- a/openfecwebapp/templates/partials/candidates-filter.html
+++ b/openfecwebapp/templates/partials/candidates-filter.html
@@ -3,11 +3,12 @@
 {% import 'macros/filters/text.html' as text %}
 {% import 'macros/filters/states.html' as states %}
 {% import 'macros/filters/typeahead-filter.html' as typeahead %}
+{% import 'macros/filters/years.html' as years %}
 
 {% block filters %}
 <div class="filters__inner">
   {{ typeahead.field('q', 'Candidate name or ID', 'Find an ID by searching for a candidate name', 'candidates', True) }}
-  {% include 'partials/filters/election-years.html' %}
+  {{ years.years('election_year', 'Election year')  }}
   {% include 'partials/filters/office-sought.html' %}
   {% include 'partials/filters/parties.html' %}
   {{ states.field('state') }}

--- a/openfecwebapp/templates/partials/committee-filter.html
+++ b/openfecwebapp/templates/partials/committee-filter.html
@@ -3,12 +3,13 @@
 {% import 'macros/filters/text.html' as text %}
 {% import 'macros/filters/states.html' as states %}
 {% import 'macros/filters/typeahead-filter.html' as typeahead %}
+{% import 'macros/filters/years.html' as years %}
 
 {% block filters %}
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
   <div class="filters__inner">
     {{ typeahead.field('q', 'Committee name or ID', False, 'committees', True) }}
-    {% include 'partials/filters/election-years.html' %}
+    {{ years.years('cycle', 'Two-year period')  }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Committee details</button>
   <div class="accordion__content">

--- a/openfecwebapp/templates/partials/filings-filter.html
+++ b/openfecwebapp/templates/partials/filings-filter.html
@@ -3,6 +3,7 @@
 {% import 'macros/filters/text.html' as text %}
 {% import 'macros/filters/typeahead-filter.html' as typeahead %}
 {% import 'macros/filters/states.html' as states %}
+{% import 'macros/filters/years.html' as years %}
 {% import 'macros/filters/date.html' as date %}
 
 {% block heading %}
@@ -19,7 +20,7 @@ Filter filings
 
   <button type="button" class="js-accordion-trigger accordion__button">Filing date</button>
   <div class="accordion__content">
-    {% include 'partials/filters/election-years.html' %}
+    {{ years.years('cycle', 'Two-year period')  }}
     {{ date.field('receipt_date', 'Receipt date', dates ) }}
   </div>
 

--- a/openfecwebapp/templates/partials/filters/election-years.html
+++ b/openfecwebapp/templates/partials/filters/election-years.html
@@ -1,3 +1,0 @@
-{% import 'macros/filters/years.html' as years %}
-
-{{ years.years('election_year', 'Election years') }}

--- a/openfecwebapp/templates/partials/independent-expenditures-filter.html
+++ b/openfecwebapp/templates/partials/independent-expenditures-filter.html
@@ -3,6 +3,7 @@
 {% import 'macros/filters/text.html' as text %}
 {% import 'macros/filters/typeahead-filter.html' as typeahead %}
 {% import 'macros/filters/states.html' as states %}
+{% import 'macros/filters/years.html' as years %}
 {% import 'macros/filters/date.html' as date %}
 
 {% block heading %}
@@ -19,7 +20,7 @@ Filter independent expenditures
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
   <div class="filters__inner">
     {{ typeahead.field('committee_id', 'Spender') }}
-    {% include 'partials/filters/election-years.html' %}
+    {{ years.years('cycle', 'Two-year period')  }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Candidate mentioned</button>
   <div class="accordion__content">


### PR DESCRIPTION
Filters for candidates, committees, filings, and independent
expenditures currently use the same partial for cycles. This leads to
unexpected behavior, since the different resources expect different
query parameters: candidates are filtered on election year, and other
resources are filtered on two-year period. This patch fixes filter
labels and query parameters, and drops an unnecessary partial.