### PR TITLE
Data microcopy

### DIFF
--- a/openfecwebapp/templates/partials/committee-totals-presidential.html
+++ b/openfecwebapp/templates/partials/committee-totals-presidential.html
@@ -2,7 +2,7 @@
 {% import 'macros/tables.html' as tables %}
 
 {% set table_data = [
-     (totals.0.federal_funds,'Federal funds'),
+     (totals.0.federal_funds,'Presidential public funds'),
      (totals.0.individual_itemized_contributions, 'Itemized individual contributions'),
      (totals.0.individual_unitemized_contributions, 'Unitemized individual contributions'),
      (totals.0.individual_contributions, 'Total individual contributions'),

--- a/openfecwebapp/templates/partials/committee-totals-presidential.html
+++ b/openfecwebapp/templates/partials/committee-totals-presidential.html
@@ -21,7 +21,7 @@
      (totals.0.other_receipts, 'Other receipts'),
    ]
 %}
-{{ tables.totals('Total Receipts', totals.0.receipts, table_data,
+{{ tables.totals('Total receipts', totals.0.receipts, table_data,
     committee.report_year, header_description='Money received by the committee' ) }}
 
 {% set table_data = [
@@ -38,7 +38,7 @@
 
    ]
 %}
-{{ tables.totals('Total Disbursements', totals.0.disbursements, table_data,
+{{ tables.totals('Total disbursements', totals.0.disbursements, table_data,
     committee.report_year, header_description='Money spent by the committee' ) }}
 
 {% endwith %}


### PR DESCRIPTION
Content only.

This fixes a capitalization problem and relabels "Federal funds" as "Presidential public funds" in our summary chart.

h/t @amykort for noticing this inconsistency. 

Anyone can review and merge.