### PR TITLE
Add a manifest for the feature space

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,14 @@
-.gitignore
+*.log
+*.swp
+*.swo
+*.pyc
+node_modules
+.coverage
+.sass-cache/
+rev-manifest.json
+openfecwebapp/local_config.py
+app/
+/.env
+.DS_Store
+coverage/
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.swo
 *.pyc
 node_modules
+.cfmeta
 .coverage
 .sass-cache/
 rev-manifest.json

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ invoke deploy --space dev
 ```
 
 The `deploy` task will use the `FEC_CF_USERNAME` and `FEC_CF_PASSWORD` environment variables to log in.
-If these variables are not provided, you will be prompted for your Cloud Foundry credentials.
+If these variables are not provided, your existing authorization will be used.
+You can use `cf login` to login manually.
 
 Credentials for Cloud Foundry applications are managed using user-provided services labeled as
 "fec-creds-prod", "fec-creds-stage", and "fec-creds-dev". Services are used to share credentials between the API and the webapp. To set up a service:

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ the following keys are set:
 Deploys of a single app can be performed manually by targeting the env/space, and specifying the corresponding manifest, as well as the app you want, like so:
 
 ```
-cf target -o [dev|stage|prod] && cf push -f manifest_<[dev|stage|prod]>.yml [api|web]
+cf target -s [feature|dev|stage|prod] && cf push -f manifest_<[feature|dev|stage|prod]>.yml [api|web]
 ```
 
 **NOTE:**  Performing a deploy in this manner will result in a brief period of downtime.

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -9,3 +9,4 @@ env:
   FEC_WEB_API_URL: https://fec-dev-api.18f.gov
   FEC_CMS_URL: https://fec-proxy.18f.gov
   FEC_WEB_DEBUG: "true"
+  FEC_FEATURE_LEGAL: "true"

--- a/manifest_feature.yml
+++ b/manifest_feature.yml
@@ -1,0 +1,11 @@
+---
+inherit: manifest_base.yml
+host: fec-feature-web
+services:
+  - fec-creds-feature
+env:
+  FEC_WEB_ENVIRONMENT: "dev"
+  NEW_RELIC_APP_NAME: OpenFEC Web (feature)
+  FEC_WEB_API_URL: https://fec-feature-api.18f.gov
+  FEC_CMS_URL: https://fec-feature-proxy.18f.gov
+  FEC_WEB_DEBUG: "true"

--- a/manifest_feature.yml
+++ b/manifest_feature.yml
@@ -9,3 +9,4 @@ env:
   FEC_WEB_API_URL: https://fec-feature-api.18f.gov
   FEC_CMS_URL: https://fec-feature-proxy.18f.gov
   FEC_WEB_DEBUG: "true"
+  FEC_FEATURE_LEGAL: "true"

--- a/tasks.py
+++ b/tasks.py
@@ -73,7 +73,6 @@ DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
-    ('feature', lambda _, branch: branch.startswith('feature')),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -91,15 +91,16 @@ def deploy(space=None, branch=None, yes=False):
     if space is None:
         return
 
-    # Log in
-    args = (
-        ('--a', 'https://api.cloud.gov'),
-        ('--u', '$FEC_CF_USERNAME'),
-        ('--p', '$FEC_CF_PASSWORD'),
-        ('--o', 'fec'),
-        ('--s', space),
-    )
-    run('cf login {0}'.format(' '.join(' '.join(arg) for arg in args)), echo=True)
+    # Set api
+    api = 'https://api.cloud.gov'
+    run('cf api  {0}'.format(api), echo=True)
+
+    # Log in if necessary
+    if os.getenv('FEC_CF_USERNAME') and os.getenv('FEC_CF_PASSWORD'):
+        run('cf auth "$FEC_CF_USERNAME" "$FEC_CF_PASSWORD"', echo=True)
+
+    # Target space
+    run('cf target -o fec -s {0}'.format(space), echo=True)
 
     # Set deploy variables
     with open('.cfmeta', 'w') as fp:

--- a/tasks.py
+++ b/tasks.py
@@ -73,14 +73,8 @@ DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
+    ('feature', lambda _, branch: branch.startswith('feature')),
 )
-
-
-SPACE_URLS = {
-    'dev': [('18f.gov', 'fec-dev-web')],
-    'stage': [('18f.gov', 'fec-stage-web')],
-    'prod': [('18f.gov', 'fec-prod-web')],
-}
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -92,7 +92,7 @@ def deploy(space=None, branch=None, yes=False):
 
     # Set api
     api = 'https://api.cloud.gov'
-    run('cf api  {0}'.format(api), echo=True)
+    run('cf api {0}'.format(api), echo=True)
 
     # Log in if necessary
     if os.getenv('FEC_CF_USERNAME') and os.getenv('FEC_CF_PASSWORD'):


### PR DESCRIPTION
This allows us to have the web app deployed to the feature space. Thanks @anthonygarvan for doing the hard work of setting up services in the feature space.

I've also tweaked the way `invoke deploy` works so that providing your password is not required. You can just login with `cf login` normally and run `invoke deploy --space feature`.

cc @ccostino @noahmanger 