### PR TITLE
Feature/refactor table columns

### DIFF
--- a/static/js/modules/column-helpers.js
+++ b/static/js/modules/column-helpers.js
@@ -1,0 +1,137 @@
+'use strict';
+
+var _ = require('underscore');
+
+var tables = require('./tables');
+var helpers = require('./helpers');
+var decoders = require('./decoders');
+
+var sizeInfo = {
+  0: {limits: [0, 199.99], label: 'Under $200'},
+  200: {limits: [200, 499.99], label: '$200—$499'},
+  500: {limits: [500, 999.99], label: '$500—$999'},
+  1000: {limits: [1000, 1999.99], label: '$1000—$1999'},
+  2000: {limits: [2000, null], label: 'Over $2000'},
+};
+
+function getSizeParams(size) {
+  var limits = sizeInfo[size].limits;
+  var params = {is_individual: 'true'};
+  if (limits[0] !== null) {
+    params.min_amount = helpers.currency(limits[0]);
+  }
+  if (limits[1] !== null) {
+    params.max_amount = helpers.currency(limits[1]);
+  }
+  return params;
+}
+
+function getColumns(columns, keys) {
+  return _.map(keys, function(key) {
+    return columns[key];
+  });
+}
+
+function formattedColumn(formatter, defaultOpts) {
+  defaultOpts = defaultOpts || {};
+  return function(opts) {
+    return _.extend({}, defaultOpts, {
+      render: function(data, type, row, meta) {
+        return formatter(data, type, row, meta);
+      }
+    }, opts);
+  };
+}
+
+function barColumn(formatter) {
+  formatter = formatter || function(value) { return value; };
+  return function(opts) {
+    return _.extend({
+      orderSequence: ['desc', 'asc'],
+      render: function(data, type, row, meta) {
+        var span = document.createElement('div');
+        span.textContent = formatter(_.max([data, 0]));
+        span.setAttribute('data-value', data || 0);
+        span.setAttribute('data-row', meta.row);
+        return span.outerHTML;
+      }
+    }, opts);
+  };
+}
+
+function urlColumn(attr, opts) {
+  return _.extend({
+    render: function(data, type, row, meta) {
+      if (row[attr]) {
+        var anchor = document.createElement('a');
+        anchor.textContent = data;
+        anchor.setAttribute('href', row[attr]);
+        anchor.setAttribute('target', '_blank');
+        return anchor.outerHTML;
+      } else {
+        return data;
+      }
+    }
+  }, opts);
+}
+
+function buildEntityLink(data, url, category, opts) {
+  opts = opts || {};
+  var anchor = document.createElement('a');
+  anchor.textContent = data;
+  anchor.setAttribute('href', url);
+  anchor.setAttribute('title', data);
+  anchor.setAttribute('data-category', category);
+  anchor.classList.add('single-link');
+
+  if (opts.isIncumbent) {
+    anchor.classList.add('is-incumbent');
+  }
+
+  return anchor.outerHTML;
+}
+
+function buildAggregateUrl(cycle) {
+  var dates = helpers.cycleDates(cycle);
+  return {
+    min_date: dates.min,
+    max_date: dates.max
+  };
+}
+
+function buildTotalLink(path, getParams) {
+  return function(data, type, row, meta) {
+    data = data || 0;
+    var params = getParams(data, type, row, meta);
+    var span = document.createElement('div');
+    span.setAttribute('data-value', data);
+    span.setAttribute('data-row', meta.row);
+    if (params) {
+      var link = document.createElement('a');
+      link.textContent = helpers.currency(data);
+      link.setAttribute('title', 'View individual transactions');
+      var uri = helpers.buildAppUrl(path, _.extend(
+        {committee_id: row.committee_id},
+        buildAggregateUrl(_.extend({}, row, params).cycle),
+        params
+      ));
+      link.setAttribute('href', uri);
+      span.appendChild(link);
+    } else {
+      span.textContent = helpers.currency(data);
+    }
+    return span.outerHTML;
+  };
+}
+
+module.exports = {
+  barColumn: barColumn,
+  buildAggregateUrl: buildAggregateUrl,
+  buildEntityLink: buildEntityLink,
+  buildTotalLink: buildTotalLink,
+  formattedColumn: formattedColumn,
+  getColumns: getColumns,
+  getSizeParams: getSizeParams,
+  sizeInfo: sizeInfo,
+  urlColumn: urlColumn
+};

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -36,6 +36,22 @@ var modalTriggerColumn = {
   }
 };
 
