### PR TITLE
Remove .results-info--top

### DIFF
--- a/openfecwebapp/templates/legal-doc-search-results.html
+++ b/openfecwebapp/templates/legal-doc-search-results.html
@@ -15,7 +15,7 @@ Searching {{ document_type_display_name }} for "{{ query }}"
   <div class="container">
     <section class="main__content--full">
       <div id="results-{{ result_type }}" class="content__section dataTables_wrapper">
-        <div class="results-info results-info--top">
+        <div class="results-info results-info--simple">
           <div class="results-info__left">
             <h2 class="results-info__title">{{ document_type_display_name }}</h2>
           </div>

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -27,7 +27,7 @@
       </div>
       <section class="main__content">
         <div id="results-advisory-opinions" class="content__section">
-          <div class="results-info results-info--top">
+          <div class="results-info results-info--simple">
             <div class="results-info__left">
               <h2 class="results-info__title">Advisory Opinions</h2>
             </div>

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -22,7 +22,7 @@ var exportWidgetTemplate = require('../../templates/tables/exportWidget.hbs');
 var titleTemplate = require('../../templates/tables/title.hbs');
 
 var simpleDOM = 't<"results-info"ip>';
-var browseDOM = '<"js-results-info results-info results-info--top"' +
+var browseDOM = '<"js-results-info results-info results-info--simple"' +
                   '<"results-info__right"ilpr>>' +
                 '<"panel__main"t>' +
                 '<"results-info"ip>';


### PR DESCRIPTION
This subclass is being dropped from fec-style. This should be merged first, before bumping the fec-style version.

Related: https://github.com/18F/fec-style/pull/342