### PR TITLE
Fixes issue with undefined sort parameter

### DIFF
--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -147,7 +147,15 @@ var filingsColumns = columnHelpers.getColumns(
 
 var disbursementPurposeColumns = [
   {data: 'purpose', className: 'all', orderable: false},
-  columnHelpers.buildTotalLink({data: 'total', className: 'all', orderable: false})
+  {
+    data: 'total',
+    className: 'all',
+    orderable: false,
+    orderSequence: ['desc', 'asc'],
+    render: columnHelpers.buildTotalLink(['disbursements'], function(data, type, row, meta) {
+      return {disbursement_purpose_categories: row.purpose.toLowerCase()};
+    })
+  }
 ];
 
 var disbursementRecipientColumns = [


### PR DESCRIPTION
Closes #1271 

This changeset addresses the issue with the undefined sort parameter being added to the API calls when viewing the Disbursements tab on a single Committee page.  Note that we also had to excplicitly set the purpose value to be lower case for this to work.

h/t to @noahmanger for the huge assist in helping track down where this was being constructed and the right values to set.

/cc @LindsayYoung
