### PR TITLE
Create a document-specific legal search page

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -68,7 +68,7 @@ def load_legal_search_results(query, query_type='all', offset=0, limit=20):
         filters['type'] = query_type
         filters['from_hit'] = offset
 
-    url = '/legal/search'
+    url = '/legal/search/'
     results = _call_api(url, **filters)
     results['limit'] = limit
     results['offset'] = offset

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -64,7 +64,7 @@ def load_legal_search_results(query, query_type='all', offset=0, limit=20):
     filters = {}
     if query:
         filters['q'] = query
-        filters['limit'] = limit
+        filters['hits_returned'] = limit
         filters['type'] = query_type
         filters['from_hit'] = offset
 

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -223,7 +223,7 @@ def legal_search(query, result_type):
 
     # Only hit the API if there's an actual query
     if query:
-        results = api_caller.load_legal_search_results(query, result_type)
+        results = api_caller.load_legal_search_results(query, result_type, limit=3)
 
     return views.render_legal_search_results(results, query, result_type)
 

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -241,3 +241,18 @@ def advisory_opinions(query, offset):
         results = api_caller.load_legal_search_results(query, result_type, offset=offset)
 
     return views.render_legal_doc_search_results(results, query, result_type)
+
+@app.route('/legal/regulations/')
+@use_kwargs({
+    'query': fields.Str(load_from='search'),
+    'offset': fields.Int(missing=0),
+})
+def regulations(query, offset):
+    result_type = 'regulations'
+    results = {}
+
+    # Only hit the API if there's an actual query
+    if query:
+        results = api_caller.load_legal_search_results(query, result_type, offset=offset)
+
+    return views.render_legal_doc_search_results(results, query, result_type)

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -233,7 +233,7 @@ def legal_search(query, result_type):
     'offset': fields.Int(missing=0),
 })
 def advisory_opinions(query, offset):
-    result_type = 'aos'
+    result_type = 'advisory_opinions'
     results = {}
 
     # Only hit the API if there's an actual query

--- a/openfecwebapp/templates/legal-doc-search-results.html
+++ b/openfecwebapp/templates/legal-doc-search-results.html
@@ -1,10 +1,12 @@
 {% extends "layouts/main.html" %}
 {% import 'macros/legal-search.html' as legal_search %}
