### PR TITLE
Updating the pinned version of fec-style

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "d3": "3.5.5",
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
-    "fec-style": "1.7.2",
+    "fec-style": "~1.7",
     "handlebars": "3.0.3",
     "hbsfy": "2.2.1",
     "intl": "1.0.0-rc-4",


### PR DESCRIPTION
This changeset updates the dependency to `fec-style` to allow for retrieving the latest patch level.

/cc @noahmanger