### PR TITLE
Feature/add regulations to search

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -49,7 +49,7 @@ def _transform_advisory_opinion(advisory_opinion):
     source = advisory_opinion['_source']
     return {
         'id': source.get('AO_Id'),
-        'no' : source.get('AO_No'),
+        'no': source.get('AO_No'),
         'name': source.get('AO_name'),
         'summary': source.get('AO_Summary'),
         'tags': source.get('AO_tags'),
@@ -60,29 +60,8 @@ def _transform_advisory_opinion(advisory_opinion):
     }
 
 
-def _transform_legal_search_results(response):
-    #TODO move this to the API
-    data = response.get('results', [])
-    count = response.get('count', -1)
-
-    results = {}
-    results['advisory_opinions'] = [_transform_advisory_opinion(i) for i in data if i['_type'] == 'ao']
-    results['regulations'] = [i for i in data if i['_type'] == 'regulation']
-    results['murs'] = [i for i in data if i['_type'] == 'mur']
-    results['total_advisory_opinions'] = len(results['advisory_opinions'])
-    results['total_regulations'] = 0
-    results['total_murs'] = 0
-
-    if count != -1:
-        # This version of the API won't always return count
-        results['total_advisory_opinions'] = count
-
-    return results
-
-
 def load_legal_search_results(query, query_type='all', offset=0, limit=20):
     filters = {}
-
     if query:
         filters['q'] = query
         filters['limit'] = limit
@@ -91,12 +70,6 @@ def load_legal_search_results(query, query_type='all', offset=0, limit=20):
 
     url = '/legal/search'
     results = _call_api(url, **filters)
-
-    if query_type == 'aos':
-        results['results'] = [_transform_advisory_opinion(ao) for ao in results.get('results', [])]
-    else:
-        results = _transform_legal_search_results(results)
-
     results['limit'] = limit
     results['offset'] = offset
 

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -220,8 +220,6 @@ def elections(office, cycle, state=None, district=None):
 })
 def legal_search(query, result_type):
     results = {}
-    if result_type not in ['all', 'aos', 'regs', 'murs']:
-        result_type = 'all'
 
     # Only hit the API if there's an actual query
     if query:

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -17,8 +17,16 @@
       <div class="sidebar-container sidebar-container--left">
         <nav class="sidebar sidebar--neutral side-nav js-sticky" data-sticky-container="main">
           <ul class="sidebar__content">
-            <li class="side-nav__item"><a class="side-nav__link" href="#results-advisory-opinions">Advisory Opinions ({{ results.total_advisory_opinions|default(0) }})</a></li>
-            <li class="is-disabled side-nav__item"><span class="side-nav__link">Regulations ({{ results.total_regulations|default(0) }})</span></li>
+            <li class="side-nav__item">
+              <a class="side-nav__link" href="#results-regulations">
+              Regulations ({{ results.total_regulations|default(0) }})
+              </a>
+            </li>
+            <li class="side-nav__item">
+              <a class="side-nav__link" href="#results-advisory-opinions">
+              Advisory Opinions ({{ results.total_advisory_opinions|default(0) }})
+              </a>
+            </li>
             <li class="is-disabled side-nav__item"><span class="side-nav__link">Matters Under Review (TBD)</span></li>
             <li class="is-disabled side-nav__item"><span class="side-nav__link">(Resource TBD)</span></li>
             <li class="is-disabled side-nav__item"><span class="side-nav__link">(Resource TBD)</span></li>
@@ -60,7 +68,7 @@
             </div>
           {% endif %}
         </div>
-        
+
         <div id="results-advisory-opinions" class="content__section">
           <div class="results-info results-info--top">
             <div class="results-info__left">

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -18,7 +18,7 @@
         <nav class="sidebar sidebar--neutral side-nav js-sticky" data-sticky-container="main">
           <ul class="sidebar__content">
             <li class="side-nav__item"><a class="side-nav__link" href="#results-advisory-opinions">Advisory Opinions ({{ results.total_advisory_opinions|default(0) }})</a></li>