+var candidateColumn = columnHelpers.formattedColumn(function(data, type, row) {
+  if (row) {
+    return columnHelpers.buildEntityLink(row.candidate_name, helpers.buildAppUrl(['candidate', row.candidate_id]), 'candidate');
+  } else {
+    return '';
+  }
+});
+
+var committeeColumn = columnHelpers.formattedColumn(function(data, type, row) {
+  if (row) {
+    return columnHelpers.buildEntityLink(row.committee_name, helpers.buildAppUrl(['committee', row.committee_id]), 'committee');
+  } else {
+    return '';
+  }
+});
+
 var renderCandidateColumn = function(data, type, row, meta) {
   if (data) {
     var query = row.election_years ? tables.getCycle(row.election_years, meta) : null;
@@ -141,7 +157,17 @@ var disbursements = [
     data: 'committee',
     orderable: false,
     className: 'min-tablet hide-panel',
-    render: renderCommitteeColumn
+    render: function(data, type, row, meta) {
+      if (data) {
+        return columnHelpers.buildEntityLink(
+          data.name,
+          helpers.buildAppUrl(['committee', data.committee_id]),
+          'committee'
+        );
+      } else {
+        return '';
+      }
+    }
   },
   modalTriggerColumn
 ];
@@ -208,7 +234,17 @@ var independentExpenditures = [
     data: 'committee',
     orderable: false,
     className: 'all',
-    render: renderCommitteeColumn
+    render: function(data, type, row, meta) {
+      if (data) {
+        return columnHelpers.buildEntityLink(
+          data.name,
+          helpers.buildAppUrl(['committee', data.committee_id]),
+          'committee'
+        );
+      } else {
+        return '';
+      }
+    }
   },
   currencyColumn({data: 'expenditure_amount', className: 'min-tablet'}),
   {
@@ -276,6 +312,8 @@ var receipts = [
 
 
 module.exports = {
+  candidateColumn: candidateColumn,
+  committeeColumn: committeeColumn,
   dateColumn: dateColumn,
   currencyColumn: currencyColumn,
   barCurrencyColumn: barCurrencyColumn,

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -54,8 +54,10 @@ var committeeColumn = columnHelpers.formattedColumn(function(data, type, row) {
 
 var renderCandidateColumn = function(data, type, row, meta) {
   if (data) {
-    var query = row.election_years ? tables.getCycle(row.election_years, meta) : null;
-    return columnHelpers.buildEntityLink(data, helpers.buildAppUrl(['candidate', row.candidate_id], query), 'candidate');
+    return columnHelpers.buildEntityLink(
+      data,
+      helpers.buildAppUrl(['candidate', row.candidate_id]),
+      'candidate');
   } else {
     return '';
   }
@@ -63,10 +65,9 @@ var renderCandidateColumn = function(data, type, row, meta) {
 
 var renderCommitteeColumn = function(data, type, row, meta) {
   if (data) {
-    var query = row.cycles ? tables.getCycle(row.cycles, meta) : null;
     return columnHelpers.buildEntityLink(
       data,
-      helpers.buildAppUrl(['committee', row.committee_id], query),
+      helpers.buildAppUrl(['committee', row.committee_id]),
       'committee');
   } else {
     return '';
@@ -100,7 +101,21 @@ var candidateOffice = {
 };
 
 var committees = [
-  {data: 'name', className: 'all', width: '280px', render: renderCommitteeColumn},
+  {
+    data: 'name',
+    className: 'all',
+    width: '280px',
+    render: function(data, type, row, meta) {
+      if (data) {
+        return columnHelpers.buildEntityLink(
+          data,
+          helpers.buildAppUrl(['committee', row.committee_id], tables.getCycle(row.cycles, meta)),
+          'committee');
+      } else {
+        return '';
+      }
+    }
+  },
   {data: 'treasurer_name', className: 'min-desktop hide-panel'},
   {data: 'state', className: 'min-desktop hide-panel', width: '60px'},
   {data: 'party_full', className: 'min-desktop hide-panel'},

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -2,30 +2,15 @@
 
 var _ = require('underscore');
 
+var columnHelpers = require('./column-helpers');
 var tables = require('./tables');
 var helpers = require('./helpers');
 var decoders = require('./decoders');
 
-var sizeInfo = {
-  0: {limits: [0, 199.99], label: 'Under $200'},
-  200: {limits: [200, 499.99], label: '$200—$499'},
-  500: {limits: [500, 999.99], label: '$500—$999'},
-  1000: {limits: [1000, 1999.99], label: '$1000—$1999'},
-  2000: {limits: [2000, null], label: 'Over $2000'},
-};
 
-function getSizeParams(size) {
-  var limits = sizeInfo[size].limits;
-  var params = {is_individual: 'true'};
-  if (limits[0] !== null) {
-    params.min_amount = helpers.currency(limits[0]);
-  }
-  if (limits[1] !== null) {
-    params.max_amount = helpers.currency(limits[1]);
-  }
-  return params;
-}
-
+var dateColumn = columnHelpers.formattedColumn(helpers.datetime, {orderSequence: ['desc', 'asc']});
+var currencyColumn = columnHelpers.formattedColumn(helpers.currency, {orderSequence: ['desc', 'asc']});
+var barCurrencyColumn = columnHelpers.barColumn(helpers.currency);
 
 var supportOpposeColumn = {
   data: 'support_oppose_indicator',
@@ -42,8 +27,150 @@ var amendmentIndicatorColumn = {
   },
 };
 
+var modalTriggerColumn = {
+  className: 'all u-no-padding',
+  width: '20px',
+  orderable: false,
+  render: function(data, type, row, meta) {
+    return tables.MODAL_TRIGGER_HTML;
+  }
+};
+
+var renderCandidateColumn = function(data, type, row, meta) {
+  if (data) {
+    var query = row.election_years ? tables.getCycle(row.election_years, meta) : null;
+    return columnHelpers.buildEntityLink(data, helpers.buildAppUrl(['candidate', row.candidate_id], query), 'candidate');
+  } else {
+    return '';
+  }
+};
+
+var renderCommitteeColumn = function(data, type, row, meta) {
+  if (data) {
+    var query = row.cycles ? tables.getCycle(row.cycles, meta) : null;
+    return columnHelpers.buildEntityLink(
+      data,
+      helpers.buildAppUrl(['committee', row.committee_id], query),
+      'committee');
+  } else {
+    return '';
+  }
+};
+
+var candidates = [
+  {data: 'name', className: 'all', width: '280px', render: renderCandidateColumn},
+  {data: 'office_full', className: 'min-tablet hide-panel'},
+  {
+    data: 'election_years',
+    className: 'min-tablet',
+    render: function(data, type, row, meta) {
+      return tables.yearRange(_.first(data), _.last(data));
+    }
+  },
+  {data: 'party_full', className: 'min-tablet hide-panel'},
+  {data: 'state', className: 'min-desktop hide-panel'},
+  {data: 'district', className: 'min-desktop hide-panel'},
+  modalTriggerColumn
+];
+
+var candidateOffice = {
+  candidate:   {data: 'name', className: 'all', width: '280px', render: renderCandidateColumn},
+  party: {data: 'party_full', className: 'min-tablet hide-panel'},
+  state: {data: 'state', className: 'min-desktop hide-panel'},
+  district: {data: 'district', className: 'min-desktop hide-panel'},
+  receipts: currencyColumn({data: 'receipts', className: 'min-tablet'}),
+  disbursements: currencyColumn({data: 'disbursements', className: 'min-tablet'}),
+  trigger: modalTriggerColumn
+};
+
+var committees = [
+  {data: 'name', className: 'all', width: '280px', render: renderCommitteeColumn},
+  {data: 'treasurer_name', className: 'min-desktop hide-panel'},
+  {data: 'state', className: 'min-desktop hide-panel', width: '60px'},
+  {data: 'party_full', className: 'min-desktop hide-panel'},
+  dateColumn({data: 'first_file_date', className: 'min-tablet hide-panel'}),
+  {data: 'committee_type_full', className: 'min-tablet hide-panel'},
+  {data: 'designation_full', className: 'min-tablet hide-panel'},
+  {data: 'organization_type_full', className: 'min-desktop hide-panel'},
+  modalTriggerColumn
+];
+
+var communicationCosts = [
+  {
+    data: 'committee_name',
+    orderable: false,
+    className: 'min-desktop',
+    render: renderCommitteeColumn,
+  },
+  currencyColumn({data: 'transaction_amount', className: 'min-tablet'}),
+  supportOpposeColumn,
+  {
+    data: 'candidate_name',
+    orderable: false,
+    className: 'min-desktop hide-panel',
+    render: renderCandidateColumn
+  },
+  dateColumn({data: 'transaction_date', className: 'min-tablet hide-panel-tablet'}),
+  modalTriggerColumn
+];
+
+var disbursements = [
+  {
+    data: 'recipient_name',
+    orderable: false,
+    className: 'all',
+    width: '200px',
+    render: function(data, type, row, meta) {
+      var committee = row.recipient_committee;
+      if (committee) {
+        return columnHelpers.buildEntityLink(
+          committee.name,
+          helpers.buildAppUrl(['committee', committee.committee_id]),
+          'committee'
+        );
+      } else {
+        return data;
+      }
+    }
+  },
+  {data: 'recipient_state', width: '80px', orderable: false, className: 'min-desktop hide-panel'},
+  currencyColumn({data: 'disbursement_amount', className: 'min-tablet hide-panel-tablet'}),
+  dateColumn({data: 'disbursement_date', className: 'min-tablet hide-panel-tablet'}),
+  {data: 'disbursement_description', className: 'min-desktop hide-panel', orderable: false},
+  {
+    data: 'committee',
+    orderable: false,
+    className: 'min-tablet hide-panel',
+    render: renderCommitteeColumn
+  },
+  modalTriggerColumn
+];
+
+var electioneeringCommunications = [
+  {
+    data: 'committee_name',
+    orderable: false,
+    className: 'min-desktop',
+    render: renderCommitteeColumn
+  },
+  currencyColumn({data: 'disbursement_amount', className: 'min-tablet'}),
+  {
+    data: 'number_of_candidates',
+    className: 'min-tablet',
+  },
+  currencyColumn({data: 'calculated_candidate_share', className: 'min-tablet'}),
+  {
+    data: 'candidate_name',
+    orderable: false,
+    className: 'min-desktop hide-panel hide-panel-tablet',
+    render: renderCandidateColumn
+  },
+  dateColumn({data: 'disbursement_date', className: 'min-tablet hide-panel'}),
+  modalTriggerColumn
+];
+
 var filings = {
-  pdf_url: tables.urlColumn('pdf_url', {data: 'document_description', className: 'all', orderable: false}),
+  pdf_url: columnHelpers.urlColumn('pdf_url', {data: 'document_description', className: 'all', orderable: false}),
   filer_name: {
     data: 'committee_id',
     className: 'all',
@@ -51,13 +178,13 @@ var filings = {
     render: function(data, type, row, meta) {
       var cycle = tables.getCycle([row.cycle], meta);
       if (row.candidate_name) {
-        return tables.buildEntityLink(
+        return columnHelpers.buildEntityLink(
           row.candidate_name,
           helpers.buildAppUrl(['candidate', row.candidate_id], cycle),
           'candidate'
         );
       } else if (row.committee_name) {
-        return tables.buildEntityLink(
+        return columnHelpers.buildEntityLink(
           row.committee_name,
           helpers.buildAppUrl(['committee', row.committee_id], cycle),
           'committee'
@@ -68,34 +195,99 @@ var filings = {
     },
   },
   amendment_indicator: amendmentIndicatorColumn,
-  receipt_date: tables.dateColumn({data: 'receipt_date', className: 'min-tablet'}),
-  coverage_end_date: tables.dateColumn({data: 'coverage_end_date', className: 'min-tablet hide-panel', orderable: false}),
-  total_receipts: tables.currencyColumn({data: 'total_receipts', className: 'min-tablet hide-panel'}),
-  total_disbursements: tables.currencyColumn({data: 'total_disbursements', className: 'min-tablet hide-panel'}),
-  total_independent_expenditures: tables.currencyColumn({data: 'total_independent_expenditures', className: 'min-tablet hide-panel'}),
-  modal_trigger: {
-    className: 'all u-no-padding',
-    width: '20px',
-    orderable: false,
-    render: function(data, type, row, meta) {
-      return row.form_type && ['F3', 'F3P', 'F3X'].indexOf(row.form_type) !== -1 ?
-        tables.MODAL_TRIGGER_HTML :
-        '';
-    }
-  }
+  receipt_date: dateColumn({data: 'receipt_date', className: 'min-tablet'}),
+  coverage_end_date: dateColumn({data: 'coverage_end_date', className: 'min-tablet hide-panel', orderable: false}),
+  total_receipts: currencyColumn({data: 'total_receipts', className: 'min-tablet hide-panel'}),
+  total_disbursements: currencyColumn({data: 'total_disbursements', className: 'min-tablet hide-panel'}),
+  total_independent_expenditures: currencyColumn({data: 'total_independent_expenditures', className: 'min-tablet hide-panel'}),
+  modal_trigger: modalTriggerColumn
 };
 
-function getColumns(columns, keys) {
-  return _.map(keys, function(key) {
-    return columns[key];
-  });
-}
+var independentExpenditures = [
+  {
+    data: 'committee',
+    orderable: false,
+    className: 'all',
+    render: renderCommitteeColumn
+  },
+  currencyColumn({data: 'expenditure_amount', className: 'min-tablet'}),
+  {
+    data: 'candidate_name',
+    orderable: false,
+    className: 'min-tablet hide-panel',
+    render: function(data, type, row, meta) {
+      if (row.candidate_id) {
+        return columnHelpers.buildEntityLink(
+          data,
+          helpers.buildAppUrl(['candidate', row.candidate_id], tables.getCycle(row, meta)),
+          'candidate'
+        );
+      } else {
+        return row.candidate_name;
+      }
+    }
+  },
+  _.extend({}, supportOpposeColumn, {className: 'min-tablet'}),
+  dateColumn({data: 'expenditure_date', className: 'min-desktop hide-panel-tablet'}),
+  columnHelpers.urlColumn('pdf_url', {data: 'expenditure_description', className: 'min-desktop hide-panel', orderable: false}),
+  modalTriggerColumn
+];
+
+var receipts = [
+  {
+    data: 'contributor',
+    orderable: false,
+    className: 'all',
+    width: '200px',
+    render: function(data, type, row, meta) {
+      if (data && row.receipt_type !== helpers.globals.EARMARKED_CODE) {
+        return columnHelpers.buildEntityLink(
+          data.name,
+          helpers.buildAppUrl(['committee', data.committee_id]),
+          'committee'
+        );
+      } else {
+        return row.contributor_name;
+      }
+    }
+  },
+  {data: 'contributor_state', orderable: false, className: 'min-desktop hide-panel'},
+  {data: 'contributor_employer', orderable: false, className: 'min-desktop hide-panel'},
+  currencyColumn({data: 'contribution_receipt_amount', className: 'min-tablet'}),
+  dateColumn({data: 'contribution_receipt_date', className: 'min-tablet hide-panel-tablet'}),
+  {
+    data: 'committee',
+    orderable: false,
+    className: 'min-desktop hide-panel',
+    render: function(data, type, row, meta) {
+      if (data) {
+        return columnHelpers.buildEntityLink(
+          data.name,
+          helpers.buildAppUrl(['committee', data.committee_id]),
+          'committee'
+        );
+      } else {
+        return '';
+      }
+    }
+  },
+  modalTriggerColumn
+];
+
 
 module.exports = {
-  filings: filings,
-  sizeInfo: sizeInfo,
-  getColumns: getColumns,
-  getSizeParams: getSizeParams,
+  dateColumn: dateColumn,
+  currencyColumn: currencyColumn,
+  barCurrencyColumn: barCurrencyColumn,
   supportOpposeColumn: supportOpposeColumn,
-  amendmentIndicatorColumn: amendmentIndicatorColumn
+  amendmentIndicatorColumn: amendmentIndicatorColumn,
+  candidates: candidates,
+  candidateOffice: candidateOffice,
+  committees: committees,
+  communicationCosts: communicationCosts,
+  disbursements: disbursements,
+  electioneeringCommunications: electioneeringCommunications,
+  independentExpenditures: independentExpenditures,
+  filings: filings,
+  receipts: receipts
 };

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -76,118 +76,6 @@ function getCycle(value, meta) {
   }
 }
 
-function buildEntityLink(data, url, category, opts) {
-  opts = opts || {};
-  var anchor = document.createElement('a');
-  anchor.textContent = data;
-  anchor.setAttribute('href', url);
-  anchor.setAttribute('title', data);
-  anchor.setAttribute('data-category', category);
-  anchor.classList.add('single-link');
-
-  if (opts.isIncumbent) {
-    anchor.classList.add('is-incumbent');
-  }
-
-  return anchor.outerHTML;
-}
-
-function buildAggregateUrl(cycle) {
-  var dates = helpers.cycleDates(cycle);
-  return {
-    min_date: dates.min,
-    max_date: dates.max
-  };
-}
-
-function buildTotalLink(path, getParams) {
-  return function(data, type, row, meta) {
-    data = data || 0;
-    var params = getParams(data, type, row, meta);
-    var span = document.createElement('div');
-    span.setAttribute('data-value', data);
-    span.setAttribute('data-row', meta.row);
-    if (params) {
-      var link = document.createElement('a');
-      link.textContent = helpers.currency(data);
-      link.setAttribute('title', 'View individual transactions');
-      var uri = helpers.buildAppUrl(path, _.extend(
-        {committee_id: row.committee_id},
-        buildAggregateUrl(_.extend({}, row, params).cycle),
-        params
-      ));
-      link.setAttribute('href', uri);
-      span.appendChild(link);
-    } else {
-      span.textContent = helpers.currency(data);
-    }
-    return span.outerHTML;
-  };
-}
-
-function formattedColumn(formatter, defaultOpts) {
-  defaultOpts = defaultOpts || {};
-  return function(opts) {
-    return _.extend({}, defaultOpts, {
-      render: function(data, type, row, meta) {
-        return formatter(data, type, row, meta);
-      }
-    }, opts);
-  };
-}
-
-function barColumn(formatter) {
-  formatter = formatter || function(value) { return value; };
-  return function(opts) {
-    return _.extend({
-      orderSequence: ['desc', 'asc'],
-      render: function(data, type, row, meta) {
-        var span = document.createElement('div');
-        span.textContent = formatter(_.max([data, 0]));
-        span.setAttribute('data-value', data || 0);
-        span.setAttribute('data-row', meta.row);
-        return span.outerHTML;
-      }
-    }, opts);
-  };
-}
-
-function urlColumn(attr, opts) {
-  return _.extend({
-    render: function(data, type, row, meta) {
-      if (row[attr]) {
-        var anchor = document.createElement('a');
-        anchor.textContent = data;
-        anchor.setAttribute('href', row[attr]);
-        anchor.setAttribute('target', '_blank');
-        return anchor.outerHTML;
-      } else {
-        return data;
-      }
-    }
-  }, opts);
-}
-
-var dateColumn = formattedColumn(helpers.datetime, {orderSequence: ['desc', 'asc']});
-var currencyColumn = formattedColumn(helpers.currency, {orderSequence: ['desc', 'asc']});
-var barCurrencyColumn = barColumn(helpers.currency);
-
-var candidateColumn = formattedColumn(function(data, type, row) {
-  if (row) {
-    return buildEntityLink(row.candidate_name, helpers.buildAppUrl(['candidate', row.candidate_id]), 'candidate');
-  } else {
-    return '';
-  }
-});
-
-var committeeColumn = formattedColumn(function(data, type, row) {
-  if (row) {
-    return buildEntityLink(row.committee_name, helpers.buildAppUrl(['committee', row.committee_id]), 'committee');
-  } else {
-    return '';
-  }
-});
-
 function mapSort(order, columns) {
   return _.map(order, function(item) {
     var name = columns[item.column].data;
@@ -613,14 +501,6 @@ module.exports = {
   browseDOM: browseDOM,
   yearRange: yearRange,
   getCycle: getCycle,
-  buildTotalLink: buildTotalLink,
-  buildEntityLink: buildEntityLink,
-  candidateColumn: candidateColumn,
-  committeeColumn: committeeColumn,
-  currencyColumn: currencyColumn,
-  urlColumn: urlColumn,
-  barCurrencyColumn: barCurrencyColumn,
-  dateColumn: dateColumn,
   barsAfterRender: barsAfterRender,
   modalRenderRow: modalRenderRow,
   modalRenderFactory: modalRenderFactory,

--- a/static/js/pages/candidate-single.js
+++ b/static/js/pages/candidate-single.js
@@ -11,7 +11,7 @@ var columns = require('../modules/columns');
 var filingsColumns = [
   columnHelpers.urlColumn('pdf_url', {data: 'document_description', className: 'all', orderable: false}),
   columns.amendmentIndicatorColumn,
-  tables.dateColumn({data: 'receipt_date', className: 'min-tablet'}),
+  columns.dateColumn({data: 'receipt_date', className: 'min-tablet'}),
 ];
 
 var expenditureColumns = [
@@ -28,7 +28,7 @@ var expenditureColumns = [
         };
     })
   },
-  columns.commiteeColumn({data: 'committee', className: 'all'}),
+  columns.committeeColumn({data: 'committee', className: 'all'}),
   columns.supportOpposeColumn
 ];
 
@@ -45,7 +45,7 @@ var communicationCostColumns = [
         };
     })
   },
-  columns.commiteeColumn({data: 'committee', className: 'all'}),
+  columns.committeeColumn({data: 'committee', className: 'all'}),
   columns.supportOpposeColumn
 ];
 
@@ -59,7 +59,7 @@ var electioneeringColumns = [
         return {candidate_id: row.candidate_id};
     })
   },
-  columns.commiteeColumn({data: 'committee', className: 'all'})
+  columns.committeeColumn({data: 'committee', className: 'all'})
 ];
 
 function initFilingsTable() {

--- a/static/js/pages/candidate-single.js
+++ b/static/js/pages/candidate-single.js
@@ -5,10 +5,11 @@
 var $ = require('jquery');
 
 var tables = require('../modules/tables');
+var columnHelpers = require('../modules/column-helpers');
 var columns = require('../modules/columns');
 
 var filingsColumns = [
-  tables.urlColumn('pdf_url', {data: 'document_description', className: 'all', orderable: false}),
+  columnHelpers.urlColumn('pdf_url', {data: 'document_description', className: 'all', orderable: false}),
   columns.amendmentIndicatorColumn,
   tables.dateColumn({data: 'receipt_date', className: 'min-tablet'}),
 ];
@@ -19,7 +20,7 @@ var expenditureColumns = [
     className: 'all',
     orderable: true,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['independent-expenditures'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['independent-expenditures'], function(data, type, row, meta) {
         return {
           support_oppose_indicator: row.support_oppose_indicator,
           candidate_id: row.candidate_id,
@@ -27,7 +28,7 @@ var expenditureColumns = [
         };
     })
   },
-  tables.committeeColumn({data: 'committee', className: 'all'}),
+  columns.commiteeColumn({data: 'committee', className: 'all'}),
   columns.supportOpposeColumn
 ];
 
@@ -37,14 +38,14 @@ var communicationCostColumns = [
     className: 'all',
     orderable: true,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['communication-costs'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['communication-costs'], function(data, type, row, meta) {
         return {
           support_oppose_indicator: row.support_oppose_indicator,
           candidate_id: row.candidate_id,
         };
     })
   },
-  tables.committeeColumn({data: 'committee', className: 'all'}),
+  columns.commiteeColumn({data: 'committee', className: 'all'}),
   columns.supportOpposeColumn
 ];
 
@@ -54,11 +55,11 @@ var electioneeringColumns = [
     className: 'all',
     orderable: true,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['electioneering-communications'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['electioneering-communications'], function(data, type, row, meta) {
         return {candidate_id: row.candidate_id};
     })
   },
-  tables.committeeColumn({data: 'committee', className: 'all'})
+  columns.commiteeColumn({data: 'committee', className: 'all'})
 ];
 
 function initFilingsTable() {

--- a/static/js/pages/candidates-office.js
+++ b/static/js/pages/candidates-office.js
@@ -5,49 +5,18 @@
 var $ = require('jquery');
 
 var tables = require('../modules/tables');
+var columnHelpers = require('../modules/column-helpers');
 var columns = require('../modules/columns');
-var helpers = require('../modules/helpers');
 
 var FilterPanel = require('fec-style/js/filter-panel').FilterPanel;
 var filterTags = require('fec-style/js/filter-tags');
 
 var candidatesTemplate = require('../../templates/candidates-office.hbs');
 
-var columnOptions = {
-  name: {
-    data: 'name',
-    className: 'all',
-    width: '280px',
-    render: function(data, type, row, meta) {
-      return tables.buildEntityLink(
-        data,
-        helpers.buildAppUrl(
-          ['candidate', row.candidate_id],
-          tables.getCycle(row.election_years, meta)
-        ),
-        'candidate'
-      );
-    }
-  },
-  party: {data: 'party_full', className: 'min-tablet hide-panel'},
-  state: {data: 'state', className: 'min-desktop hide-panel'},
-  district: {data: 'district', className: 'min-desktop hide-panel'},
-  receipts: tables.currencyColumn({data: 'receipts', className: 'min-tablet'}),
-  disbursements: tables.currencyColumn({data: 'disbursements', className: 'min-tablet'}),
-  trigger: {
-    className: 'all u-no-padding',
-    width: '20px',
-    orderable: false,
-    render: function(data, type, row, meta) {
-      return tables.MODAL_TRIGGER_HTML;
-    }
-  }
-};
-
 var columnGroups = {
-  president: columns.getColumns(columnOptions, ['name', 'party', 'receipts', 'disbursements', 'trigger']),
-  senate: columns.getColumns(columnOptions, ['name', 'party', 'state', 'receipts', 'disbursements', 'trigger']),
-  house: columns.getColumns(columnOptions, ['name', 'party', 'state', 'district', 'receipts', 'disbursements', 'trigger']),
+  president: columnHelpers.getColumns(columns.candidateOffice, ['name', 'party', 'receipts', 'disbursements', 'trigger']),
+  senate: columnHelpers.getColumns(columns.candidateOffice, ['name', 'party', 'state', 'receipts', 'disbursements', 'trigger']),
+  house: columnHelpers.getColumns(columns.candidateOffice, ['name', 'party', 'state', 'district', 'receipts', 'disbursements', 'trigger']),
 };
 
 $(document).ready(function() {

--- a/static/js/pages/candidates.js
+++ b/static/js/pages/candidates.js
@@ -5,52 +5,16 @@ var _ = require('underscore');
 
 var tables = require('../modules/tables');
 var helpers = require('../modules/helpers');
+var columns = require('../modules/columns');
 
 var candidatesTemplate = require('../../templates/candidates.hbs');
-
-var columns = [
-  {
-    data: 'name',
-    className: 'all',
-    width: '280px',
-    render: function(data, type, row, meta) {
-      return tables.buildEntityLink(
-        data,
-        helpers.buildAppUrl(
-          ['candidate', row.candidate_id],
-          tables.getCycle(row.election_years, meta)
-        ),
-        'candidate'
-      );
-    }
-  },
-  {data: 'office_full', className: 'min-tablet hide-panel'},
-  {
-    data: 'election_years',
-    className: 'min-tablet',
-    render: function(data, type, row, meta) {
-      return tables.yearRange(_.first(data), _.last(data));
-    }
-  },
-  {data: 'party_full', className: 'min-tablet hide-panel'},
-  {data: 'state', className: 'min-desktop hide-panel'},
-  {data: 'district', className: 'min-desktop hide-panel'},
-  {
-    className: 'all u-no-padding',
-    width: '20px',
-    orderable: false,
-    render: function(data, type, row, meta) {
-      return tables.MODAL_TRIGGER_HTML;
-    }
-  }
-];
 
 $(document).ready(function() {
   var $table = $('#results');
   new tables.DataTable($table, {
     title: 'Candidate',
     path: ['candidates'],
-    columns: columns,
+    columns: columns.candidates,
     useFilters: true,
     useExport: true,
     rowCallback: tables.modalRenderRow,

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -147,7 +147,7 @@ var filingsColumns = columnHelpers.getColumns(
 
 var disbursementPurposeColumns = [
   {data: 'purpose', className: 'all', orderable: false},
-  tables.barCurrencyColumn({data: 'total', className: 'all', orderable: false})
+  columnHelpers.buildTotalLink({data: 'total', className: 'all', orderable: false})
 ];
 
 var disbursementRecipientColumns = [

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -11,6 +11,7 @@ var maps = require('../modules/maps');
 var tables = require('../modules/tables');
 var filings = require('../modules/filings');
 var helpers = require('../modules/helpers');
+var columnHelpers = require('../modules/column-helpers');
 var columns = require('../modules/columns');
 
 var tableOpts = {
@@ -27,7 +28,7 @@ var sizeColumns = [
     width: '50%',
     className: 'all',
     render: function(data, type, row, meta) {
-      return columns.sizeInfo[data].label;
+      return columnHelpers.sizeInfo[data].label;
     }
   },
   {
@@ -35,8 +36,8 @@ var sizeColumns = [
     width: '50%',
     className: 'all',
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['receipts'], function(data, type, row, meta) {
-      return columns.getSizeParams(row.size);
+    render: columnHelpers.buildTotalLink(['receipts'], function(data, type, row, meta) {
+      return columnHelpers.getSizeParams(row.size);
     })
   }
 ];
@@ -47,7 +48,7 @@ var committeeColumns = [
     className: 'all',
     orderable: false,
     render: function(data, type, row, meta) {
-      return tables.buildEntityLink(
+      return columnHelpers.buildEntityLink(
         data,
         helpers.buildAppUrl(['committee', row.committee_id]),
         'committee'
@@ -59,7 +60,7 @@ var committeeColumns = [
     className: 'all',
     orderable: false,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['disbursements'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['disbursements'], function(data, type, row, meta) {
       return {
         committee_id: row.committee_id,
         recipient_committee_id: row.recipient_id
@@ -86,7 +87,7 @@ var stateColumns = [
     width: '50%',
     className: 'all',
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['receipts'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['receipts'], function(data, type, row, meta) {
       return {
         contributor_state: row.state,
         is_individual: 'true'
@@ -102,7 +103,7 @@ var employerColumns = [
     className: 'all',
     orderable: false,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['receipts'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['receipts'], function(data, type, row, meta) {
       if (row.employer) {
         return {
           contributor_employer: row.employer,
@@ -122,7 +123,7 @@ var occupationColumns = [
     className: 'all',
     orderable: false,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['receipts'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['receipts'], function(data, type, row, meta) {
       if (row.occupation) {
         return {
           contributor_occupation: row.occupation,
@@ -135,7 +136,7 @@ var occupationColumns = [
   }
 ];
 
-var filingsColumns = columns.getColumns(
+var filingsColumns = columnHelpers.getColumns(
   columns.filings,
   [
     'pdf_url', 'amendment_indicator', 'receipt_date', 'coverage_end_date',
@@ -156,7 +157,7 @@ var disbursementRecipientColumns = [
     className: 'all',
     orderable: false,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['disbursements'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['disbursements'], function(data, type, row, meta) {
       return {recipient_name: row.recipient_name};
     })
   }
@@ -168,7 +169,7 @@ var disbursementRecipientIDColumns = [
     className: 'all',
     orderable: false,
     render: function(data, type, row, meta) {
-      return tables.buildEntityLink(
+      return columnHelpers.buildEntityLink(
         data,
         helpers.buildAppUrl(['committee', row.recipient_id]),
         'committee'
@@ -180,7 +181,7 @@ var disbursementRecipientIDColumns = [
     className: 'all',
     orderable: false,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['disbursements'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['disbursements'], function(data, type, row, meta) {
       return {recipient_committee_id: row.recipient_id};
     })
   }
@@ -192,7 +193,7 @@ var expendituresColumns = [
     className: 'all',
     orderable: true,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['independent-expenditures'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['independent-expenditures'], function(data, type, row, meta) {
       return {
         support_oppose_indicator: row.support_oppose_indicator,
         candidate_id: row.candidate_id,
@@ -201,7 +202,7 @@ var expendituresColumns = [
     })
   },
   columns.supportOpposeColumn,
-  tables.candidateColumn({data: 'candidate', className: 'all'})
+  columns.candidateColumn({data: 'candidate', className: 'all'})
 ];
 
 var electioneeringColumns = [
@@ -210,14 +211,14 @@ var electioneeringColumns = [
     className: 'all',
     orderable: true,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['electioneering-communications'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['electioneering-communications'], function(data, type, row, meta) {
       return {
         support_oppose_indicator: row.support_oppose_indicator,
         candidate_id: row.candidate_id,
       };
     })
   },
-  tables.candidateColumn({data: 'candidate', className: 'all'})
+  columns.candidateColumn({data: 'candidate', className: 'all'})
 ];
 
 var communicationCostColumns = [
@@ -226,7 +227,7 @@ var communicationCostColumns = [
     className: 'all',
     orderable: true,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['communication-costs'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['communication-costs'], function(data, type, row, meta) {
       return {
         support_oppose_indicator: row.support_oppose_indicator,
         candidate_id: row.candidate_id,
@@ -234,7 +235,7 @@ var communicationCostColumns = [
     })
   },
   columns.supportOpposeColumn,
-  tables.candidateColumn({data: 'candidate', className: 'all'})
+  columns.candidateColumn({data: 'candidate', className: 'all'})
 ];
 
 function buildStateUrl($elm) {

--- a/static/js/pages/committees.js
+++ b/static/js/pages/committees.js
@@ -6,48 +6,16 @@ var $ = require('jquery');
 
 var tables = require('../modules/tables');
 var helpers = require('../modules/helpers');
+var columns = require('../modules/columns');
 
 var committeesTemplate = require('../../templates/committees.hbs');
-
-var columns = [
-  {
-    data: 'name',
-    className: 'all',
-    width: '280px',
-    render: function(data, type, row, meta) {
-      return tables.buildEntityLink(
-        data,
-        helpers.buildAppUrl(
-          ['committee', row.committee_id],
-          tables.getCycle(row.cycles, meta)
-        ),
-        'committee'
-      );
-    }
-  },
-  {data: 'treasurer_name', className: 'min-desktop hide-panel'},
-  {data: 'state', className: 'min-desktop hide-panel', width: '60px'},
-  {data: 'party_full', className: 'min-desktop hide-panel'},
-  tables.dateColumn({data: 'first_file_date', className: 'min-tablet hide-panel'}),
-  {data: 'committee_type_full', className: 'min-tablet hide-panel'},
-  {data: 'designation_full', className: 'min-tablet hide-panel'},
-  {data: 'organization_type_full', className: 'min-desktop hide-panel'},
-  {
-    className: 'all u-no-padding',
-    width: '20px',
-    orderable: false,
-    render: function(data, type, row, meta) {
-      return tables.MODAL_TRIGGER_HTML;
-    }
-  }
-];
 
 $(document).ready(function() {
   var $table = $('#results');
   new tables.DataTable($table, {
     title: 'Committee',
     path: ['committees'],
-    columns: columns,
+    columns: columns.committees,
     useFilters: true,
     useExport: true,
     order: [[4, 'desc']],

--- a/static/js/pages/communication-costs.js
+++ b/static/js/pages/communication-costs.js
@@ -4,58 +4,17 @@ var $ = require('jquery');
 
 var tables = require('../modules/tables');
 var helpers = require('../modules/helpers');
+var columnHelpers = require('../modules/column-helpers');
 var columns = require('../modules/columns');
 
 var electioneeringTemplate = require('../../templates/communication-costs.hbs');
-
-var columns = [
-  {
-    data: 'committee_name',
-    orderable: false,
-    className: 'min-desktop',
-    render: function(data, type, row, meta) {
-      if (data) {
-        return tables.buildEntityLink(
-          data,
-          helpers.buildAppUrl(['committee', row.committee_id]),
-          'committee'
-        );
-      } else {
-        return '';
-      }
-    }
-  },
-  tables.currencyColumn({data: 'transaction_amount', className: 'min-tablet'}),
-  columns.supportOpposeColumn,
-  {
-    data: 'candidate_name',
-    orderable: false,
-    className: 'min-desktop hide-panel',
-    render: function(data, type, row, meta) {
-      return tables.buildEntityLink(
-        data,
-        helpers.buildAppUrl(['candidate', row.candidate_id]),
-        'candidate'
-      );
-    }
-  },
-  tables.dateColumn({data: 'transaction_date', className: 'min-tablet hide-panel-tablet'}),
-  {
-    className: 'all u-no-padding',
-    width: '20px',
-    orderable: false,
-    render: function(data, type, row, meta) {
-      return tables.MODAL_TRIGGER_HTML;
-    }
-  }
-];
 
 $(document).ready(function() {
   var $table = $('#results');
   new tables.DataTable($table, {
     title: 'Communication costs',
     path: ['communication-costs'],
-    columns: columns,
+    columns: columns.communicationCosts,
     rowCallback: tables.modalRenderRow,
     useExport: true,
     order: [[4, 'desc']],

--- a/static/js/pages/disbursements.js
+++ b/static/js/pages/disbursements.js
@@ -6,64 +6,16 @@ var $ = require('jquery');
 
 var tables = require('../modules/tables');
 var helpers = require('../modules/helpers');
+var columns = require('../modules/columns');
 
 var disbursementTemplate = require('../../templates/disbursements.hbs');
-
-var columns = [
-  {
-    data: 'recipient_name',
-    orderable: false,
-    className: 'all',
-    width: '200px',
-    render: function(data, type, row, meta) {
-      var committee = row.recipient_committee;
-      if (committee) {
-        return tables.buildEntityLink(
-          committee.name,
-          helpers.buildAppUrl(['committee', committee.committee_id]),
-          'committee'
-        );
-      } else {
-        return data;
-      }
-    }
-  },
-  {data: 'recipient_state', width: '80px', orderable: false, className: 'min-desktop hide-panel'},
-  tables.currencyColumn({data: 'disbursement_amount', className: 'min-tablet hide-panel-tablet'}),
-  tables.dateColumn({data: 'disbursement_date', className: 'min-tablet hide-panel-tablet'}),
-  {data: 'disbursement_description', className: 'min-desktop hide-panel', orderable: false},
-  {
-    data: 'committee',
-    orderable: false,
-    className: 'min-tablet hide-panel',
-    render: function(data, type, row, meta) {
-      if (data) {
-        return tables.buildEntityLink(
-          data.name,
-          helpers.buildAppUrl(['committee', data.committee_id]),
-          'committee'
-        );
-      } else {
-        return '';
-      }
-    }
-  },
-  {
-    className: 'all u-no-padding',
-    width: '20px',
-    orderable: false,
-    render: function(data, type, row, meta) {
-      return tables.MODAL_TRIGGER_HTML;
-    }
-  }
-];
 
 $(document).ready(function() {
   var $table = $('#results');
   new tables.DataTable($table, {
     title: 'Disbursement',
     path: ['schedules', 'schedule_b'],
-    columns: columns,
+    columns: columns.disbursements,
     paginator: tables.SeekPaginator,
     order: [[3, 'desc']],
     useFilters: true,

--- a/static/js/pages/electioneering-communications.js
+++ b/static/js/pages/electioneering-communications.js
@@ -4,58 +4,13 @@ var $ = require('jquery');
 
 var tables = require('../modules/tables');
 var helpers = require('../modules/helpers');
+var columnHelpers = require('../modules/column-helpers');
 var columns = require('../modules/columns');
 
 var FilterPanel = require('fec-style/js/filter-panel').FilterPanel;
 var filterTags = require('fec-style/js/filter-tags');
 
 var electioneeringTemplate = require('../../templates/electioneering-communications.hbs');
-
-var columns = [
-  {
-    data: 'committee_name',
-    orderable: false,
-    className: 'min-desktop',
-    render: function(data, type, row, meta) {
-      if (data) {
-        return tables.buildEntityLink(
-          data,
-          helpers.buildAppUrl(['committee', row.committee_id]),
-          'committee'
-        );
-      } else {
-        return '';
-      }
-    }
-  },
-  tables.currencyColumn({data: 'disbursement_amount', className: 'min-tablet'}),
-  {
-    data: 'number_of_candidates',
-    className: 'min-tablet',
-  },
-  tables.currencyColumn({data: 'calculated_candidate_share', className: 'min-tablet'}),
-  {
-    data: 'candidate_name',
-    orderable: false,
-    className: 'min-desktop hide-panel hide-panel-tablet',
-    render: function(data, type, row, meta) {
-      return tables.buildEntityLink(
-        data,
-        helpers.buildAppUrl(['candidate', row.candidate_id]),
-        'candidate'
-      );
-    }
-  },
-  tables.dateColumn({data: 'disbursement_date', className: 'min-tablet hide-panel'}),
-  {
-    className: 'all u-no-padding',
-    width: '20px',
-    orderable: false,
-    render: function(data, type, row, meta) {
-      return tables.MODAL_TRIGGER_HTML;
-    }
-  }
-];
 
 $(document).ready(function() {
   var $table = $('#results');
@@ -66,7 +21,7 @@ $(document).ready(function() {
     title: 'Electioneering communications',
     path: ['electioneering'],
     panel: filterPanel,
-    columns: columns,
+    columns: columns.electioneeringCommunications,
     rowCallback: tables.modalRenderRow,
     useExport: true,
     order: [[3, 'desc']],

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -35,7 +35,7 @@ var independentExpenditureColumns = [
         };
     })
   },
-  columns.commiteeColumn({data: 'committee', className: 'all'}),
+  columns.committeeColumn({data: 'committee', className: 'all'}),
   columns.supportOpposeColumn,
   columns.candidateColumn({data: 'candidate', className: 'all'}),
 ];
@@ -53,7 +53,7 @@ var communicationCostColumns = [
         };
     })
   },
-  columns.commiteeColumn({data: 'committee', className: 'all'}),
+  columns.committeeColumn({data: 'committee', className: 'all'}),
   columns.supportOpposeColumn,
   columns.candidateColumn({data: 'candidate', className: 'all'})
 ];
@@ -70,7 +70,7 @@ var electioneeringColumns = [
         };
     })
   },
-  columns.commiteeColumn({data: 'committee', className: 'all'}),
+  columns.committeeColumn({data: 'committee', className: 'all'}),
   columns.candidateColumn({data: 'candidate', className: 'all'})
 ];
 

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -12,6 +12,7 @@ var dropdown = require('fec-style/js/dropdowns');
 var fips = require('../modules/fips');
 var maps = require('../modules/maps');
 var tables = require('../modules/tables');
+var columnHelpers = require('../modules/column-helpers');
 var columns = require('../modules/columns');
 var helpers = require('../modules/helpers');
 
@@ -26,7 +27,7 @@ var independentExpenditureColumns = [
     className: 'all',
     orderable: true,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['independent-expenditures'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['independent-expenditures'], function(data, type, row, meta) {
         return {
           support_oppose_indicator: row.support_oppose_indicator,
           candidate_id: row.candidate_id,
@@ -34,9 +35,9 @@ var independentExpenditureColumns = [
         };
     })
   },
-  tables.committeeColumn({data: 'committee', className: 'all'}),
+  columns.commiteeColumn({data: 'committee', className: 'all'}),
   columns.supportOpposeColumn,
-  tables.candidateColumn({data: 'candidate', className: 'all'}),
+  columns.candidateColumn({data: 'candidate', className: 'all'}),
 ];
 
 var communicationCostColumns = [
@@ -45,16 +46,16 @@ var communicationCostColumns = [
     className: 'all',
     orderable: true,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['communication-costs'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['communication-costs'], function(data, type, row, meta) {
         return {
           support_oppose_indicator: row.support_oppose_indicator,
           candidate_id: row.candidate_id,
         };
     })
   },
-  tables.committeeColumn({data: 'committee', className: 'all'}),
+  columns.commiteeColumn({data: 'committee', className: 'all'}),
   columns.supportOpposeColumn,
-  tables.candidateColumn({data: 'candidate', className: 'all'})
+  columns.candidateColumn({data: 'candidate', className: 'all'})
 ];
 
 var electioneeringColumns = [
@@ -63,14 +64,14 @@ var electioneeringColumns = [
     className: 'all',
     orderable: true,
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['electioneering-communications'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['electioneering-communications'], function(data, type, row, meta) {
         return {
           candidate_id: row.candidate_id,
         };
     })
   },
-  tables.committeeColumn({data: 'committee', className: 'all'}),
-  tables.candidateColumn({data: 'candidate', className: 'all'})
+  columns.commiteeColumn({data: 'committee', className: 'all'}),
+  columns.candidateColumn({data: 'candidate', className: 'all'})
 ];
 
 var electionColumns = [
@@ -79,7 +80,7 @@ var electionColumns = [
     className: 'all',
     width: '30%',
     render: function(data, type, row, meta) {
-      return tables.buildEntityLink(
+      return columnHelpers.buildEntityLink(
         data,
         helpers.buildAppUrl(['candidate', row.candidate_id]),
         'candidate',
@@ -88,9 +89,9 @@ var electionColumns = [
     }
   },
   {data: 'party_full', className: 'all'},
-  tables.currencyColumn({data: 'total_receipts', orderSequence: ['desc', 'asc']}),
-  tables.currencyColumn({data: 'total_disbursements', orderSequence: ['desc', 'asc']}),
-  tables.barCurrencyColumn({data: 'cash_on_hand_end_period'}),
+  columns.currencyColumn({data: 'total_receipts', orderSequence: ['desc', 'asc']}),
+  columns.currencyColumn({data: 'total_disbursements', orderSequence: ['desc', 'asc']}),
+  columns.barCurrencyColumn({data: 'cash_on_hand_end_period'}),
   {
     render: function(data, type, row, meta) {
       var dates = helpers.cycleDates(context.election.cycle);
@@ -116,7 +117,7 @@ var electionColumns = [
 function makeCommitteeColumn(opts, factory) {
   return _.extend({}, {
     orderSequence: ['desc', 'asc'],
-    render: tables.buildTotalLink(['receipts'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['receipts'], function(data, type, row, meta) {
       row.cycle = context.election.cycle;
       var column = meta.settings.aoColumns[meta.col].data;
       return _.extend({
@@ -127,7 +128,7 @@ function makeCommitteeColumn(opts, factory) {
 }
 
 var makeSizeColumn = _.partial(makeCommitteeColumn, _, function(data, type, row, meta, column) {
-  return columns.getSizeParams(column);
+  return columnHelpers.getSizeParams(column);
 });
 
 var sizeColumns = [
@@ -136,7 +137,7 @@ var sizeColumns = [
     className: 'all',
     width: '30%',
     render: function(data, type, row, meta) {
-      return tables.buildEntityLink(
+      return columnHelpers.buildEntityLink(
         data,
         helpers.buildAppUrl(['candidate', row.candidate_id]),
         'candidate'

--- a/static/js/pages/filings.js
+++ b/static/js/pages/filings.js
@@ -6,9 +6,9 @@ var $ = require('jquery');
 
 var tables = require('../modules/tables');
 var filings = require('../modules/filings');
-var columns = require('../modules/columns');
+var columnHelpers = require('../modules/column-helpers');
 
-var filingsColumns = columns.getColumns(
+var filingsColumns = columnHelpers.getColumns(
   columns.filings,
   [
     'pdf_url', 'filer_name', 'amendment_indicator', 'receipt_date', 'coverage_end_date',

--- a/static/js/pages/filings.js
+++ b/static/js/pages/filings.js
@@ -7,6 +7,7 @@ var $ = require('jquery');
 var tables = require('../modules/tables');
 var filings = require('../modules/filings');
 var columnHelpers = require('../modules/column-helpers');
+var columns = require('../modules/columns');
 
 var filingsColumns = columnHelpers.getColumns(
   columns.filings,

--- a/static/js/pages/independent-expenditures.js
+++ b/static/js/pages/independent-expenditures.js
@@ -5,56 +5,10 @@ var _ = require('underscore');
 
 var tables = require('../modules/tables');
 var helpers = require('../modules/helpers');
+var columnHelpers = require('../modules/column-helpers');
 var columns = require('../modules/columns');
 
 var expenditureTemplate = require('../../templates/independent-expenditures.hbs');
-
-var columns = [
-  {
-    data: 'committee',
-    orderable: false,
-    className: 'all',
-    render: function(data, type, row, meta) {
-      if (data) {
-        return tables.buildEntityLink(
-          data.name,
-          helpers.buildAppUrl(['committee', data.committee_id]),
-          'committee'
-        );
-      } else {
-        return '';
-      }
-    }
-  },
-  tables.currencyColumn({data: 'expenditure_amount', className: 'min-tablet'}),
-  {
-    data: 'candidate_name',
-    orderable: false,
-    className: 'min-tablet hide-panel',
-    render: function(data, type, row, meta) {
-      if (row.candidate_id) {
-        return tables.buildEntityLink(
-          data,
-          helpers.buildAppUrl(['candidate', row.candidate_id], tables.getCycle(row, meta)),
-          'candidate'
-        );
-      } else {
-        return row.candidate_name;
-      }
-    }
-  },
-  _.extend({}, columns.supportOpposeColumn, {className: 'min-tablet'}),
-  tables.dateColumn({data: 'expenditure_date', className: 'min-desktop hide-panel-tablet'}),
-  tables.urlColumn('pdf_url', {data: 'expenditure_description', className: 'min-desktop hide-panel', orderable: false}),
-  {
-    className: 'all u-no-padding',
-    width: '20px',
-    orderable: false,
-    render: function(data, type, row, meta) {
-      return tables.MODAL_TRIGGER_HTML;
-    }
-  }
-];
 
 $(document).ready(function() {
   var $table = $('#results');
@@ -65,7 +19,7 @@ $(document).ready(function() {
       is_notice: 'false',
       filing_form: 'F3X'
     },
-    columns: columns,
+    columns: columns.independentExpenditures,
     paginator: tables.SeekPaginator,
     rowCallback: tables.modalRenderRow,
     useExport: true,

--- a/static/js/pages/individual-contributions.js
+++ b/static/js/pages/individual-contributions.js
@@ -4,56 +4,9 @@ var $ = require('jquery');
 
 var tables = require('../modules/tables');
 var helpers = require('../modules/helpers');
+var columns = require('../modules/columns');
 
 var donationTemplate = require('../../templates/receipts.hbs');
-
-var columns = [
-  {
-    data: 'contributor',
-    orderable: false,
-    className: 'all',
-    width: '200px',
-    render: function(data, type, row, meta) {
-      if (data && row.receipt_type !== helpers.globals.EARMARKED_CODE) {
-        return tables.buildEntityLink(
-          data.name,
-          helpers.buildAppUrl(['committee', data.committee_id]),
-          'committee'
-        );
-      } else {
-        return row.contributor_name;
-      }
-    }
-  },
-  {data: 'contributor_state', orderable: false, className: 'min-desktop hide-panel'},
-  {data: 'contributor_employer', orderable: false, className: 'min-desktop hide-panel'},
-  tables.currencyColumn({data: 'contribution_receipt_amount', className: 'min-tablet'}),
-  tables.dateColumn({data: 'contribution_receipt_date', className: 'min-tablet hide-panel-tablet'}),
-  {
-    data: 'committee',
-    orderable: false,
-    className: 'min-desktop hide-panel',
-    render: function(data, type, row, meta) {
-      if (data) {
-        return tables.buildEntityLink(
-          data.name,
-          helpers.buildAppUrl(['committee', data.committee_id]),
-          'committee'
-        );
-      } else {
-        return '';
-      }
-    }
-  },
-  {
-    className: 'all u-no-padding',
-    width: '20px',
-    orderable: false,
-    render: function(data, type, row, meta) {
-      return tables.MODAL_TRIGGER_HTML;
-    }
-  }
-];
 
 $(document).ready(function() {
   var $table = $('#results');
@@ -61,7 +14,7 @@ $(document).ready(function() {
     title: 'Individual contributions',
     path: ['schedules', 'schedule_a'],
     query: {contributor_type: 'individual'},
-    columns: columns,
+    columns: columns.receipts,
     paginator: tables.SeekPaginator,
     order: [[4, 'desc']],
     useFilters: true,

--- a/static/js/pages/landing.js
+++ b/static/js/pages/landing.js
@@ -6,10 +6,11 @@ var $ = require('jquery');
 
 var tables = require('../modules/tables');
 var columns = require('../modules/columns');
+var columnHelpers = require('../modules/column-helpers');
 var lookup = require('../modules/election-lookup');
 var summary = require('../modules/election-summary');
 
-var filingsColumns = columns.getColumns(
+var filingsColumns = columnHelpers.getColumns(
   columns.filings,
   ['pdf_url', 'filer_name', 'receipt_date']
 );

--- a/static/js/pages/operating-expenditures.js
+++ b/static/js/pages/operating-expenditures.js
@@ -6,57 +6,9 @@ var $ = require('jquery');
 
 var tables = require('../modules/tables');
 var helpers = require('../modules/helpers');
+var columns = require('../modules/columns');
 
 var disbursementTemplate = require('../../templates/disbursements.hbs');
-
-var columns = [
-  {
-    data: 'recipient_name',
-    orderable: false,
-    className: 'all',
-    width: '200px',
-    render: function(data, type, row, meta) {
-      var committee = row.recipient_committee;
-      if (committee) {
-        return tables.buildEntityLink(
-          committee.name,
-          helpers.buildAppUrl(['committee', committee.committee_id]),
-          'committee'
-        );
-      } else {
-        return data;
-      }
-    }
-  },
-  {data: 'recipient_state', width: '80px', orderable: false, className: 'min-desktop hide-panel'},
-  tables.currencyColumn({data: 'disbursement_amount', className: 'min-tablet hide-panel-tablet'}),
-  tables.dateColumn({data: 'disbursement_date', className: 'min-tablet hide-panel-tablet'}),
-  {data: 'disbursement_description', className: 'min-desktop hide-panel', orderable: false},
-  {
-    data: 'committee',
-    orderable: false,
-    className: 'min-tablet hide-panel',
-    render: function(data, type, row, meta) {
-      if (data) {
-        return tables.buildEntityLink(
-          data.name,
-          helpers.buildAppUrl(['committee', data.committee_id]),
-          'committee'
-        );
-      } else {
-        return '';
-      }
-    }
-  },
-  {
-    className: 'all u-no-padding',
-    width: '20px',
-    orderable: false,
-    render: function(data, type, row, meta) {
-      return tables.MODAL_TRIGGER_HTML;
-    }
-  }
-];
 
 $(document).ready(function() {
   var $table = $('#results');
@@ -64,7 +16,7 @@ $(document).ready(function() {
     title: 'Operating expenditures',
     path: ['schedules', 'schedule_b'],
     // query: {filter for operating expenditures},
-    columns: columns,
+    columns: columns.disbursements,
     paginator: tables.SeekPaginator,
     order: [[3, 'desc']],
     useFilters: true,

--- a/static/js/pages/receipts.js
+++ b/static/js/pages/receipts.js
@@ -4,63 +4,16 @@ var $ = require('jquery');
 
 var tables = require('../modules/tables');
 var helpers = require('../modules/helpers');
+var columns = require('../modules/columns');
 
 var donationTemplate = require('../../templates/receipts.hbs');
-
-var columns = [
-  {
-    data: 'contributor',
-    orderable: false,
-    className: 'all',
-    width: '200px',
-    render: function(data, type, row, meta) {
-      if (data && row.receipt_type !== helpers.globals.EARMARKED_CODE) {
-        return tables.buildEntityLink(
-          data.name,
-          helpers.buildAppUrl(['committee', data.committee_id]),
-          'committee'
-        );
-      } else {
-        return row.contributor_name;
-      }
-    }
-  },
-  {data: 'contributor_state', orderable: false, className: 'min-desktop hide-panel'},
-  {data: 'contributor_employer', orderable: false, className: 'min-desktop hide-panel'},
-  tables.currencyColumn({data: 'contribution_receipt_amount', className: 'min-tablet'}),
-  tables.dateColumn({data: 'contribution_receipt_date', className: 'min-tablet hide-panel-tablet'}),
-  {
-    data: 'committee',
-    orderable: false,
-    className: 'min-desktop hide-panel',
-    render: function(data, type, row, meta) {
-      if (data) {
-        return tables.buildEntityLink(
-          data.name,
-          helpers.buildAppUrl(['committee', data.committee_id]),
-          'committee'
-        );
-      } else {
-        return '';
-      }
-    }
-  },
-  {
-    className: 'all u-no-padding',
-    width: '20px',
-    orderable: false,
-    render: function(data, type, row, meta) {
-      return tables.MODAL_TRIGGER_HTML;
-    }
-  }
-];
 
 $(document).ready(function() {
   var $table = $('#results');
   new tables.DataTable($table, {
     title: 'Receipt',
     path: ['schedules', 'schedule_a'],
-    columns: columns,
+    columns: columns.receipts,
     paginator: tables.SeekPaginator,
     order: [[4, 'desc']],
     useFilters: true,


### PR DESCRIPTION
This cuts down on the amount of duplicate code needed when creating a new datatable page by moving all column definitions to a separate partial. 

It also cleans up tables.js by moving some functions to columns.js and a new column-helpers.js

I'm sure there's more that can be done to further simplify things, but want to leave it here for now.

I branched off of `feature/new-datatable-pages` and wanted to PR into it to make the code easier to review, since it touches so many files. So we should merge this first, and then #1166