### PR TITLE
Improvements to the legal resources search

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -80,13 +80,14 @@ def _transform_legal_search_results(response):
     return results
 
 
-def load_legal_search_results(query, query_type='all', limit=20):
+def load_legal_search_results(query, query_type='all', offset=0, limit=20):
     filters = {}
 
     if query:
         filters['q'] = query
         filters['limit'] = limit
         filters['type'] = query_type
+        filters['from_hit'] = offset
 
     url = '/legal/search'
     results = _call_api(url, **filters)
@@ -97,6 +98,7 @@ def load_legal_search_results(query, query_type='all', limit=20):
         results = _transform_legal_search_results(results)
 
     results['limit'] = limit
+    results['offset'] = offset
 
     return results
 

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -47,18 +47,21 @@ def load_search_results(query, query_type='candidates'):
 def _transform_advisory_opinion(advisory_opinion):
     source = advisory_opinion['_source']
     return {
-        'id': source['AO_Id'],
-        'no' : source['AO_No'],
-        'name': source['AO_name'],
-        'summary': source['AO_Summary'],
-        'tags': source['AO_tags'],
-        'description': source['description'],
-        'doc_id': source['doc_id'],
-        'text': source['text'],
+        'id': source.get('AO_Id'),
+        'no' : source.get('AO_No'),
+        'name': source.get('AO_name'),
+        'summary': source.get('AO_Summary'),
+        'tags': source.get('AO_tags'),
+        'description': source.get('description'),
+        'doc_id': source.get('doc_id'),
+        'highlights': advisory_opinion['highlight']['text'],
+        'pdf_url': advisory_opinion.get('pdf_url'),
     }
 
 
-def _transform_legal_search_results(data):
+def _transform_legal_search_results(response):
+    data = response.get('results', [])
+
     results = {}
     results['advisory_opinions'] = [_transform_advisory_opinion(i) for i in data if i['_type'] == 'ao']
     results['regulations'] = [i for i in data if i['_type'] == 'regulation']
@@ -77,7 +80,7 @@ def load_legal_search_results(query, query_type='all', limit=20):
     url = '/legal/search'
     results = _call_api(url, **filters)
 
-    return _transform_legal_search_results(results.get('results', []))
+    return _transform_legal_search_results(results)
 
 
 def load_single_type(data_type, c_id, *path, **filters):

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -45,6 +45,7 @@ def load_search_results(query, query_type='candidates'):
     return results['results'] if len(results) else []
 
 def _transform_advisory_opinion(advisory_opinion):
+    #TODO move this to the API
     source = advisory_opinion['_source']
     return {
         'id': source.get('AO_Id'),
@@ -60,6 +61,7 @@ def _transform_advisory_opinion(advisory_opinion):
 
 
 def _transform_legal_search_results(response):
+    #TODO move this to the API
     data = response.get('results', [])
     count = response.get('count', -1)
 
@@ -89,7 +91,14 @@ def load_legal_search_results(query, query_type='all', limit=20):
     url = '/legal/search'
     results = _call_api(url, **filters)
 
-    return _transform_legal_search_results(results)
+    if query_type == 'aos':
+        results['results'] = [_transform_advisory_opinion(ao) for ao in results.get('results', [])]
+    else:
+        results = _transform_legal_search_results(results)
+
+    results['limit'] = limit
+
+    return results
 
 
 def load_single_type(data_type, c_id, *path, **filters):

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -54,18 +54,27 @@ def _transform_advisory_opinion(advisory_opinion):
         'tags': source.get('AO_tags'),
         'description': source.get('description'),
         'doc_id': source.get('doc_id'),
-        'highlights': advisory_opinion['highlight']['text'],
+        'highlights': advisory_opinion.get('highlight', {}).get('text', []),
         'pdf_url': advisory_opinion.get('pdf_url'),
     }
 
 
 def _transform_legal_search_results(response):
     data = response.get('results', [])
+    count = response.get('count', -1)
 
     results = {}
     results['advisory_opinions'] = [_transform_advisory_opinion(i) for i in data if i['_type'] == 'ao']
     results['regulations'] = [i for i in data if i['_type'] == 'regulation']
     results['murs'] = [i for i in data if i['_type'] == 'mur']
