### PR TITLE
Moving filter panel and widgets code

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -405,6 +405,8 @@ function DataTable(selector, opts) {
 
   this.$widgets = $(DATA_WIDGETS);
 
+  // Set `this.filterSet` before instantiating the nested `DataTable` so that
+  // filters are available on fetching initial data
   if (this.opts.useFilters) {
     var tagList = new filterTags.TagList({title: 'All records'});
     this.$widgets.find('.js-filter-tags').prepend(tagList.$body);

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -403,19 +403,21 @@ function DataTable(selector, opts) {
   this.hasWidgets = null;
   this.filters = null;
 
+  this.$widgets = $(DATA_WIDGETS);
+
+  if (this.opts.useFilters) {
+    var tagList = new filterTags.TagList({title: 'All records'});
+    this.$widgets.find('.js-filter-tags').prepend(tagList.$body);
+    this.filterPanel = new FilterPanel();
+    this.filterSet = this.filterPanel.filterSet;
+    $(window).on('popstate', this.handlePopState.bind(this));
+  }
+
   var Paginator = this.opts.paginator || OffsetPaginator;
   this.paginator = new Paginator();
   this.api = this.$body.DataTable(this.opts);
 
   DataTable.registry[this.$body.attr('id')] = this;
-
-  if (this.opts.useFilters) {
-    $(window).on('popstate', this.handlePopState.bind(this));
-    var tagList = new filterTags.TagList({title: 'All records'});
-    this.$widgets.find('.js-filter-tags').prepend(tagList.$body);
-    this.filterPanel = new FilterPanel();
-    this.filterSet = this.filterPanel.filterSet;
-  }
 
   if (this.opts.useExport) {
     $(document.body).on('download:countChanged', this.refreshExport.bind(this));
@@ -467,7 +469,6 @@ DataTable.prototype.ensureWidgets = function() {
   if (this.hasWidgets) { return; }
   this.$processing = $('<div class="overlay is-loading"></div>').hide();
   this.$body.before(this.$processing);
-  this.$widgets = $(DATA_WIDGETS);
 
   var $paging = this.$body.closest('.dataTables_wrapper').find('.js-results-info');
 


### PR DESCRIPTION
This is a hotfix version of @jmcarp 's PR: https://github.com/18F/openFEC-web-app/pull/1195

As he explained:

> As described in #1192, a recent refactor to data tables caused a
> regression such that filters in query parameters were ignored on initial
> fetch. This happened because the DataTable class was instantiated
> before the filterSet attribute was set; since data tables depend on
> the filterSet attribute to create filters, and since fetching starts
> as soon as the DataTable is instantiated, the filterSet attribute
> must be set first. This patch restores the order of operations and adds
> a comment explaining why it matters.

Additionally, this patch moves the `tagList` instantiation before the DataTable class to ensure the filter tags are generated by the URL as well.
