### PR TITLE
Updates placeholder

### DIFF
--- a/openfecwebapp/templates/search.html
+++ b/openfecwebapp/templates/search.html
@@ -24,7 +24,7 @@
             <div class="row">
               <label for="zip" class="label">Find by ZIP code</label>
               <div class="search-controls__zip">
-                <input type="text" inputmode="numeric" id="zip" name="zip" placeholder="e.g. 10001">
+                <input type="text" inputmode="numeric" id="zip" name="zip" placeholder="Example: 90210">
               </div>
               <div class="search-controls__submit">
                 <button type="submit" class="button--search--text button--cta">Search</button>


### PR DESCRIPTION
Content only :)
This fixes the ZIP code placeholder text match what exists here: https://github.com/18F/openFEC-web-app/blob/2d9d56aa485a7a06b4a1c04a5e8f289cc2b19371/openfecwebapp/templates/election-lookup.html

Which has been _bugging me_. 

Also eliminates `e.g.,` which I'm trying to avoid as much as possible.

_h/t @ccostino for helping me find this in the code!_