### PR TITLE
Adds breadcrumbs

### DIFF
--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -21,7 +21,7 @@ def search():
         results = api_caller.load_search_results(query, result_type)
         return views.render_search_results(results, query, result_type)
     else:
-        return render_template('search.html', page='home', dates=utils.date_ranges())
+        return render_template('search.html', page='home', dates=utils.date_ranges(), title='Campaign finance data')
 
 @app.route('/api/')
 def api():

--- a/openfecwebapp/templates/candidates-single.html
+++ b/openfecwebapp/templates/candidates-single.html
@@ -1,18 +1,17 @@
 {% extends 'layouts/main.html' %}
 {% import 'macros/cycle-select.html' as select %}
 {% import 'macros/tabs.html' as tabs %}
+{% import 'macros/page-header.html' as header %}
 
 {% block title %}
     {{ name }} - Candidate overview
 {% endblock %}
 
-{% block body %}
+{% set links=[('', 'Candidate profiles')] %}
 
+{% block body %}
 <div class="tab-interface">
-  <header class="page-header page-header--primary">
-    <span class="page-header__title">Candidates</span>
-    {{ search.search('page-header', 'candidates') }}
-  </header>
+  {{ header.header(name, links) }}
   <header class="entity__header entity__header--neutral">
     <div class="container">
       <div class="entity__header__top row">

--- a/openfecwebapp/templates/candidates-single.html
+++ b/openfecwebapp/templates/candidates-single.html
@@ -7,11 +7,11 @@
     {{ name }} - Candidate overview
 {% endblock %}
 
-{% set links=[('', 'Candidate profiles')] %}
+{% set breadcrumbs=[('', 'Candidate profiles')] %}
 
 {% block body %}
 <div class="tab-interface">
-  {{ header.header(name, links) }}
+  {{ header.header(name, breadcrumbs) }}
   <header class="entity__header entity__header--neutral">
     <div class="container">
       <div class="entity__header__top row">

--- a/openfecwebapp/templates/committees-single.html
+++ b/openfecwebapp/templates/committees-single.html
@@ -2,17 +2,17 @@
 {% import 'macros/null.html' as null %}
 {% import 'macros/cycle-select.html' as select %}
 {% import 'macros/tabs.html' as tabs %}
+{% import 'macros/page-header.html' as header %}
 
 {% block title %}
     {{ name }} - committee overview
 {% endblock %}
 
+{% set links=[('', 'Committee profiles')] %}
+
 {% block body %}
   <div class="tab-interface">
-    <header class="page-header page-header--primary">
-    <span class="page-header__title">Committees</span>
-    {{ search.search('page-header', 'committees') }}
-    </header>
+    {{ header.header(name, links, search_type='committees') }}
     <header class="entity__header entity__header--primary">
       <div class="container">
         <div class="entity__header__top row">

--- a/openfecwebapp/templates/committees-single.html
+++ b/openfecwebapp/templates/committees-single.html
@@ -8,11 +8,11 @@
     {{ name }} - committee overview
 {% endblock %}
 
-{% set links=[('', 'Committee profiles')] %}
+{% set breadcrumbs=[('', 'Committee profiles')] %}
 
 {% block body %}
   <div class="tab-interface">
-    {{ header.header(name, links, search_type='committees') }}
+    {{ header.header(name, breadcrumbs, search_type='committees') }}
     <header class="entity__header entity__header--primary">
       <div class="container">
         <div class="entity__header__top row">

--- a/openfecwebapp/templates/datatable.html
+++ b/openfecwebapp/templates/datatable.html
@@ -5,10 +5,10 @@
   Browse {{ title }}
 {% endblock %}
 
-{% set links=[('', 'Advanced data')] %}
+{% set breadcrumbs=[('', 'Advanced data')] %}
 {% block body %}
 
-{{ header.header(slug | title, links, show_search=False) }}
+{{ header.header(slug | title, breadcrumbs, show_search=False) }}
 
 <section class="main__content--full">
   <div class="data-container__widgets js-data-widgets">

