### PR TITLE
Glossary "Party" links

### DIFF
--- a/openfecwebapp/templates/candidates-single.html
+++ b/openfecwebapp/templates/candidates-single.html
@@ -23,7 +23,7 @@
       </div>
       <ul class="entity__info">
         <li class="entity__term">
-          <span class="entity__term__label"><a class="term" data-term="Party">Party</a></span>
+          <span class="entity__term__label"><a class="term" data-term="Political party">Party</a></span>
           <span class="entity__term__data">{{ party_full }}</span>
         </li>
         <li class="entity__term">

--- a/openfecwebapp/templates/committees-single.html
+++ b/openfecwebapp/templates/committees-single.html
@@ -26,7 +26,7 @@
         <ul class="entity__info">
           {% if party_full %}
           <li class="entity__term">
-            <span class="entity__term__label"><span class="term" data-term="Party">Political party</span></span>
+            <span class="entity__term__label"><span class="term" data-term="Political party">Political party</span></span>
             <span class="entity__term__data">{{ party_full }}</span>
           </li>
           {% endif %}

--- a/openfecwebapp/templates/partials/search-results-candidate.html
+++ b/openfecwebapp/templates/partials/search-results-candidate.html
@@ -17,7 +17,7 @@
   <div class="row">
     <ul class="result__column">
       <li>Office sought: {{ candidate.office_full }}</li>
-      <li><span class="term" data-term="party">Party:</span> {{ candidate.party_full }}</li>
+      <li><span class="term" data-term="Political party">Party:</span> {{ candidate.party_full }}</li>
     </ul>
     <ul class="result__column">
       <li>State: {{ candidate.state or 'N/A' }}</li>


### PR DESCRIPTION
This should be a fast PR review :)

All our "party" links were misdirected in the glossary (to nothing). This fixes the links, so they all go to the "Political party" definition. 

Resolves: https://github.com/18F/FEC/issues/295
