### PR TITLE
Fixes the app initialization with gunicorn

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,2 +1,2 @@
 invoke notify
-gunicorn openfecwebapp:app
+gunicorn openfecwebapp.app:app

--- a/openfecwebapp/app.py
+++ b/openfecwebapp/app.py
@@ -24,7 +24,7 @@ locale.setlocale(locale.LC_ALL, '')
 
 logger = logging.getLogger(__name__)
 
-app = Flask('openfecwebapp', static_path='/static', static_folder='../dist')
+app = Flask(__name__, static_path='/static', static_folder='../dist')
 
 from openfecwebapp import routes  # noqa
 from openfecwebapp import filters  # noqa


### PR DESCRIPTION
This changeset addresses an issue I introduced with the last commit to update the deployment.  I tried to account for this by explicitly setting the app name to `openfecwebapp` in the Flask app initialization, but by moving it into `app.py` this still ultimately did not work.  I have changed this to simply use the module name itself as is standard practice and fixed the `gunicorn` initialization in `bin/run.sh` to properly account for the new namespace.

/cc @LindsayYoung