+    results['total_advisory_opinions'] = len(results['advisory_opinions'])
+    results['total_regulations'] = 0
+    results['total_murs'] = 0
+
+    if count != -1:
+        # This version of the API won't always return count
+        results['total_advisory_opinions'] = count
+
     return results
 
 

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -214,10 +214,14 @@ def elections(office, cycle, state=None, district=None):
     )
 
 @app.route('/legal/search/')
-def legal_search():
-    query = request.args.get('search')
-    result_type = request.args.get('search_type') or 'all'
+@use_kwargs({
+    'query': fields.Str(load_from='search'),
+    'result_type': fields.Str(load_from='search_type', missing='all'),
+})
+def legal_search(query, result_type):
     results = {}
+    if result_type not in ['all', 'aos', 'regs', 'murs']:
+        result_type = 'all'
 
     # Only hit the API if there's an actual query
     if query:
@@ -226,13 +230,16 @@ def legal_search():
     return views.render_legal_search_results(results, query, result_type)
 
 @app.route('/legal/advisory-opinions/')
-def advisory_opinions():
-    query = request.args.get('search')
+@use_kwargs({
+    'query': fields.Str(load_from='search'),
+    'offset': fields.Int(missing=0),
+})
+def advisory_opinions(query, offset):
     result_type = 'aos'
     results = {}
 
     # Only hit the API if there's an actual query
     if query:
-        results = api_caller.load_legal_search_results(query, result_type)
+        results = api_caller.load_legal_search_results(query, result_type, offset=offset)
 
     return views.render_legal_doc_search_results(results, query, result_type)

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -224,3 +224,15 @@ def legal_search():
         results = api_caller.load_legal_search_results(query, result_type)
 
     return views.render_legal_search_results(results, query, result_type)
+
+@app.route('/legal/advisory-opinions/')
+def advisory_opinions():
+    query = request.args.get('search')
+    result_type = 'aos'
+    results = {}
+
+    # Only hit the API if there's an actual query
+    if query:
+        results = api_caller.load_legal_search_results(query, result_type)
+
+    return views.render_legal_doc_search_results(results, query, result_type)

--- a/openfecwebapp/templates/legal-doc-search-results.html
+++ b/openfecwebapp/templates/legal-doc-search-results.html
@@ -14,7 +14,7 @@ Searching {{ document_type_display_name }} for "{{ query }}"
 <div class="main">
   <div class="container">
     <section class="main__content--full">
-      <div id="results-{{ result_type }}" class="content__section">
+      <div id="results-{{ result_type }}" class="content__section dataTables_wrapper">
         <div class="results-info results-info--top">
           <div class="results-info__left">
             <h2 class="results-info__title">{{ document_type_display_name }}</h2>
@@ -36,18 +36,27 @@ Searching {{ document_type_display_name }} for "{{ query }}"
               {% endfor %}
             </tbody>
           </table>
+          <div class="results-info">
+            <div class="dataTables_info">Showing {{ results.offset + 1 }}&ndash;{{ results.offset + results.results|length }} of about {{ results.count }}</span></div>
+            <div class="dataTables_paginate">
+              {% if results.offset > 0 %}
+              <a class="paginate_button previous" href="/legal/advisory-opinions?search={{ query }}&offset={{ results.offset - results.limit }}">Previous</a>
+              {% else %}
+              <span class="paginate_button previous is-disabled">Previous</span>
+              {% endif %}
+              {% if results.offset + results.limit < results.count %}
+              <a class="paginate_button next" href="/legal/advisory-opinions?search={{ query }}&offset={{ results.offset + results.limit }}">Next</a>
+              {% else %}
+              <span class="paginate_button next is-disabled">Next</span>
+              {% endif %}
+            </div>
+          </div>
         {% else %}
           <div class="message message--alert">
             <p>Sorry, there were no results.</p>
           </div>
         {% endif %}
       </div>