--- a/openfecwebapp/templates/datatable.html
+++ b/openfecwebapp/templates/datatable.html
@@ -1,14 +1,14 @@
 {% extends 'layouts/main.html' %}
+{% import 'macros/page-header.html' as header %}
 
 {% block title %}
   Browse {{ title }}
 {% endblock %}
 
+{% set links=[('', 'Advanced data')] %}
 {% block body %}
 
-<header class="page-header slab slab--primary">
-  <h1 class="page-header__title">{{ title }}</h1>
-</header>
+{{ header.header(slug | title, links, show_search=False) }}
 
 <section class="main__content--full">
   <div class="data-container__widgets js-data-widgets">

--- a/openfecwebapp/templates/election-lookup.html
+++ b/openfecwebapp/templates/election-lookup.html
@@ -1,13 +1,13 @@
 {% extends 'layouts/main.html' %}
 {% import 'macros/cycle-select.html' as select %}
+{% import 'macros/page-header.html' as header %}
+
 {% block title %}
   Find candidates and elections by location
 {% endblock %}
 
 {% block body %}
-<header class="page-header slab slab--primary">
-  <span class="page-header__title">Find candidates and elections by location</span>
-</header>
+  {{ header.header(title, show_search=False) }}
 <section class="main" id="election-lookup" >
   <div class="container">
     <h2 class="t-ruled--bottom t-ruled--bold">Search</h2>

--- a/openfecwebapp/templates/elections.html
+++ b/openfecwebapp/templates/elections.html
@@ -1,6 +1,7 @@
 {% extends 'layouts/main.html' %}
 {% import 'macros/cycle-select.html' as select %}
 {% import 'macros/tabs.html' as tabs %}
+{% import 'macros/page-header.html' as header %}
 
 {{ cycle }} Election - US {{ office|title }} {% if state %} - {{ state|fmt_state_full }} {% if district %} - District {{ district }} {% endif %} {% endif %}
 
@@ -10,10 +11,7 @@
 
 {% block body %}
 <div class="tab-interface">
-  <header class="page-header page-header--primary">
-    <span class="page-header__title">Elections and candidates by location</span>
-    {{ search.search('page-header', 'candidates') }}
-  </header>
+  {{ header.header(title) }}
   <header class="entity__header {% if office != 'president' %}entity__header--map{% endif %} entity__header--primary">
     <div class="container">
       <div class="entity__header--info">

--- a/openfecwebapp/templates/macros/breadcrumbs.html
+++ b/openfecwebapp/templates/macros/breadcrumbs.html
@@ -14,7 +14,7 @@
     {% endfor %}
     <li class="breadcrumbs__item breadcrumbs__item--current">
       <span class="breadcrumbs__separator">&rsaquo;</span>
-      {{ title }}
+      <span>{{ title }}</span>
     </li>
   </ul>
 </header>

--- a/openfecwebapp/templates/macros/breadcrumbs.html
+++ b/openfecwebapp/templates/macros/breadcrumbs.html
@@ -1,0 +1,21 @@
+{% macro breadcrumbs(title, links) %}
+<header class="page-header page-header--primary">
+  <ul class="breadcrumbs">
+    <li class="breadcrumbs__item"><a href="{{ cms_url }}" class="breadcrumbs__link" rel="Home">Home</a></li>
+    {% for link in links %}
+    <li class="breadcrumbs__item">
+      {% if link[0] != '' %}
+        <span class="breadcrumbs__separator">&rsaquo;</span>
+        <a class="breadcrumbs__link" href="{{ link[0] }}">{{ link[1] }}</a>
+      {% else %}
+        <span>{{ link[1] }}</span>
+      {% endif %}
+    </li>
+    {% endfor %}
+    <li class="breadcrumbs__item breadcrumbs__item--current">
+      <span class="breadcrumbs__separator">&rsaquo;</span>
+      {{ title }}
+    </li>
+  </ul>
+</header>
+{% endmacro %}

