### PR TITLE
Adjusting totals table accordions

### DIFF
--- a/openfecwebapp/templates/macros/tables.html
+++ b/openfecwebapp/templates/macros/tables.html
@@ -4,18 +4,18 @@
 {% macro totals(header_name, header_value, data, report_year, header_description='') %}
   <figure class="totals-table totals-table--charts js-chart-series chart-series--horizontal">
       {% if data|length %}
-      <div class="totals-table__header-label">
-        <span class="term" data-term="{{header_name}}">{{ header_name }}</span>
-      </div>
-      <button class="accordion__button js-accordion-trigger">
-        {{ null.null(header_value | currency) }}
+      <button tabindex="0" class="accordion__button accordion__button--spacious js-accordion-trigger">
+        <span class="totals-table__header-label">{{ header_name }}</span>
+        <span class="t-normal">{{ null.null(header_value | currency) }}</span>
       </button>
       <div class="accordion__content">
         {% for item in data %}
           <div class="totals-table__row totals-table__row--nested">
-            <div class="totals-table__cell">{{ item[1] }} </div>
-            <div class="totals-table__cell">{{ null.null(item[0] | currency) }}</div>
-            <div class="totals-table__cell totals-table__cell--bar">
+            <div class="row">
+              <div class="totals-table__cell">{{ item[1] }} </div>
+              <div class="totals-table__cell">{{ null.null(item[0] | currency) }}</div>
+            </div>
+            <div class="totals-table__cell--bar">
               <div class="bar-container">
                 {{ charts.chart_bar(item[0]|default(0),
                                     item[1],

--- a/openfecwebapp/templates/partials/committee/financial-summary.html
+++ b/openfecwebapp/templates/partials/committee/financial-summary.html
@@ -13,7 +13,7 @@
     {% if reports and totals %}
       <div class="content__section">
         <h3 class="results-info results-info--simple results-info__title">Detailed summary {{ reports.0.cycle-1 }}–{{ reports.0.cycle }}</h3>
-        <div class="js-accordion">
+        <div class="js-accordion accordion--neutral">
           {% if committee_type == 'P' %}
             {% include 'partials/committee-totals-presidential.html' %}
           {% elif committee_type == 'H' or committee_type == 'S' %}

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "url": "https://github.com/18F/openfec-web-app/issues"
   },
   "dependencies": {
-    "aria-accordion": "0.1.0",
+    "aria-accordion": "0.1.1",
     "chroma-js": "1.0.1",
     "colorbrewer": "0.0.2",
     "component-sticky": "1.0.0",


### PR DESCRIPTION
Adjusts the totals tables on committee pages to look like this:
![image](https://cloud.githubusercontent.com/assets/1696495/16174634/fecdc18e-357f-11e6-801c-49205f7bd4d0.png)

Depends on https://github.com/18F/accordion/pull/8 and https://github.com/18F/fec-style/pull/400

Resolves https://github.com/18F/fec-style/issues/321