### PR TITLE
Adds a more specific zipcode lookup link

### DIFF
--- a/static/templates/electionZipWarning.hbs
+++ b/static/templates/electionZipWarning.hbs
@@ -1,6 +1,6 @@
 <div class="message message--alert">
   <div class="message__content">
     <p>ZIP code {{zip}} includes multiple congressional <span class="term" data-term="District">districts</span> with elections in {{cycle}}.</p>
-    <p class="t-sans">Find your district on <a href="https://www.house.gov">house.gov</a>.</p>
+    <p class="t-sans">Find your district on <a href="http://ziplook.house.gov/htbin/findrep?ZIP={{zip}}">house.gov</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
Per the suggestion in https://github.com/18F/FEC/issues/292 , this
directs users directly to the house.gov results page for the zipcode
they entered.

Fixes https://github.com/18F/FEC/issues/292