--- a/openfecwebapp/templates/macros/page-header.html
+++ b/openfecwebapp/templates/macros/page-header.html
@@ -1,0 +1,31 @@
+{% macro header(title, links, show_search=True, search_type='candidates') %}
+{% import 'macros/search.html' as search %}
+<header class="page-header page-header--primary">
+  <ul class="breadcrumbs">
+    <li class="breadcrumbs__item"><a href="{{ cms_url }}" class="breadcrumbs__link" rel="Home">Home</a></li>
+    {% if title != 'Campaign finance data' %}
+      <li class="breadcrumbs__item">
+        <span class="breadcrumbs__separator">&rsaquo;</span>
+        <a href="/" class="breadcrumbs__link">Campaign finance data</a>
+      </li>
+    {% endif %}
+    {% for link in links %}
+    <li class="breadcrumbs__item">
+      <span class="breadcrumbs__separator">&rsaquo;</span>
+      {% if link[0] != '' %}
+        <a class="breadcrumbs__link" href="{{ link[0] }}">{{ link[1] }}</a>
+      {% else %}
+        <span>{{ link[1] }}</span>
+      {% endif %}
+    </li>
+    {% endfor %}
+    <li class="breadcrumbs__item breadcrumbs__item--current">
+      <span class="breadcrumbs__separator">&rsaquo;</span>
+      {{ title }}
+    </li>
+  </ul>
+  {% if show_search %}
+    {{ search.search('page-header', search_type) }}
+  {% endif %}
+</header>
+{% endmacro %}

--- a/openfecwebapp/templates/partials/hero.html
+++ b/openfecwebapp/templates/partials/hero.html
@@ -1,7 +1,6 @@
 {% import 'macros/search.html' as search %}
 {% import 'macros/page-header.html' as header %}
 
-{{ header.header(title, show_search=False) }}
 <section class="hero hero--primary" aria-labelledby="hero-heading">
   <div class="container">
     <h1 id="hero-heading" class="t-display">Explore campaign finance data</h1>

--- a/openfecwebapp/templates/partials/hero.html
+++ b/openfecwebapp/templates/partials/hero.html
@@ -1,4 +1,7 @@
 {% import 'macros/search.html' as search %}
+{% import 'macros/page-header.html' as header %}
+
+{{ header.header(title, show_search=False) }}
 <section class="hero hero--primary" aria-labelledby="hero-heading">
   <div class="container">
     <h1 id="hero-heading" class="t-display">Explore campaign finance data</h1>

--- a/openfecwebapp/templates/search-results.html
+++ b/openfecwebapp/templates/search-results.html
@@ -1,6 +1,6 @@
 {% extends "layouts/main.html" %}
 {% import 'macros/search.html' as search %}
-{% set hide_header_search = true %}
+{% import 'macros/page-header.html' as header %}
 
 {% block title %}
     Search results for "{{query}}"
@@ -14,9 +14,7 @@
 {% set alt_type = 'committees' %}
 {% endif %}
 
-<header class="page-header slab slab--primary">
-  <span class="page-header__title">Search results</span>
-</header>
+{{ header.header(title, show_search=False) }}
 
 <div class="main">
   <div class="container">

--- a/openfecwebapp/templates/search.html
+++ b/openfecwebapp/templates/search.html
@@ -3,7 +3,7 @@
 {% set hide_header_search = true %}
 
 {% block title %}
-    Campaign finance data
+  {{ title }}
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
Adds simple breadcrumb navigation pattern to data pages through a macro.

![image](https://cloud.githubusercontent.com/assets/1696495/14479994/2700f440-00d9-11e6-960a-7daf16f56614.png)

The macro automatically adds the `page-header` bar, and by passing the page title and array of breadcrumbs, generates the breadcrumb list.

It also accepts a `show_search` param to show the search and `search_type` to set the type of search (candidates or committees).

Goes with:
- https://github.com/18F/fec-style/pull/307