### PR TITLE
Adds tests for tablist

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,13 +27,15 @@ module.exports = function(config) {
 
     files: [
       'tests/unit/**/*.js',
-      'static/js/modules/**/*.js'
+      'static/js/modules/**/*.js',
+      'static/js/vendor/**/*.js'
     ],
 
     preprocessors: {
       'tests/unit/**/*.js': ['browserify'],
       'static/js/pages/**/*.js': ['browserify'],
-      'static/js/modules/**/*.js': ['browserify']
+      'static/js/modules/**/*.js': ['browserify'],
+      'static/js/vendor/**/*.js': ['browserify']
     },
 
     browserify: browserify,

--- a/tests/unit/vendor/tablist.js
+++ b/tests/unit/vendor/tablist.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var chai = require('chai');
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+var expect = chai.expect;
+chai.use(sinonChai);
+
+var tablist = require('../../../static/js/vendor/tablist');
+
+describe('show', function() {
+  var fixture;
+  before(function() {
+    fixture = $('<div id="fixtures"></div>');
+    $('body').append(this.fixture);
+  });
+
+  beforeEach(function() {
+    fixture.empty().append(
+      '<ul role="tablist" data-name="tab">' +
+        '<li><a role="tab" data-name="tab0">0</a></li>' +
+        '<li><a role="tab" data-name="tab1">1</a></li>' +
+      '</ul>'
+    );
+  });
+});

--- a/tests/unit/vendor/tablist.js
+++ b/tests/unit/vendor/tablist.js
@@ -6,21 +6,27 @@ var sinonChai = require('sinon-chai');
 var expect = chai.expect;
 chai.use(sinonChai);
 
+var $ = require('jquery');
+
 var tablist = require('../../../static/js/vendor/tablist');
 
-describe('show', function() {
+describe('tablist', function() {
   var fixture;
   before(function() {
     fixture = $('<div id="fixtures"></div>');
     $('body').append(this.fixture);
   });
 
-  beforeEach(function() {
-    fixture.empty().append(
-      '<ul role="tablist" data-name="tab">' +
-        '<li><a role="tab" data-name="tab0">0</a></li>' +
-        '<li><a role="tab" data-name="tab1">1</a></li>' +
-      '</ul>'
-    );
+  describe('init', function() {
+    it('should show all tab panels if there are no tabs', function() {
+      fixture.empty().append(
+        '<ul role="tablist" data-name="tab"></ul>' +
+        '<section role="tabpanel" aria-hidden></section>'
+      );
+
+      tablist.init();
+
+      expect($('[role="tabpanel"]').attr('aria-hidden')).to.be.undefined;
+    });
   });
 });

--- a/tests/unit/vendor/tablist.js
+++ b/tests/unit/vendor/tablist.js
@@ -14,19 +14,45 @@ describe('tablist', function() {
   var fixture;
   before(function() {
     fixture = $('<div id="fixtures"></div>');
-    $('body').append(this.fixture);
+    $('body').append(fixture);
   });
 
   describe('init', function() {
     it('should show all tab panels if there are no tabs', function() {
       fixture.empty().append(
-        '<ul role="tablist" data-name="tab"></ul>' +
-        '<section role="tabpanel" aria-hidden></section>'
+        '<div class="tab-interface">' + 
+          '<ul role="tablist" data-name="tab"></ul>' +
+          '<section role="tabpanel" aria-hidden="true"></section>' +
+        '</div>'
       );
 
       tablist.init();
 
       expect($('[role="tabpanel"]').attr('aria-hidden')).to.be.undefined;
+    });
+
+    it('should show first tab if there\'s no query', function() {
+      fixture.empty().append(
+        '<div class="tab-interface">' + 
+          '<ul role="tablist" data-name="tab">' +
+            '<li><a role="tab" data-name="tab0" href="#section-0">0</a></li>' +
+            '<li><a role="tab" data-name="tab1" href="#section-1">1</a></li>' +
+          '</ul>' +
+          '<section id="section-0" role="tabpanel" aria-hidden="true">' +
+            '' +
+          '</section>' +
+          '<section id="section-1" role="tabpanel">' +
+            '' +
+          '</section>' +
+        '</div>'
+      );
+
+      tablist.init();
+
+      expect($('[data-name="tab0"]').attr('aria-selected')).to.be.eql('true');
+      expect($('[data-name="tab1"]').attr('aria-selected')).to.be.undefined;
+      expect($('#section-0').attr('aria-hidden')).to.be.undefined;
+      expect($('#section-1').attr('aria-hidden')).to.be.eql('true');
     });
   });
 });

--- a/tests/unit/vendor/tablist.js
+++ b/tests/unit/vendor/tablist.js
@@ -1,10 +1,5 @@
-'use strict';
-
 var chai = require('chai');
-var sinon = require('sinon');
-var sinonChai = require('sinon-chai');
 var expect = chai.expect;
-chai.use(sinonChai);
 
 var $ = require('jquery');
 
@@ -39,11 +34,8 @@ describe('tablist', function() {
             '<li><a role="tab" data-name="tab1" href="#section-1">1</a></li>' +
           '</ul>' +
           '<section id="section-0" role="tabpanel" aria-hidden="true">' +
-            '' +
           '</section>' +
-          '<section id="section-1" role="tabpanel">' +
-            '' +
-          '</section>' +
+          '<section id="section-1" role="tabpanel"></section>' +
         '</div>'
       );
 

--- a/tests/unit/vendor/tablist.js
+++ b/tests/unit/vendor/tablist.js
@@ -1,3 +1,6 @@
+/* jshint strict:true */
+'use strict';
+
 var chai = require('chai');
 var expect = chai.expect;
 


### PR DESCRIPTION
1. Configures Browserify to process tablist.js.
2. Adds basic tests for tablist.

Part of step two of #1052.