### PR TITLE
Use global hbsfy transform in tests.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,7 +5,9 @@ var istanbul = require('browserify-istanbul');
 module.exports = function(config) {
   var browserify = {
     debug: true,
-    transform: ['hbsfy']
+    transform: [
+      [{global: true}, 'hbsfy']
+    ]
   };
 
   var reporters = ['progress'];


### PR DESCRIPTION
By default, browserify only applies the requested transforms to source files, not to dependencies. This patch uses the global flag to apply the handlebars transform to dependencies too.

cc @noahmanger