### PR TITLE
Removing duplicate row in the H + S totals table

### DIFF
--- a/openfecwebapp/templates/partials/committee-totals-house-senate.html
+++ b/openfecwebapp/templates/partials/committee-totals-house-senate.html
@@ -30,7 +30,6 @@
      (totals.0.refunded_individual_contributions, 'Individual refunds'),
      (totals.0.refunded_political_party_committee_contributions, 'Political party refunds'),
      (totals.0.refunded_other_political_committee_contributions, 'Other committee refunds'),
-     (totals.0.other_disbursements, 'Other disbursements'),
      (totals.0.contribution_refunds, 'Total contribution refunds'),
      (totals.0.other_disbursements, 'Other disbursements'),
    ]


### PR DESCRIPTION
Noticed there was a duplicate on House and Senate totals tables:

![screen shot 2016-03-17 at 1 02 49 pm](https://cloud.githubusercontent.com/assets/1696495/13859418/9b50f9f6-ec40-11e5-9f5b-1beb8423ba88.png)

Can be merged after release.
