### PR TITLE
Fix initial data table fetch.

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -403,6 +403,14 @@ function DataTable(selector, opts) {
   this.hasWidgets = null;
   this.filters = null;
 
+  // Set `this.filterSet` before instantiating the nested `DataTable` so that
+  // filters are available on fetching initial data
+  if (this.opts.useFilters) {
+    this.filterPanel = new FilterPanel();
+    this.filterSet = this.filterPanel.filterSet;
+    $(window).on('popstate', this.handlePopState.bind(this));
+  }
+
   var Paginator = this.opts.paginator || OffsetPaginator;
   this.paginator = new Paginator();
   this.api = this.$body.DataTable(this.opts);
@@ -410,11 +418,8 @@ function DataTable(selector, opts) {
   DataTable.registry[this.$body.attr('id')] = this;
 
   if (this.opts.useFilters) {
-    $(window).on('popstate', this.handlePopState.bind(this));
     var tagList = new filterTags.TagList({title: 'All records'});
     this.$widgets.find('.js-filter-tags').prepend(tagList.$body);
-    this.filterPanel = new FilterPanel();
-    this.filterSet = this.filterPanel.filterSet;
   }
 
   if (this.opts.useExport) {


### PR DESCRIPTION
As described in #1192, a recent refactor to data tables caused a
regression such that filters in query parameters were ignored on initial
fetch. This happened because the `DataTable` class was instantiated
before the `filterSet` attribute was set; since data tables depend on
the `filterSet` attribute to create filters, and since fetching starts
as soon as the `DataTable` is instantiated, the `filterSet` attribute
must be set first. This patch restores the order of operations and adds
a comment explaining why it matters.

[Resolves #1192]