-      {% if results.count %}
-      <div class="results-info">
-        <div class="dataTables_info">Showing {{ results.offset|default(1) }}&ndash;{{ min(results.limit, results.count) }} of about {{ results.count }}</span>
-        <div class="dataTables_paginate">
-      </div>
-      {% endif %}
     </section>
     </div>
   </div>

--- a/openfecwebapp/templates/legal-doc-search-results.html
+++ b/openfecwebapp/templates/legal-doc-search-results.html
@@ -1,0 +1,55 @@
+{% extends "layouts/main.html" %}
+{% import 'macros/legal-search.html' as legal_search %}
+{% set document_type_display_name = 'Advisory Opinions' %}
+
+{% block title %}
+Searching {{ document_type_display_name }} for "{{ query }}"
+{% endblock %}
+
+{% block body %}
+<header class="page-header slab slab--primary">
+  <span class="page-header__title">Legal resources // {{ document_type_display_name }}</span>
+</header>
+
+<div class="main">
+  <div class="container">
+    <section class="main__content--full">
+      <div id="results-{{ result_type }}" class="content__section">
+        <div class="results-info results-info--top">
+          <div class="results-info__left">
+            <h2 class="results-info__title">{{ document_type_display_name }}</h2>
+          </div>
+        </div>
+        {% if results.count %}
+          <table class="data-table data-table--text">
+            <thead>
+              <tr>
+                <th class="cell--15">No.</th>
+                <th class="cell--25">Name</th>
+                <th class="cell--60">Hit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {# TODO this should handle generic document types (aos, murs, regs, etc) #}
+              {% for advisory_opinion in results.results %}
+                {% include 'partials/legal-search-results-advisory-opinion.html' %}
+              {% endfor %}
+            </tbody>
+          </table>
+        {% else %}
+          <div class="message message--alert">
+            <p>Sorry, there were no results.</p>
+          </div>
+        {% endif %}
+      </div>
+      {% if results.count %}
+      <div class="results-info">
+        <div class="dataTables_info">Showing {{ results.offset|default(1) }}&ndash;{{ min(results.limit, results.count) }} of about {{ results.count }}</span>
+        <div class="dataTables_paginate">
+      </div>
+      {% endif %}
+    </section>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -17,7 +17,7 @@
       <div class="sidebar-container sidebar-container--left">
         <nav class="sidebar sidebar--neutral side-nav js-sticky" data-sticky-container="main">
           <ul class="sidebar__content">
-            <li class="side-nav__item"><a class="side-nav__link" href="#results-advisory-opinions">Advisory Opinions ({{ results.total_advisory_opinions }})</a></li>
+            <li class="side-nav__item"><a class="side-nav__link" href="#results-advisory-opinions">Advisory Opinions ({{ results.total_advisory_opinions|default(0) }})</a></li>
             <li class="is-disabled side-nav__item"><span class="side-nav__link">Regulations (TBD)</span></li>
             <li class="is-disabled side-nav__item"><span class="side-nav__link">Matters Under Review (TBD)</span></li>
             <li class="is-disabled side-nav__item"><span class="side-nav__link">(Resource TBD)</span></li>

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -17,7 +17,7 @@
       <div class="sidebar-container sidebar-container--left">
         <nav class="sidebar sidebar--neutral side-nav js-sticky" data-sticky-container="main">
           <ul class="sidebar__content">
-            <li class="side-nav__item"><a class="side-nav__link" href="#results-advisory-opinions">Advisory Opinions ({{results.advisory_opinions|length}})</a></li>
+            <li class="side-nav__item"><a class="side-nav__link" href="#results-advisory-opinions">Advisory Opinions ({{ results.total_advisory_opinions }})</a></li>
             <li class="is-disabled side-nav__item"><span class="side-nav__link">Regulations (TBD)</span></li>
             <li class="is-disabled side-nav__item"><span class="side-nav__link">Matters Under Review (TBD)</span></li>
             <li class="is-disabled side-nav__item"><span class="side-nav__link">(Resource TBD)</span></li>
@@ -31,11 +31,13 @@
             <div class="results-info__left">
               <h2 class="results-info__title">Advisory Opinions</h2>
             </div>
+            {% if results.total_advisory_opinions %}
             <div class="results-info__right">
-              <span class="results-info__details"><a href="/legal/advisory-opinions">View all <strong>{{ results.advisory_opinions|length }}</strong> results</a></span>
+              <span class="results-info__details"><a href="/legal/advisory-opinions?search={{ query }}">View all <strong>{{ results.total_advisory_opinions }}</strong> results</a></span>
             </div>
+            {% endif %}
           </div>
-          {% if results.advisory_opinions|length %}
+          {% if results.total_advisory_opinions %}
             <table class="data-table data-table--text">
               <thead>
                 <tr>

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -32,7 +32,7 @@
               <h2 class="results-info__title">Advisory Opinions</h2>
             </div>
             <div class="results-info__right">
-              <span class="results-info__details">Showing the top 10 results</span>
+              <span class="results-info__details"><a href="/legal/advisory-opinions">View all <strong>{{ results.advisory_opinions|length }}</strong> results</a></span>
             </div>
           </div>
           {% if results.advisory_opinions|length %}

--- a/openfecwebapp/templates/partials/legal-search-results-advisory-opinion.html
+++ b/openfecwebapp/templates/partials/legal-search-results-advisory-opinion.html
@@ -1,8 +1,13 @@
-<tr>
-  <td><a title="{{ advisory_opinion.description }}" href="http://saos.fec.gov/aodocs/{{ advisory_opinion.no }}.pdf#search={{ query }}">{{ advisory_opinion.no }}</a></td>
+<tr class="legal-search-result">
+  <td><a title="{{ advisory_opinion.description }}" href="{{ advisory_opinion.pdf_url }}">{{ advisory_opinion.no }}</a></td>
   <td>{{ advisory_opinion.name }}</td>
   <td>
     <strong>{{ advisory_opinion.summary }}</strong>
-    <div class="t-serif" title="{{advisory_opinion.text}}">{{ advisory_opinion.text|truncate }}</div>
+    <div class="t-serif legal-search-result__hit">
+      &hellip;
+      {% for highlight in advisory_opinion.highlights %}
+        {{ highlight|safe }} &hellip;
+      {% endfor %}
+    </div>
   </td>
 </tr>

--- a/openfecwebapp/templates/partials/legal-search-results-advisory-opinion.html
+++ b/openfecwebapp/templates/partials/legal-search-results-advisory-opinion.html
@@ -1,5 +1,5 @@
 <tr class="legal-search-result">
-  <td><a title="{{ advisory_opinion.description }}" href="{{ advisory_opinion.pdf_url }}">{{ advisory_opinion.no }}</a></td>
+  <td><a title="{{ advisory_opinion.description }}" href="{{ advisory_opinion.pdf_url }}">AO {{ advisory_opinion.no }}</a></td>
   <td>{{ advisory_opinion.name }}</td>
   <td>
     <strong>{{ advisory_opinion.summary }}</strong>
@@ -9,5 +9,10 @@
         {{ highlight|safe }} &hellip;
       {% endfor %}
     </div>
+    {% if legal_include_display_all %}
+    <div class="legal-search-result__display-all">
+      <a href="/legal/advisory-opinions?search={{ query }}">Display all hits</a>
+    </div>
+    {% endif %}
   </td>
 </tr>

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -29,6 +29,16 @@ def render_search_results(results, query, result_type):
 def render_legal_search_results(results, query, result_type):
     return render_template(
         'legal-search-results.html',
+        legal_include_display_all=True, # includes the display-all link in results
+        query=query,
+        results=results,
+        result_type=result_type,
+    )
+
+
+def render_legal_doc_search_results(results, query, result_type):
+    return render_template(
+        'legal-doc-search-results.html',
         results=results,
         result_type=result_type,
         query=query,


### PR DESCRIPTION
The next iteration of the legal resources search as per https://github.com/18F/fec-eregs/issues/62.
- [x] Pagination on advisory opinions search page
- [x] Use `pdf_url` from API
- [x] Use total count from API, not limited to 10
- [x] Use snippet text from API with term highlights
- [x] Create advisory opinion search page at `/legal/advisory-opinions`
- [x] Review from the design team.
