### PR TITLE
Feature/fixing district button

### DIFF
--- a/openfecwebapp/templates/partials/filters/districts.html
+++ b/openfecwebapp/templates/partials/filters/districts.html
@@ -3,7 +3,7 @@
     <legend class="label" for="district"><span class="term" data-term="District">District</span></legend>
     <ul class="dropdown__selected"></ul>
     <div class="dropdown">
-      <button type="button" class="dropdown__button button--neutral">More</button>
+      <button type="button" class="dropdown__button button--primary-contrast">More</button>
       <div id="district-dropdown" class="dropdown__panel" aria-hidden="true">
         <ul class="dropdown__list">
             {% for district in range(100) %}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "d3": "3.5.5",
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
-    "fec-style": "1.7.0",
+    "fec-style": "1.7.1",
     "handlebars": "3.0.3",
     "hbsfy": "2.2.1",
     "intl": "1.0.0-rc-4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "d3": "3.5.5",
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
-    "fec-style": "1.7.1",
+    "fec-style": "1.7.2",
     "handlebars": "3.0.3",
     "hbsfy": "2.2.1",
     "intl": "1.0.0-rc-4",

--- a/static/js/modules/download.js
+++ b/static/js/modules/download.js
@@ -165,7 +165,7 @@ DownloadItem.prototype.handleError = function(xhr, textStatus) {
 DownloadItem.prototype.finish = function(downloadUrl) {
   this.downloadUrl = downloadUrl;
   this.push();
-  // this.$body.removeClass('is-pending');
+  this.$body.removeClass('is-pending');
   this.$body.addClass('is-complete');
   this.$body.find('.download__message').remove();
   this.$button.attr('href', this.downloadUrl).removeClass('disabled');

--- a/static/js/modules/download.js
+++ b/static/js/modules/download.js
@@ -84,7 +84,6 @@ function DownloadItem(url, container, opts) {
   this.timestamp = payload.timestamp || moment().format(DATE_FORMAT);
   this.downloadUrl = payload.downloadUrl;
   this.isPending = !_.isEmpty(payload);
-
   this.filename = this.resource + '-' + this.timestamp + '.zip';
 }
 
@@ -166,6 +165,7 @@ DownloadItem.prototype.handleError = function(xhr, textStatus) {
 DownloadItem.prototype.finish = function(downloadUrl) {
   this.downloadUrl = downloadUrl;
   this.push();
+  // this.$body.removeClass('is-pending');
   this.$body.addClass('is-complete');
   this.$body.find('.download__message').remove();
   this.$button.attr('href', this.downloadUrl).removeClass('disabled');

--- a/static/templates/download/item.hbs
+++ b/static/templates/download/item.hbs
@@ -1,4 +1,4 @@
-<li class="download">
+<li class="download {{#if downloadUrl}}is-complete{{else}}is-pending{{/if}}">
   <div class="download__item">
     <span id="download-file-name" class="download__name">{{filename}}</span>
       <a class="button button--primary-contrast download__button {{#unless downloadUrl}}disabled{{/unless}}"


### PR DESCRIPTION
- Fixes the button style on the district button for consistency
- Bumps the fec-style version
- Restores `.is-pending` / `.is-complete` status on the download items, which we lost when consolidating to a single handlebars template

Also needs to be merged into the release.