-            <li class="is-disabled side-nav__item"><span class="side-nav__link">Regulations (TBD)</span></li>
+            <li class="is-disabled side-nav__item"><span class="side-nav__link">Regulations ({{ results.total_regulations|default(0) }})</span></li>
             <li class="is-disabled side-nav__item"><span class="side-nav__link">Matters Under Review (TBD)</span></li>
             <li class="is-disabled side-nav__item"><span class="side-nav__link">(Resource TBD)</span></li>
             <li class="is-disabled side-nav__item"><span class="side-nav__link">(Resource TBD)</span></li>
@@ -26,6 +26,41 @@
         </nav>
       </div>
       <section class="main__content">
+        <div id="results-regulations" class="content__section">
+          <div class="results-info results-info--top">
+            <div class="results-info__left">
+              <h2 class="results-info__title">Regulations</h2>
+            </div>
+            {% if results.total_regulations %}
+            <div class="results-info__right">
+              <span class="results-info__details">
+                <a href="/legal/advisory-opinions?search={{ query }}">
+                  View all <strong>{{ results.total_regulations }}</strong> results</a></span>
+            </div>
+            {% endif %}
+          </div>
+          {% if results.total_regulations %}
+            <table class="data-table data-table--text">
+              <thead>
+                <tr>
+                  <th class="cell--15">Part No.</th>
+                  <th class="cell--25">Name</th>
+                  <th class="cell--60">Hit</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for regulation in results.regulations %}
+                  {% include 'partials/legal-search-results-regulation.html' %}
+                {% endfor %}
+              </tbody>
+            </table>
+          {% else %}
+            <div class="message message--alert">
+              <p>Sorry, there were no results.</p>
+            </div>
+          {% endif %}
+        </div>
+        
         <div id="results-advisory-opinions" class="content__section">
           <div class="results-info results-info--top">
             <div class="results-info__left">

--- a/openfecwebapp/templates/macros/legal-search.html
+++ b/openfecwebapp/templates/macros/legal-search.html
@@ -6,9 +6,9 @@
   <div class="combo combo--search {{ size }}">
     <select class="search__select {{select_class}}" name="search_type" aria-label="Select a document type">
       {% for value, name in (('all', 'All sources'),
-                             ('aos', 'AOs'),
+                             ('advisory_opinions', 'AOs'),
                              ('regulations', 'Regulations'),
-                             ('murs', 'MURs')) %}
+                             ('matters_under_review', 'MURs')) %}
       <option value="{{ value }}" {% if result_type == value %}selected{% endif %}>{{ name }}</option>
       {% endfor %}
     </select>

--- a/openfecwebapp/templates/partials/legal-search-results-regulation.html
+++ b/openfecwebapp/templates/partials/legal-search-results-regulation.html
@@ -1,11 +1,11 @@
 <tr class="legal-search-result">
-  <td><a title="{{ advisory_opinion.description }}" href="{{ advisory_opinion.url }}">AO {{ advisory_opinion.no }}</a></td>
-  <td>{{ advisory_opinion.name }}</td>
+  <td><a title="{{ regulation.description }}" href="{{ regulation.url }}">PART {{ regulation.no }}</a></td>
+  <td>{{ regulation.name }}</td>
   <td>
-    <strong>{{ advisory_opinion.summary }}</strong>
+    <strong>{{ regulation.name }}</strong>
     <div class="t-serif legal-search-result__hit">
       &hellip;
-      {% for highlight in advisory_opinion.highlights %}
+      {% for highlight in regulation.highlights %}
         {{ highlight|safe }} &hellip;
       {% endfor %}
     </div>


### PR DESCRIPTION
This PR covers the removal of transformations in this app (they are now handled during ETL + api), as well as added templates to display regulations. Should me merged / deployed simultaneously with 18F/openFEC#1657. 