### PR TITLE
Feature/release-fixes

### DIFF
--- a/openfecwebapp/templates/macros/filters/election-filter.html
+++ b/openfecwebapp/templates/macros/filters/election-filter.html
@@ -20,7 +20,7 @@
     >
   <label class="label" for="{{ name }}">{{ title }}</label>
   <ul class="dropdown__selected"></ul>
-  <select name="{{ name }}" class="js-election select--full">
+  <select id="{{name}}" name="{{ name }}" class="js-election select--full">
     {% for year in years %}
       <option value="{{ year }}">{{ year }}</option>
     {% endfor %}

--- a/openfecwebapp/templates/partials/candidates-filter.html
+++ b/openfecwebapp/templates/partials/candidates-filter.html
@@ -15,15 +15,14 @@
   {% include 'partials/filters/districts.html' %}
   <div class="filter">
     <fieldset class="js-filter">
-      <legend class="label">Candidate status</legend>
+      <legend class="label">Candidate fundraising</legend>
       <ul>
         <li>
           <input id="cycle-checkbox-five-thousand" name="five_thousand_flag" type="checkbox" value="true">
-          <label for="cycle-checkbox-five-thousand">Has raised more $5,000</label>
+          <label for="cycle-checkbox-five-thousand">Has raised more than $5,000</label>
         </li>
       </ul>
     </fieldset>
   </div>
-
 </div>
 {% endblock %}

--- a/openfecwebapp/templates/partials/filters.html
+++ b/openfecwebapp/templates/partials/filters.html
@@ -9,7 +9,7 @@
       {% endblock %}
     </h2>
     <form id="category-filters">
-      <div class="filters__inner">
+      <div class="filters__message-container">
         {% block message %}{% endblock %}
       </div>
       {% block filters %}{% endblock %}

--- a/openfecwebapp/templates/partials/individual-contributions-filter.html
+++ b/openfecwebapp/templates/partials/individual-contributions-filter.html
@@ -24,6 +24,22 @@ Filter individual contributions
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Contributor information</button>
   <div class="accordion__content">
+    {{ text.field('contributor_name', 'Contributor name') }}
+    {{ text.field('contributor_city', 'City') }}
+    {{ states.field('contributor_state') }}
+    {{ text.field('contributor_employer', 'Employer') }}
+    {{ text.field('contributor_occupation', 'Occupation') }}
+  </div>
+  <button type="button" class="js-accordion-trigger accordion__button">Transaction information</button>
+  <div class="accordion__content">
+    {{ text.field('min_amount', 'Minimum contribution', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
+    {{ text.field('max_amount', 'Maximum contribution', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
+    {{ date.field('date', 'Receipt date', dates ) }}
+    <div class="message message--info message--small">
+      <span class="t-block">Receipts are reported periodically, according to the filer's reporting schedule. Receipts are updated as they’re processed— that time can vary.</span>
+    </div>
+  </div>
+  <div class="filters__inner">
     <div class="filter">
       <fieldset class="js-filter">
         <legend class="label">Restrict contributions</legend>
@@ -40,20 +56,6 @@ Filter individual contributions
           </li>
         </ul>
       </fieldset>
-    </div>
-    {{ typeahead.field('contributor_name', 'Contributor name or ID', dataset='committees', allow_text=True) }}
-    {{ text.field('contributor_city', 'City') }}
-    {{ states.field('contributor_state') }}
-    {{ text.field('contributor_employer', 'Employer') }}
-    {{ text.field('contributor_occupation', 'Occupation') }}
-  </div>
-  <button type="button" class="js-accordion-trigger accordion__button">Transaction information</button>
-  <div class="accordion__content">
-    {{ text.field('min_amount', 'Minimum contribution', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
-    {{ text.field('max_amount', 'Maximum contribution', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
-    {{ date.field('date', 'Receipt date', dates ) }}
-    <div class="message message--info message--small">
-      <span class="t-block">Receipts are reported periodically, according to the filer's reporting schedule. Receipts are updated as they’re processed— that time can vary.</span>
     </div>
   </div>
 </div>

--- a/openfecwebapp/templates/partials/individual-contributions-filter.html
+++ b/openfecwebapp/templates/partials/individual-contributions-filter.html
@@ -11,7 +11,7 @@ Filter individual contributions
 {% endblock %}
 
 {% block message %}
-<div class="message message--info message--small">
+<div class="message message--info message--small message--inverse-alt">
   <span class="t-block">Due to the large number of transactions, records begin in 2011.</span>
 </div>
 {% endblock %}

--- a/openfecwebapp/templates/search.html
+++ b/openfecwebapp/templates/search.html
@@ -112,7 +112,7 @@
       <div class="grid__item card card--wide">
         <div class="card__image__container">
           <img class="card__image icon--complex" src="{{ url_for('static', filename='img/i-committees--neutral.svg') }}" alt="Icon representing committees">
-          <h2 class="card__title"><span class="term" data-term="Committee">Committee</span> data</h2>
+          <h2 class="card__title">Committee data</h2>
         </div>
         <div class="card__content">
           <h2 class="card__title">Committee data</h2>


### PR DESCRIPTION
I'm starting a running PR of small fixes that will be included in the release.

- Updates the language on the $5k filter based on FEC discussion
- Adds an ID to the election filter on candidate office pages
- Removes glossary tag from a mobile-only heading on the landing page
- Updates the filters on the individual contributions page
  - Fixes the message to use the correct class
  - Replaces contributor name typeahead filter with a regular typeahead filter
  - Moves the "is individual" filter to the bottom, like on the receipts page

Should be merged into `release/public-beta-20160525`, not `develop`. 