### PR TITLE
Rename transaction_year field

### DIFF
--- a/openfecwebapp/templates/macros/filters/date.html
+++ b/openfecwebapp/templates/macros/filters/date.html
@@ -30,15 +30,15 @@
 
 {% macro partition_field(name, label, dates) %}
   {% set current_year = dates['year'][1] | date(fmt='%Y') %}
-  <div class="filter js-filter js-select-filter js-filter-control" data-modifies-filter="{{ name }}" data-modifies-property="data-transaction-year" data-required-default="{{ current_year }}">
+  <div class="filter js-filter js-select-filter js-filter-control" data-modifies-filter="{{ name }}" data-modifies-property="data-two-year-transaction-period" data-required-default="{{ current_year }}">
     <div class="tooltip__container">
-      <label class="label tooltip__trigger-text" for="transaction-year">Transaction period</label>
+      <label class="label tooltip__trigger-text" for="two-year-transaction-period">Transaction period</label>
       <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
       <div id="year-tooltip" role="tooltip" class="tooltip tooltip--under">
         <p class="tooltip__content">The two-year period in which the transaction was made. Due to the large number of itemized transactions, you can only view one period at a time.</p>
       </div>
     </div>
-    <select id="transaction-year" name="transaction_year" aria-describedby="unique-tooltip">
+    <select id="two-year-transaction-period" name="two_year_transaction_period" aria-describedby="unique-tooltip">
       {% for year in range(current_year | int, 1978, -2) %}
         <option value="{{year}}" >{{ year | fmt_year_range }}</option>
       {% endfor %}


### PR DESCRIPTION
Part of https://github.com/18F/openFEC/issues/1735
Dependent on https://github.com/18F/openFEC/pull/1736

This changeset renames the field we originally went with for partitioning the itemized schedule A and B tables. We had received feedback that `transaction_year` was a bit confusing and have decided to go with `two_year_transaction_period` instead to be more descriptive of what this value represents.

/cc @LindsayYoung, @jontours, @noahmanger