### PR TITLE
Omits "funds"

### DIFF
--- a/openfecwebapp/templates/search.html
+++ b/openfecwebapp/templates/search.html
@@ -65,11 +65,11 @@
         <h2 class="widget__title"><span class="t-short">So far in the 2016 presidential election:</span></h2>
         <div class="widget__content">
           <div>
-            <h5 class="t-data-header">Funds raised</h5>
+            <h5 class="t-data-header">Raised</h5>
             <span class="t-big-data js-receipts"></span>
           </div>
           <div>
-            <h5 class="t-data-header">Funds spent</h5>
+            <h5 class="t-data-header">Spent</h5>
             <span class="t-big-data js-disbursements"></span>
           </div>
           <div>


### PR DESCRIPTION
"Funds" is a weird word. And in this case, the H5 is followed by a dollar sign, which I think is a clear explainer that we are talking about money. 

This PR proposes that rather than saying "Funds raised" and "Funds spent" we say only "Raised" and "Spent."

Related: https://github.com/18F/openFEC-web-app/issues/1158

Content only. Let me know if anyone has questions or concerns.