### PR TITLE
fixes disbursement route and disabled class

### DIFF
--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -123,8 +123,8 @@ def receipts():
 def disbursements():
     return render_template(
         'datatable.html',
-        slug='receipts',
-        title='Receipts',
+        slug='disbursements',
+        title='Disbursements',
         dates=utils.date_ranges())
 
 @app.route('/filings/')

--- a/static/js/modules/download.js
+++ b/static/js/modules/download.js
@@ -168,7 +168,7 @@ DownloadItem.prototype.finish = function(downloadUrl) {
   this.$body.removeClass('is-pending');
   this.$body.addClass('is-complete');
   this.$body.find('.download__message').remove();
-  this.$button.attr('href', this.downloadUrl).removeClass('disabled');
+  this.$button.attr('href', this.downloadUrl).removeClass('is-disabled');
 };
 
 DownloadItem.prototype.close = function() {

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -493,7 +493,7 @@ DataTable.prototype.ensureWidgets = function() {
 };
 
 DataTable.prototype.disableExport = function(opts) {
-  this.$exportButton.addClass('disabled');
+  this.$exportButton.addClass('is-disabled');
   this.$exportButton.off('click');
 
   // Adding everything we need for the tooltip
@@ -515,7 +515,7 @@ DataTable.prototype.disableExport = function(opts) {
 
 DataTable.prototype.enableExport = function() {
   this.$exportButton.off('click');
-  this.$exportButton.removeClass('disabled');
+  this.$exportButton.removeClass('is-disabled');
   this.$exportButton.on('click', this.export.bind(this));
   this.$exportTooltip.attr('aria-hidden', 'true');
 

--- a/static/templates/download/item.hbs
+++ b/static/templates/download/item.hbs
@@ -1,7 +1,7 @@
 <li class="download {{#if downloadUrl}}is-complete{{else}}is-pending{{/if}}">
   <div class="download__item">
     <span id="download-file-name" class="download__name">{{filename}}</span>
-      <a class="button button--cta download__button {{#unless downloadUrl}}disabled{{/unless}}"
+      <a class="button button--cta download__button {{#unless downloadUrl}}is-disabled{{/unless}}"
               href="{{downloadUrl}}"
               aria-describedby="download-file-name">Download</a>
     <button class="js-close button--cancel download__cancel"><span class="u-visually-hidden">Remove</span></button>

--- a/tests/unit/modules/tables.js
+++ b/tests/unit/modules/tables.js
@@ -95,7 +95,7 @@ describe('data table', function() {
     });
 
     it('adds a disabled class', function() {
-      expect(this.table.$exportButton.hasClass('disabled')).to.be.true;
+      expect(this.table.$exportButton.hasClass('is-disabled')).to.be.true;
     });
 
     it('does nothing on click', function() {
@@ -117,7 +117,7 @@ describe('data table', function() {
     });
 
     it('removes the disabled class', function() {
-      expect(this.table.$exportButton.hasClass('disabled')).to.be.false;
+      expect(this.table.$exportButton.hasClass('is-disabled')).to.be.false;
     });
 
     it('adds starts an export when clicked', function() {


### PR DESCRIPTION
Fixes a couple things I messed up earlier:
- Incorrectly had the disbursements route variables set to receipts, causing the receipts page to be generated at /disbursements
- In fec-style we changed from `.disabled` to `.is-disabled` but forgot to make the changes here
