### PR TITLE
Typesetting and note text adjustments

### DIFF
--- a/openfecwebapp/templates/macros/disclaimer.html
+++ b/openfecwebapp/templates/macros/disclaimer.html
@@ -1,6 +1,6 @@
 {% macro disclaimer(type, id, cycle) %}
   <div class="datatable__note">
-    <p class="t-note">Note: These totals are calculated, in part, using free-text input as reported by this committee. Variations in spelling or abbreviation can produce multiple totals for the same category. For the most complete information,
-    <a href="{{ url_for(type, committee_id=id, cycle=cycle) }}">view the list of itemized transactions. &raquo;</a></p>
+    <p class="t-note">These totals are calculated, in part, using free-text input as reported by this committee. Variations in spelling or abbreviation can produce multiple totals for the same category. For the most complete information,
+    <a href="{{ url_for(type, committee_id=id, cycle=cycle) }}">view the list of itemized transactions.</a></p>
   </div>
 {% endmacro %}

--- a/openfecwebapp/templates/partials/candidate/financial-summary.html
+++ b/openfecwebapp/templates/partials/candidate/financial-summary.html
@@ -82,7 +82,7 @@
         </div>
         {% endfor %}
       {% endif %}
-      <p>Candidates receive and spend money through <span class="term" data-term="Committee">committees</span>. These are the <strong>combined financial totals</strong> for all of this candidate's <span class="term" data-term="Authorized committee">authorized committees</span>. Learn more about each committee's fundraising and spending on its page.</p>
+      <div class="t-note">Candidates receive and spend money through <span class="term" data-term="Committee">committees</span>. These are the <strong>combined financial totals</strong> for all of this candidate's <span class="term" data-term="Authorized committee">authorized committees</span>. Learn more about each committee's fundraising and spending on its page.</div>
     </div>
   </div>
 

--- a/openfecwebapp/templates/partials/candidate/other-spending-tab.html
+++ b/openfecwebapp/templates/partials/candidate/other-spending-tab.html
@@ -31,7 +31,7 @@
         </thead>
       </table>
       <div class="datatable__note">
-        <p class="t-note">Note: These totals are drawn from quarterly, monthly and semi-annual reports. 24-hour and 48-hour independent expenditures reports are not included.</p>
+        <p class="t-note">These totals are drawn from quarterly, monthly and semi-annual reports. 24-hour and 48-hour independent expenditures reports are not included.</p>
       </div>
     </div>
 

--- a/openfecwebapp/templates/partials/committee/independent-expenditures-tab.html
+++ b/openfecwebapp/templates/partials/committee/independent-expenditures-tab.html
@@ -23,7 +23,7 @@
         </thead>
       </table>
       <div class="datatable__note">
-        <p class="t-note">Note: These totals are drawn from quarterly, monthly and semi-annual reports. 24-hour and 48-hour independent expenditures reports are not included.</p>
+        <p class="t-note">These totals are drawn from quarterly, monthly and semi-annual reports. 24-hour and 48-hour independent expenditures reports are not included.</p>
       </div>
     </div>
   </div>

--- a/openfecwebapp/templates/partials/elections/other-spending-tab.html
+++ b/openfecwebapp/templates/partials/elections/other-spending-tab.html
@@ -21,7 +21,7 @@
         </thead>
       </table>
       <div class="datatable__note">
-        <p class="t-note">Note: These totals are drawn from quarterly, monthly and semi-annual reports. 24-hour and 48-hour independent expenditures reports are not included.</p>
+        <p class="t-note">These totals are drawn from quarterly, monthly and semi-annual reports. 24-hour and 48-hour independent expenditures reports are not included.</p>
       </div>
     </div>
 
@@ -51,7 +51,7 @@
         </thead>
       </table>
       <div class="datatable__note">
-        <p class="t-note">Note: To help users work with this data, we divide each itemized disbursement amount by the number of federal candidates named in connection with that disbursement. The resulting amount is listed here.</p>
+        <p class="t-note">To help users work with this data, we divide each itemized disbursement amount by the number of federal candidates named in connection with that disbursement. The resulting amount is listed here.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
This is a partner PR for https://github.com/18F/fec-style/pull/345 and adjusts type treatments in instances  of notes about the information on the data side. It makes some language consistent (removes "Note:" because we had been using it in some places, but not others) and changes one font style.

## Screenshots

**After**

![screen shot 2016-05-09 at 12 33 17 pm](https://cloud.githubusercontent.com/assets/11636908/15120161/69d7197a-15e2-11e6-84d3-e431fd9336e6.png)



**Before**

![screen shot 2016-05-09 at 12 21 03 pm](https://cloud.githubusercontent.com/assets/11636908/15120144/5b167df4-15e2-11e6-9e75-e855a35934a5.png)

cc @emileighoutlaw @noahmanger 