### PR TITLE
Enabling calendar

### DIFF
--- a/openfecwebapp/templates/partials/navigation.html
+++ b/openfecwebapp/templates/partials/navigation.html
@@ -44,8 +44,8 @@
     <li class="site-nav__item">
       <a href="{{ cms_url }}/registration-and-reporting" class="site-nav__link">Registration and reporting</a>
     </li>
-    <li class="site-nav__item is-disabled">
-      <a href="#" class="site-nav__link" tabindex="-1">(Calendar)</a>
+    <li class="site-nav__item">
+      <a href="{{ cms_url }}/calendar" class="site-nav__link">Calendar</a>
     </li>
     <li class="site-nav__item is-disabled">
       <a href="#" class="site-nav__link" tabindex="-1">(Page TBD)</a>


### PR DESCRIPTION
Somewhere along the line the calendar link reverted to its disabled state. This restores it.