### PR TITLE
Adding filters for 5000 and federal fund flags

### DIFF
--- a/openfecwebapp/templates/partials/candidates-filter.html
+++ b/openfecwebapp/templates/partials/candidates-filter.html
@@ -13,6 +13,17 @@
   {% include 'partials/filters/parties.html' %}
   {{ states.field('state') }}
   {% include 'partials/filters/districts.html' %}
-  {% include 'partials/filters/candidate_status.html' %}
+  <div class="filter">
+    <fieldset class="js-filter">
+      <legend class="label">Candidate status</legend>
+      <ul>
+        <li>
+          <input id="cycle-checkbox-five-thousand" name="five_thousand_flag" type="checkbox" value="true">
+          <label for="cycle-checkbox-five-thousand">Has raised more $5,000</label>
+        </li>
+      </ul>
+    </fieldset>
+  </div>
+
 </div>
 {% endblock %}

--- a/openfecwebapp/templates/partials/candidates-office-filter.html
+++ b/openfecwebapp/templates/partials/candidates-office-filter.html
@@ -6,22 +6,54 @@
 {% import 'macros/filters/election-filter.html' as election_filter %}
 
 {% block filters %}
-{{ typeahead.field('q', 'Candidate name or ID', 'Find an ID by searching for a candidate name', 'candidates', True) }}
-{{ election_filter.field('election_year', 'Election cycle', 'cycle', 'election_full', office) }}
-<input id="election_full" name="election_full" type="checkbox" value="true">
-{% include 'partials/filters/parties.html' %}
-{% if office in ['senate', 'house'] %}
-  {{ states.field('state') }}
-{% endif %}
-{% if office == 'house' %}
-  {% include 'partials/filters/districts.html' %}
-{% endif %}
-{{ text.field('min_receipts', 'Minimum receipts', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
-{{ text.field('max_receipts', 'Maximum receipts', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
-{{ text.field('min_disbursements', 'Minimum disbursements', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
-{{ text.field('max_disbursements', 'Maximum disbursements', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
-{{ text.field('min_cash_on_hand_end_period', 'Minimum cash on hand', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
-{{ text.field('max_cash_on_hand_end_period', 'Maximum cash on hand', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
-{{ text.field('min_debts_owed_by_committee', 'Minimum debt', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
-{{ text.field('max_debts_owed_by_committee', 'Maximum debt', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
-{% endblock %}
+<div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
+  <div class="filters__inner">
+    {{ typeahead.field('q', 'Candidate name or ID', '', dataset='candidates', allow_text=True) }}
+    {{ election_filter.field('election_year', 'Election cycle', 'cycle', 'election_full', office) }}
+    <input id="election_full" name="election_full" type="checkbox" value="true">
+  </div>
+  <button type="button" class="js-accordion-trigger accordion__button">Candidate information</button>
+  <div class="accordion__content">
+    {% include 'partials/filters/parties.html' %}
+    {% if office in ['senate', 'house'] %}
+      {{ states.field('state') }}
+    {% endif %}
+    {% if office == 'house' %}
+      {% include 'partials/filters/districts.html' %}
+    {% endif %}
+  </div>
+  <button type="button" class="js-accordion-trigger accordion__button">Money received</button>
+  <div class="accordion__content">
+    {{ text.field('min_receipts', 'Minimum receipts', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
+    {{ text.field('max_receipts', 'Maximum receipts', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
+    {% if office == 'president' %}
+      <div class="filter">
+        <fieldset class="js-filter">
+          <legend class="label">Federal funds</legend>
+          <ul>
+            <li>
+              <input id="cycle-checkbox-federal-fund" name="federal_fund_flag" type="checkbox" value="true">
+              <label for="cycle-checkbox-federal-fund">Has received federal funds</label>
+            </li>
+          </ul>
+        </fieldset>
+      </div>
+    {% endif %}
+  </div>
+  <button type="button" class="js-accordion-trigger accordion__button">Money spent</button>
+  <div class="accordion__content">
+    {{ text.field('min_disbursements', 'Minimum disbursements', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
+    {{ text.field('max_disbursements', 'Maximum disbursements', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
+  </div>
+  <button type="button" class="js-accordion-trigger accordion__button">Cash on hand</button>
+  <div class="accordion__content">
+    {{ text.field('min_cash_on_hand_end_period', 'Minimum cash on hand', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
+    {{ text.field('max_cash_on_hand_end_period', 'Maximum cash on hand', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
+  </div>
+  <button type="button" class="js-accordion-trigger accordion__button">Debt</button>
+  <div class="accordion__content">
+    {{ text.field('min_debts_owed_by_committee', 'Minimum debt', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
+    {{ text.field('max_debts_owed_by_committee', 'Maximum debt', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
+  </div>
+  {% endblock %}
+</div>

--- a/openfecwebapp/templates/partials/candidates-office-filter.html
+++ b/openfecwebapp/templates/partials/candidates-office-filter.html
@@ -32,8 +32,8 @@
           <legend class="label">Federal funds</legend>
           <ul>
             <li>
-              <input id="cycle-checkbox-federal-fund" name="federal_fund_flag" type="checkbox" value="true">
-              <label for="cycle-checkbox-federal-fund">Has received federal funds</label>
+              <input id="cycle-checkbox-federal-funds" name="federal_funds_flag" type="checkbox" value="true">
+              <label for="cycle-checkbox-federal-funds">Has received federal funds</label>
             </li>
           </ul>
         </fieldset>

--- a/openfecwebapp/templates/partials/filters/candidate_status.html
+++ b/openfecwebapp/templates/partials/filters/candidate_status.html
@@ -1,8 +1,0 @@
-{% import 'macros/filters/checkbox.html' as checkbox %}
-
-{{ checkbox.checkbox_dropdown(
-  'candidate_status',
-  'Candidates raising more than $5,000',
-  selected=constants.candidate_status,
-  options=constants.candidate_status_extended,
-) }}

--- a/static/js/pages/candidates-office.js
+++ b/static/js/pages/candidates-office.js
@@ -52,15 +52,10 @@ var columnGroups = {
 
 $(document).ready(function() {
   var $table = $('#results');
-  var $widgets = $(tables.dataWidgets);
-  var $tagList = new filterTags.TagList({title: 'All records'}).$body;
-  var filterPanel = new FilterPanel();
-
   new tables.DataTable($table, {
     title: 'Candidate',
     path: ['candidates', 'totals'],
     query: {office: context.office.slice(0, 1).toUpperCase()},
-    panel: filterPanel,
     columns: columnGroups[context.office],
     useFilters: true,
     useExport: true,
@@ -69,5 +64,4 @@ $(document).ready(function() {
       afterRender: tables.modalRenderFactory(candidatesTemplate)
     }
   });
-  $widgets.find('.js-filter-tags').prepend($tagList);
 });


### PR DESCRIPTION
- Adds filters for $5,000 flag
- Adds filter for federal funds flag on president page
- Groups candidate office filters in accordions
- Fixes a bug on the candidate office pages (we moved the filter-panel and filter-tag initialization to tables.js, but this still had it) 

Depends on https://github.com/18F/openFEC/pull/1548

Resolves https://github.com/18F/openFEC-web-app/issues/859