-{% set document_type_display_name = 'Advisory Opinions' %}
+{% import 'macros/breadcrumbs.html' as breadcrumb %}
+
+{% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources')] %}
 
 {% block title %}
   {% if query %}
-  Searching {{ document_type_display_name }} for "{{ query }}"
+  Searching {{ document_type_display_name }} for &rdquo;{{ query }}&ldquo;
   {% else %}
   Search {{ document_type_display_name }}
   {% endif %}
@@ -12,7 +14,7 @@
 
 {% block body %}
 <header class="page-header slab slab--primary">
-  <span class="page-header__title">Legal resources // {{ document_type_display_name }}</span>
+  {{ breadcrumb.breadcrumbs(document_type_display_name, breadcrumb_links) }}
 </header>
 
 <section class="main__content--full">

--- a/openfecwebapp/templates/legal-doc-search-results.html
+++ b/openfecwebapp/templates/legal-doc-search-results.html
@@ -25,7 +25,7 @@
         <h2 class="results-info__title">Searching {{ document_type_display_name }}{% if query %} for “{{ query }}”{% endif %}</h2>
       </div>
     </div>
-    {% if results.count %}
+    {% if results.total_all %}
     <table class="data-table data-table--text">
       <thead>
         <tr>
@@ -42,14 +42,14 @@
       </tbody>
     </table>
     <div class="results-info">
-      <div class="dataTables_info">Showing {{ results.offset + 1 }}&ndash;{{ results.offset + results.results|length }} of about {{ results.count }}</span></div>
+      <div class="dataTables_info">Showing {{ results.offset + 1 }}&ndash;{{ results.offset + results.results|length }} of about {{ results.total_all }}</span></div>
       <div class="dataTables_paginate">
         {% if results.offset > 0 %}
 	<a class="paginate_button previous" href="{{ url_for('advisory_opinions', search=query, offset=(results.offset - results.limit)) }}#results-{{ result_type }}">Previous</a>
         {% else %}
         <span class="paginate_button previous is-disabled">Previous</span>
         {% endif %}
-        {% if results.offset + results.limit < results.count %}
+        {% if results.offset + results.limit < results.total_all %}
 	<a class="paginate_button next" href="{{ url_for('advisory_opinions', search=query, offset=(results.offset + results.limit)) }}#results-{{ result_type }}">Next</a>
         {% else %}
         <span class="paginate_button next is-disabled">Next</span>

--- a/openfecwebapp/templates/legal-doc-search-results.html
+++ b/openfecwebapp/templates/legal-doc-search-results.html
@@ -3,6 +3,7 @@
 {% import 'macros/breadcrumbs.html' as breadcrumb %}
 
 {% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources')] %}
+{% set result_entites = results.get(result_type, []) %}
 
 {% block title %}
   {% if query %}
@@ -36,21 +37,29 @@
       </thead>
       <tbody>
         {# TODO this should handle generic document types (aos, murs, regs, etc) #}
-        {% for advisory_opinion in results.results %}
-        {% include 'partials/legal-search-results-advisory-opinion.html' %}
+        {% for result in result_entites %}
+          {% if result_type == 'advisory_opinions' %}
+            {% with advisory_opinion = result %}
+            {% include 'partials/legal-search-results-advisory-opinion.html' %}
+            {% endwith %}
+          {% elif result_type == 'regulations' %}
+            {% with regulation = result %}
+            {% include 'partials/legal-search-results-regulation.html' %}
+            {% endwith %}
+          {% endif %}
         {% endfor %}
       </tbody>
     </table>
     <div class="results-info">
-      <div class="dataTables_info">Showing {{ results.offset + 1 }}&ndash;{{ results.offset + results.results|length }} of about {{ results.total_all }}</span></div>
+      <div class="dataTables_info">Showing {{ results.offset + 1 }}&ndash;{{ results.offset + result_entites|length }} of about {{ results.total_all }}</span></div>
       <div class="dataTables_paginate">
         {% if results.offset > 0 %}
-	<a class="paginate_button previous" href="{{ url_for('advisory_opinions', search=query, offset=(results.offset - results.limit)) }}#results-{{ result_type }}">Previous</a>
+	<a class="paginate_button previous" href="{{ url_for(result_type, search=query, offset=(results.offset - results.limit)) }}#results-{{ result_type }}">Previous</a>
         {% else %}
         <span class="paginate_button previous is-disabled">Previous</span>
         {% endif %}
         {% if results.offset + results.limit < results.total_all %}
-	<a class="paginate_button next" href="{{ url_for('advisory_opinions', search=query, offset=(results.offset + results.limit)) }}#results-{{ result_type }}">Next</a>
+	<a class="paginate_button next" href="{{ url_for(result_type, search=query, offset=(results.offset + results.limit)) }}#results-{{ result_type }}">Next</a>
         {% else %}
         <span class="paginate_button next is-disabled">Next</span>
         {% endif %}

--- a/openfecwebapp/templates/legal-doc-search-results.html
+++ b/openfecwebapp/templates/legal-doc-search-results.html
@@ -43,12 +43,12 @@
       <div class="dataTables_info">Showing {{ results.offset + 1 }}&ndash;{{ results.offset + results.results|length }} of about {{ results.count }}</span></div>
       <div class="dataTables_paginate">
         {% if results.offset > 0 %}
-        <a class="paginate_button previous" href="/legal/advisory-opinions?search={{ query }}&offset={{ results.offset - results.limit }}">Previous</a>
+	<a class="paginate_button previous" href="{{ url_for('advisory_opinions', search=query, offset=(results.offset - results.limit)) }}#results-{{ result_type }}">Previous</a>
         {% else %}
         <span class="paginate_button previous is-disabled">Previous</span>
         {% endif %}
         {% if results.offset + results.limit < results.count %}
-        <a class="paginate_button next" href="/legal/advisory-opinions?search={{ query }}&offset={{ results.offset + results.limit }}">Next</a>
+	<a class="paginate_button next" href="{{ url_for('advisory_opinions', search=query, offset=(results.offset + results.limit)) }}#results-{{ result_type }}">Next</a>
         {% else %}
         <span class="paginate_button next is-disabled">Next</span>
         {% endif %}

--- a/openfecwebapp/templates/legal-doc-search-results.html
+++ b/openfecwebapp/templates/legal-doc-search-results.html
@@ -23,7 +23,7 @@
   <div id="results-{{ result_type }}" class="content__section dataTables_wrapper">
     <div class="results-info results-info--simple">
       <div class="results-info__left">
-        <h2 class="results-info__title">Searching {{ document_type_display_name }}{% if query %} for “{{ query }}”{% endif %}</h2>
+        <h2 class="results-info__title">Searching {{ document_type_display_name }}{% if query %} for &ldquo;{{ query }}&rdquo;{% endif %}</h2>
       </div>
     </div>
     {% if results.total_all %}

--- a/openfecwebapp/templates/legal-doc-search-results.html
+++ b/openfecwebapp/templates/legal-doc-search-results.html
@@ -6,7 +6,7 @@
 
 {% block title %}
   {% if query %}
-  Searching {{ document_type_display_name }} for &rdquo;{{ query }}&ldquo;
+  Searching {{ document_type_display_name }} for &ldquo;{{ query }}&rdquo;
   {% else %}
   Search {{ document_type_display_name }}
   {% endif %}

--- a/openfecwebapp/templates/legal-doc-search-results.html
+++ b/openfecwebapp/templates/legal-doc-search-results.html
@@ -3,7 +3,11 @@
 {% set document_type_display_name = 'Advisory Opinions' %}
 
 {% block title %}
-Searching {{ document_type_display_name }} for "{{ query }}"
+  {% if query %}
+  Searching {{ document_type_display_name }} for "{{ query }}"
+  {% else %}
+  Search {{ document_type_display_name }}
+  {% endif %}
 {% endblock %}
 
 {% block body %}
@@ -11,54 +15,50 @@ Searching {{ document_type_display_name }} for "{{ query }}"
   <span class="page-header__title">Legal resources // {{ document_type_display_name }}</span>
 </header>
 
-<div class="main">
-  <div class="container">
-    <section class="main__content--full">
-      <div id="results-{{ result_type }}" class="content__section dataTables_wrapper">
-        <div class="results-info results-info--simple">
-          <div class="results-info__left">
-            <h2 class="results-info__title">{{ document_type_display_name }}</h2>
-          </div>
-        </div>
-        {% if results.count %}
-          <table class="data-table data-table--text">
-            <thead>
-              <tr>
-                <th class="cell--15">No.</th>
-                <th class="cell--25">Name</th>
-                <th class="cell--60">Hit</th>
-              </tr>
-            </thead>
-            <tbody>
-              {# TODO this should handle generic document types (aos, murs, regs, etc) #}
-              {% for advisory_opinion in results.results %}
-                {% include 'partials/legal-search-results-advisory-opinion.html' %}
-              {% endfor %}
-            </tbody>
-          </table>
-          <div class="results-info">
-            <div class="dataTables_info">Showing {{ results.offset + 1 }}&ndash;{{ results.offset + results.results|length }} of about {{ results.count }}</span></div>
-            <div class="dataTables_paginate">
-              {% if results.offset > 0 %}
-              <a class="paginate_button previous" href="/legal/advisory-opinions?search={{ query }}&offset={{ results.offset - results.limit }}">Previous</a>
-              {% else %}
-              <span class="paginate_button previous is-disabled">Previous</span>
-              {% endif %}
-              {% if results.offset + results.limit < results.count %}
-              <a class="paginate_button next" href="/legal/advisory-opinions?search={{ query }}&offset={{ results.offset + results.limit }}">Next</a>
-              {% else %}
-              <span class="paginate_button next is-disabled">Next</span>
-              {% endif %}
-            </div>
-          </div>
+<section class="main__content--full">
+  {% include 'partials/legal-filter.html' %}
+  <div id="results-{{ result_type }}" class="content__section dataTables_wrapper">
+    <div class="results-info results-info--simple">
+      <div class="results-info__left">
+        <h2 class="results-info__title">Searching {{ document_type_display_name }}{% if query %} for “{{ query }}”{% endif %}</h2>
+      </div>
+    </div>
+    {% if results.count %}
+    <table class="data-table data-table--text">
+      <thead>
+        <tr>
+          <th class="cell--15">No.</th>
+          <th class="cell--25">Name</th>
+          <th class="cell--60">Hit</th>
+        </tr>
+      </thead>
+      <tbody>
+        {# TODO this should handle generic document types (aos, murs, regs, etc) #}
+        {% for advisory_opinion in results.results %}
+        {% include 'partials/legal-search-results-advisory-opinion.html' %}
+        {% endfor %}
+      </tbody>
+    </table>
+    <div class="results-info">
+      <div class="dataTables_info">Showing {{ results.offset + 1 }}&ndash;{{ results.offset + results.results|length }} of about {{ results.count }}</span></div>
+      <div class="dataTables_paginate">
+        {% if results.offset > 0 %}
+        <a class="paginate_button previous" href="/legal/advisory-opinions?search={{ query }}&offset={{ results.offset - results.limit }}">Previous</a>
         {% else %}
-          <div class="message message--alert">
-            <p>Sorry, there were no results.</p>
-          </div>
+        <span class="paginate_button previous is-disabled">Previous</span>
+        {% endif %}
+        {% if results.offset + results.limit < results.count %}
+        <a class="paginate_button next" href="/legal/advisory-opinions?search={{ query }}&offset={{ results.offset + results.limit }}">Next</a>
+        {% else %}
+        <span class="paginate_button next is-disabled">Next</span>
         {% endif %}
       </div>
-    </section>
     </div>
+    {% else %}
+    <div class="message message--alert">
+      <p>Sorry, there were no results.</p>
+    </div>
+    {% endif %}
   </div>
-</div>
+</section>
 {% endblock %}

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -51,9 +51,7 @@
             </div>
             {% if results.total_regulations %}
             <div class="results-info__right">
-              <span class="results-info__details">
-                <a href="/legal/advisory-opinions?search={{ query }}">
-                  View all <strong>{{ results.total_regulations }}</strong> results</a></span>
+              <span class="results-info__details">1&ndash;{{ results.regulations|length }} of <a href="{{ url_for('regulations', search=query, search_type='regulations') }}"><strong>{{ results.total_regulations }}</strong> results</a></span>
             </div>
             {% endif %}
           </div>
@@ -72,6 +70,9 @@
                 {% endfor %}
               </tbody>
             </table>
+            <div class="results-info">
+              <a class="button button--browse button--alt" href="{{ url_for('regulations', search=query, search_type='regulations') }}">View all results</a>
+            </div>
           {% else %}
             <div class="message message--alert">
               <p>Sorry, there were no results.</p>

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -45,7 +45,7 @@
         <h1 class="main__title">Results for “{{ query }}”</h1>
         {% endif %}
         <div id="results-regulations" class="content__section">
-          <div class="results-info results-info--top">
+          <div class="results-info results-info--simple">
             <div class="results-info__left">
               <h2 class="results-info__title">Regulations</h2>
             </div>
@@ -80,7 +80,7 @@
         </div>
 
         <div id="results-advisory-opinions" class="content__section">
-          <div class="results-info results-info--top">
+          <div class="results-info results-info--simple">
             <div class="results-info__left">
               <h2 class="results-info__title">Advisory Opinions</h2>
             </div>

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -1,5 +1,8 @@
 {% extends "layouts/main.html" %}
 {% import 'macros/legal-search.html' as legal_search %}
+{% import 'macros/breadcrumbs.html' as breadcrumb %}
+
+{% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources')] %}
 
 {% block title %}
   {% if query %}
@@ -11,7 +14,7 @@
 
 {% block body %}
 <header class="page-header slab slab--primary">
-  <span class="page-header__title">Search results</span>
+  {{ breadcrumb.breadcrumbs('Search results', breadcrumb_links) }}
   {{ legal_search.search('header', result_type, query) }}
 </header>
 

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -42,7 +42,7 @@
       </div>
       <section class="main__content--right">
         {% if query %}
-        <h1 class="main__title">Results for “{{ query }}”</h1>
+        <h1 class="main__title">Results for &ldquo;{{ query }}&rdquo;</h1>
         {% endif %}
         <div id="results-regulations" class="content__section">
           <div class="results-info results-info--simple">
@@ -75,7 +75,16 @@
             </div>
           {% else %}
             <div class="message message--alert">
-              <p>Sorry, there were no results.</p>
+              <h2 class="message__title">No results</h2>
+              <p>Sorry, we didn't find any regulations matching <span class="t-bold">{{ query }}</span>.</p>
+              <div class="message--alert__bottom">
+                <p>Think this was a mistake?</p>
+                <ul class="list--buttons">
+                  <li><a class="button button--standard" href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources=Administrative_Fine%2CAdvisory_Opinion%2CAlternative_Dispute_Resolution%2CAudit_Reports%2CMatters_Under_Review%2CMatters_Under_Review_Archived%2CRulemaster%2CCandidate_Summary%2CCommittee_Summary%2Cfec.gov&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&">Try FEC.gov</a></li>
+                  <li><a class="button button--standard" href="mailto:{{ contact_email }}">Email our team</a></li>
+                  <li><a class="button button--standard" href="https://github.com/18f/fec/issues">File an issue</a></li>
+                </ul>
+              </div>
             </div>
           {% endif %}
         </div>
@@ -111,7 +120,16 @@
             </div>
           {% else %}
             <div class="message message--alert">
-              <p>Sorry, there were no results.</p>
+              <h2 class="message__title">No results</h2>
+              <p>Sorry, we didn't find any advisory opinions matching <span class="t-bold">{{ query }}</span>.</p>
+              <div class="message--alert__bottom">
+                <p>Think this was a mistake?</p>
+                <ul class="list--buttons">
+                  <li><a class="button button--standard" href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources=Administrative_Fine%2CAdvisory_Opinion%2CAlternative_Dispute_Resolution%2CAudit_Reports%2CMatters_Under_Review%2CMatters_Under_Review_Archived%2CRulemaster%2CCandidate_Summary%2CCommittee_Summary%2Cfec.gov&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&">Try FEC.gov</a></li>
+                  <li><a class="button button--standard" href="mailto:{{ contact_email }}">Email our team</a></li>
+                  <li><a class="button button--standard" href="https://github.com/18f/fec/issues">File an issue</a></li>
+                </ul>
+              </div>
             </div>
           {% endif %}
         </div>

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -105,7 +105,7 @@
                 {% endfor %}
               </tbody>
             </table>
-            <div class="results-info results-info--bottom">
+            <div class="results-info">
               <a class="button button--browse button--alt" href="{{ url_for('advisory_opinions', search=query, search_type='aos') }}">View all results</a>
             </div>
           {% else %}

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -83,7 +83,7 @@
             </div>
             {% if results.total_advisory_opinions %}
             <div class="results-info__right">
-              <span class="results-info__details">1&ndash;{{ results.advisory_opinions|length }} of <a href="/legal/advisory-opinions/?search={{ query }}"><strong>{{ results.total_advisory_opinions }}</strong> results</a></span>
+              <span class="results-info__details">1&ndash;{{ results.advisory_opinions|length }} of <a href="{{ url_for('advisory_opinions', search=query) }}"><strong>{{ results.total_advisory_opinions }}</strong> results</a></span>
             </div>
             {% endif %}
           </div>
@@ -103,7 +103,7 @@
               </tbody>
             </table>
             <div class="results-info results-info--bottom">
-              <a class="button button--browse button--alt" href="/legal/advisory-opinions/?search={{ query }}">View all results</a>
+              <a class="button button--browse button--alt" href="{{ url_for('advisory_opinions', search=query) }}">View all results</a>
             </div>
           {% else %}
             <div class="message message--alert">

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -83,7 +83,7 @@
             </div>
             {% if results.total_advisory_opinions %}
             <div class="results-info__right">
-              <span class="results-info__details">1&ndash;{{ results.advisory_opinions|length }} of <a href="{{ url_for('advisory_opinions', search=query) }}"><strong>{{ results.total_advisory_opinions }}</strong> results</a></span>
+              <span class="results-info__details">1&ndash;{{ results.advisory_opinions|length }} of <a href="{{ url_for('advisory_opinions', search=query, search_type='aos') }}"><strong>{{ results.total_advisory_opinions }}</strong> results</a></span>
             </div>
             {% endif %}
           </div>
@@ -103,7 +103,7 @@
               </tbody>
             </table>
             <div class="results-info results-info--bottom">
-              <a class="button button--browse button--alt" href="{{ url_for('advisory_opinions', search=query) }}">View all results</a>
+              <a class="button button--browse button--alt" href="{{ url_for('advisory_opinions', search=query, search_type='aos') }}">View all results</a>
             </div>
           {% else %}
             <div class="message message--alert">

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -34,6 +34,7 @@
         </nav>
       </div>
       <section class="main__content">
+        <h1 class="main__title">Results for “{{ query }}”</h1>
         <div id="results-regulations" class="content__section">
           <div class="results-info results-info--top">
             <div class="results-info__left">
@@ -76,7 +77,7 @@
             </div>
             {% if results.total_advisory_opinions %}
             <div class="results-info__right">
-              <span class="results-info__details"><a href="/legal/advisory-opinions?search={{ query }}">View all <strong>{{ results.total_advisory_opinions }}</strong> results</a></span>
+              <span class="results-info__details">1&ndash;{{ results.advisory_opinions|length }} of <a href="/legal/advisory-opinions/?search={{ query }}"><strong>{{ results.total_advisory_opinions }}</strong> results</a></span>
             </div>
             {% endif %}
           </div>
@@ -95,6 +96,9 @@
                 {% endfor %}
               </tbody>
             </table>
+            <div class="results-info results-info--simple">
+              <a class="button button--alt" href="/legal/advisory-opinions/?search={{ query }}">View all results</a>
+            </div>
           {% else %}
             <div class="message message--alert">
               <p>Sorry, there were no results.</p>

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -86,7 +86,7 @@
             </div>
             {% if results.total_advisory_opinions %}
             <div class="results-info__right">
-              <span class="results-info__details">1&ndash;{{ results.advisory_opinions|length }} of <a href="{{ url_for('advisory_opinions', search=query, search_type='aos') }}"><strong>{{ results.total_advisory_opinions }}</strong> results</a></span>
+              <span class="results-info__details">1&ndash;{{ results.advisory_opinions|length }} of <a href="{{ url_for('advisory_opinions', search=query, search_type='advisory_opinions') }}"><strong>{{ results.total_advisory_opinions }}</strong> results</a></span>
             </div>
             {% endif %}
           </div>
@@ -106,7 +106,7 @@
               </tbody>
             </table>
             <div class="results-info">
-              <a class="button button--browse button--alt" href="{{ url_for('advisory_opinions', search=query, search_type='aos') }}">View all results</a>
+              <a class="button button--browse button--alt" href="{{ url_for('advisory_opinions', search=query, search_type='advisory_opinions') }}">View all results</a>
             </div>
           {% else %}
             <div class="message message--alert">

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -2,7 +2,11 @@
 {% import 'macros/legal-search.html' as legal_search %}
 
 {% block title %}
+  {% if query %}
   Search results for &ldquo;{{query}}&rdquo;
+  {% else %}
+  Search legal resources
+  {% endif %}
 {% endblock %}
 
 {% block body %}
@@ -33,8 +37,10 @@
           </ul>
         </nav>
       </div>
-      <section class="main__content">
+      <section class="main__content--right">
+        {% if query %}
         <h1 class="main__title">Results for “{{ query }}”</h1>
+        {% endif %}
         <div id="results-regulations" class="content__section">
           <div class="results-info results-info--top">
             <div class="results-info__left">
@@ -71,7 +77,7 @@
         </div>
 
         <div id="results-advisory-opinions" class="content__section">
-          <div class="results-info results-info--simple">
+          <div class="results-info results-info--top">
             <div class="results-info__left">
               <h2 class="results-info__title">Advisory Opinions</h2>
             </div>
@@ -96,8 +102,8 @@
                 {% endfor %}
               </tbody>
             </table>
-            <div class="results-info results-info--simple">
-              <a class="button button--alt" href="/legal/advisory-opinions/?search={{ query }}">View all results</a>
+            <div class="results-info results-info--bottom">
+              <a class="button button--browse button--alt" href="/legal/advisory-opinions/?search={{ query }}">View all results</a>
             </div>
           {% else %}
             <div class="message message--alert">

--- a/openfecwebapp/templates/macros/breadcrumbs.html
+++ b/openfecwebapp/templates/macros/breadcrumbs.html
@@ -1,21 +1,19 @@
 {% macro breadcrumbs(title, links) %}
-<header class="page-header page-header--primary">
-  <ul class="breadcrumbs">
-    <li class="breadcrumbs__item"><a href="{{ cms_url }}" class="breadcrumbs__link" rel="Home">Home</a></li>
-    {% for link in links %}
-    <li class="breadcrumbs__item">
-      {% if link[0] != '' %}
-        <span class="breadcrumbs__separator">&rsaquo;</span>
-        <a class="breadcrumbs__link" href="{{ link[0] }}">{{ link[1] }}</a>
-      {% else %}
-        <span>{{ link[1] }}</span>
-      {% endif %}
-    </li>
-    {% endfor %}
-    <li class="breadcrumbs__item breadcrumbs__item--current">
+<ul class="breadcrumbs">
+  <li class="breadcrumbs__item"><a href="{{ cms_url }}" class="breadcrumbs__link" rel="Home">Home</a></li>
+  {% for link in links %}
+  <li class="breadcrumbs__item">
+    {% if link[0] != '' %}
       <span class="breadcrumbs__separator">&rsaquo;</span>
-      <span>{{ title }}</span>
-    </li>
-  </ul>
-</header>
+      <a class="breadcrumbs__link" href="{{ link[0] }}">{{ link[1] }}</a>
+    {% else %}
+      <span>{{ link[1] }}</span>
+    {% endif %}
+  </li>
+  {% endfor %}
+  <li class="breadcrumbs__item breadcrumbs__item--current">
+    <span class="breadcrumbs__separator">&rsaquo;</span>
+    <span>{{ title }}</span>
+  </li>
+</ul>
 {% endmacro %}

--- a/openfecwebapp/templates/partials/legal-filter.html
+++ b/openfecwebapp/templates/partials/legal-filter.html
@@ -1,0 +1,21 @@
+<div id="filters" class="filters filters--fixed is-open">
+  <div class="filters__hider">
+    <h2 class="filter__header filters__inner">
+      Search AOs
+    </h2>
+    <form id="category-filters" action="#results-{{ result_type }}">
+      <div class="filters__inner">
+        <div class="filter" id="search-field">
+          <label class="label" for="search-input">Search terms</label>
+          <div class="combo combo--search--mini">
+            <ul class="dropdown__selected"></ul>
+            <input id="search-input" type="text" name="search" class="combo__input"{% if query %} value="{{ query }}"{% endif %}>
+            <button class="combo__button button--search button--standard" type="submit">
+              <span class="u-visually-hidden">Search</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>

--- a/openfecwebapp/templates/partials/legal-filter.html
+++ b/openfecwebapp/templates/partials/legal-filter.html
@@ -1,7 +1,7 @@
 <div id="filters" class="filters filters--fixed is-open">
   <div class="filters__hider">
     <h2 class="filter__header filters__inner">
-      Search AOs
+      Search {{ document_type_display_name }}
     </h2>
     <form id="category-filters" action="#results-{{ result_type }}">
       <div class="filters__inner">

--- a/openfecwebapp/templates/partials/legal-search-results-advisory-opinion.html
+++ b/openfecwebapp/templates/partials/legal-search-results-advisory-opinion.html
@@ -9,10 +9,5 @@
         {{ highlight|safe }} &hellip;
       {% endfor %}
     </div>
-    {% if legal_include_display_all %}
-    <div class="legal-search-result__display-all">
-      <a href="/legal/advisory-opinions?search={{ query }}">Display all hits</a>
-    </div>
-    {% endif %}
   </td>
 </tr>

--- a/openfecwebapp/templates/partials/legal-search-results-regulation.html
+++ b/openfecwebapp/templates/partials/legal-search-results-regulation.html
@@ -9,10 +9,5 @@
         {{ highlight|safe }} &hellip;
       {% endfor %}
     </div>
-    {% if legal_include_display_all %}
-    <div class="legal-search-result__display-all">
-      <a href="/legal/advisory-opinions?search={{ query }}">Display all hits</a>
-    </div>
-    {% endif %}
   </td>
 </tr>

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -37,8 +37,14 @@ def render_legal_search_results(results, query, result_type):
 
 
 def render_legal_doc_search_results(results, query, result_type):
+    if result_type == 'aos':
+        document_type_display_name = 'Advisory Opinions'
+    else:
+        document_type_display_name = 'Documents'
+
     return render_template(
         'legal-doc-search-results.html',
+        document_type_display_name=document_type_display_name,
         results=results,
         result_type=result_type,
         query=query,

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -39,6 +39,8 @@ def render_legal_search_results(results, query, result_type):
 def render_legal_doc_search_results(results, query, result_type):
     if result_type == 'advisory_opinions':
         document_type_display_name = 'Advisory Opinions'
+    elif result_type == 'regulations':
+        document_type_display_name = 'Regulations'
     else:
         document_type_display_name = 'Documents'
 

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -37,7 +37,7 @@ def render_legal_search_results(results, query, result_type):
 
 
 def render_legal_doc_search_results(results, query, result_type):
-    if result_type == 'aos':
+    if result_type == 'advisory_opinions':
         document_type_display_name = 'Advisory Opinions'
     else:
         document_type_display_name = 'Documents'

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -382,7 +382,7 @@ $(document).ready(function() {
         query: query,
         columns: filingsColumns,
         rowCallback: filings.renderRow,
-        dom: '<"panel__main"t><"results-info results-info--bottom"frip>',
+        dom: '<"panel__main"t><"results-info"frip>',
         pagingType: 'simple',
         // Order by receipt date descending
         order: [[2, 'desc']],


### PR DESCRIPTION
This introduces the Advisory Opinion search page. Eventually this document-specific search page would be used to implement Regs and MURs search as well.
https://github.com/18F/fec-eregs/issues/52

**search results**
![screenshot from 2016-04-26 16-00-03](https://cloud.githubusercontent.com/assets/509703/14836907/ad74ddf8-0bc8-11e6-904a-83d4f36fedd3.png)

**pagination**
![screenshot from 2016-04-26 16-04-45](https://cloud.githubusercontent.com/assets/509703/14836908/ad78729c-0bc8-11e6-887c-d6180ca02889.png)

Changes to fec-style coming soon.