### PR TITLE
Updates "spender" filter

### DIFF
--- a/openfecwebapp/templates/partials/communication-costs-filter.html
+++ b/openfecwebapp/templates/partials/communication-costs-filter.html
@@ -14,7 +14,7 @@ Filter communication costs
 
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
   <div class="filters__inner">
-    {{ typeahead.field('committee_id', 'Committee name or ID') }}
+    {{ typeahead.field('committee_id', 'Spender name or ID') }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Candidate mentioned</button>
   <div class="accordion__content">


### PR DESCRIPTION
This is a content only update. Anyone can review.

This updates the communication costs filter so that it says "spender." This will help us unify our content with what's already on the electioneering communications and IE filter pages.

Resolves: https://github.com/18F/openFEC-web-app/issues/1262#issuecomment-225050785

cc @LindsayYoung 