### PR TITLE
Bump fec-style version to support ~1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "d3": "3.5.5",
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
-    "fec-style": "~1.9",
+    "fec-style": "~1.10",
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",
     "intl": "1.0.0-rc-4",


### PR DESCRIPTION
This changeset brings the `fec-style` dependency up to date with the latest release.