### PR TITLE
Adding methodology content

### DIFF
--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -88,7 +88,7 @@
             <li>Offsets to operating expenditures</li>
             <li>Transfers from nonfederal accounts for allocated activities</li>
           </ul>
-          <p><span>The form-by-form breakdown for adjsuted receipts is:</span></p>
+          <p><span>The form-by-form breakdown for adjusted receipts is:</span></p>
           <ul class="list--bulleted">
             <li><strong>Form 3:</strong> <em>line 16</em> - (<em>line 11(b)</em> + <em>line 11(c)</em> + <em>line 14</em> + <em>line 19(c)</em> + <em>line 20(d))</em></li>
             <li><strong>Form 3P:</strong> <em>line 22</em> - (<em>line 17(b)</em> + <em>line 17(c)</em> + <em>line 20(d)</em> + <em>line 27(c)</em> + <em>line 28(d)</em>)</li>
@@ -136,7 +136,7 @@
           <ul class="list--bulleted">
             <li><strong>Form 3:</strong> <em>line 22</em> - (<em>line 18</em> + <em>line 19(c)</em> + <em>line 20(d)</em> + <em>line 21</em>)</li>
             <li><strong>Form 3P:</strong> <em>line 30</em> - (<em>line 20(d)</em> + <em>line 24</em> + <em>line 27(c)</em> + <em>line 28(d)</em> + <em>line 29</em>)</li>
-            <li><strong>Form 3X l:</strong> <em>line 31</em> - (<em>line 21(a)(ii)</em> + <em>line 22</em> + <em>line 23</em> + <em>line 26</em> + <em>line 28(d)</em> + <em>line 29</em>)_</li>
+            <li><strong>Form 3X:</strong> <em>line 31</em> - (<em>line 21(a)(ii)</em> + <em>line 22</em> + <em>line 23</em> + <em>line 26</em> + <em>line 28(d)</em> + <em>line 29</em>)</li>
           </ul>
         </div>
       </div>

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -71,8 +71,29 @@
         </div>
         {{ overviews.overview(totals['raising'], 'raised', 'landing')}}
         <button class="accordion__button js-accordion-trigger">About this data</button>
-        <div class="accordion__content">
-          Explanation of methodology
+        <div class="accordion__content overview__methodology">
+          <p>This data includes Forms 3, 3P, 3X, 5, 7 and 9 from January 1, 2015 to May 25, 2016.</p>
+          <h5>Methodology overview</h5>
+          <p><strong>Money raised</strong> includes each of the following:</p>
+          <ul class="list--bulleted">
+            <li><em>Adjusted receipts</em> for PACs, parties, congressional filers and presidential filers</li>
+            <li>Total contributions for independent expenditure (Form 5) filers</li>
+            <li>Total donations for electioneering communications (Form 9) filers</li>
+          </ul>
+          <p><em>Adjusted receipts</em> are the total receipts minus the following:</p>
+          <ul class="list--bulleted">
+            <li>Contribution refunds</li>
+            <li>Contributions from political party committees and other political committees</li>
+            <li>Loan repayments</li>
+            <li>Offsets to operating expenditures</li>
+            <li>Transfers from nonfederal accounts for allocated activities</li>
+          </ul>
+          <p><span>The form-by-form breakdown for adjsuted receipts is:</span></p>
+          <ul class="list--bulleted">
+            <li><strong>Form 3:</strong> <em>line 16</em> - (<em>line 11(b)</em> + <em>line 11(c)</em> + <em>line 14</em> + <em>line 19(c)</em> + <em>line 20(d))</em></li>
+            <li><strong>Form 3P:</strong> <em>line 22</em> - (<em>line 17(b)</em> + <em>line 17(c)</em> + <em>line 20(d)</em> + <em>line 27(c)</em> + <em>line 28(d)</em>)</li>
+            <li><strong>Form 3X:</strong> <em>line 19</em> - (<em>line 11(b)</em> + <em>line 11(c)</em> + <em>line 15</em> + <em>line 16</em> + <em>line 18(a)</em> + <em>line 26</em> + <em>line 28(d)</em>)</li>
+          </ul>
         </div>
       </div>
     </section>
@@ -91,8 +112,32 @@
         </div>
         {{ overviews.overview(totals['spending'], 'spent', 'landing')}}
         <button class="accordion__button js-accordion-trigger">About this data</button>
-        <div class="accordion__content">
-          Explanation of methodology
+        <div class="accordion__content overview__methodology">
+          <p>This data includes Forms 3, 3P, 3X, 5, 7 and 9 from January 1, 2015 to May 25, 2016.</p>
+          <h5>Methodology overview</h5>
+          <p><strong>Money spent</strong> includes each of the following:</p>
+          <ul class="list--bulleted">
+            <li><em>Adjusted disbursements</em> for PACs, parties, congressional filers and presidential filers</li>
+            <li>Total independent expenditures for independent expenditure (Form 5) filers</li>
+            <li>Total disbursements and obligations electioneering communication (Form 9) filers</li>
+            <li>Total communications costs for communication cost (Form 7) filers</li>
+          </ul>
+          <p><em>Adjusted disbursements</em> are total disbursements minus the following:</p>
+          <ul class="list--bulleted">
+            <li>Contribution refunds</li>
+            <li>Contributions to candidates and other political committees</li>
+            <li>Loan repayments</li>
+            <li>Nonfederal share of allocated disbursements</li>
+            <li>Offsets to expenditures</li>
+            <li>Other disbursements</li>
+            <li>Transfers to other authorized committees and affiliated committees</li>
+          </ul>
+          <p>The form-by-form breakdown for adjusted disbursements is:</p>
+          <ul class="list--bulleted">
+            <li><strong>Form 3:</strong> <em>line 22</em> - (<em>line 18</em> + <em>line 19(c)</em> + <em>line 20(d)</em> + <em>line 21</em>)</li>
+            <li><strong>Form 3P:</strong> <em>line 30</em> - (<em>line 20(d)</em> + <em>line 24</em> + <em>line 27(c)</em> + <em>line 28(d)</em> + <em>line 29</em>)</li>
+            <li><strong>Form 3X l:</strong> <em>line 31</em> - (<em>line 21(a)(ii)</em> + <em>line 22</em> + <em>line 23</em> + <em>line 26</em> + <em>line 28(d)</em> + <em>line 29</em>)_</li>
+          </ul>
         </div>
       </div>
     </section>

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -70,7 +70,7 @@
           </div>
         </div>
         {{ overviews.overview(totals['raising'], 'raised', 'landing')}}
-        <button class="accordion__button js-accordion-trigger">About this data</button>
+        <button class="accordion__button js-accordion-trigger js-ga-event" data-ga-event="Raised methodology accordion clicked">About this data</button>
         <div class="accordion__content overview__methodology">
           <p>This data includes Forms 3, 3P, 3X, 5, 7 and 9 from January 1, 2015 to May 25, 2016.</p>
           <h5>Methodology overview</h5>
@@ -111,7 +111,7 @@
           </div>
         </div>
         {{ overviews.overview(totals['spending'], 'spent', 'landing')}}
-        <button class="accordion__button js-accordion-trigger">About this data</button>
+        <button class="accordion__button js-accordion-trigger js-ga-event" data-ga-event="Spending methodology accordion clicked">About this data</button>
         <div class="accordion__content overview__methodology">
           <p>This data includes Forms 3, 3P, 3X, 5, 7 and 9 from January 1, 2015 to May 25, 2016.</p>
           <h5>Methodology overview</h5>

--- a/static/js/pages/landing.js
+++ b/static/js/pages/landing.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global require */
+/* global require, ga */
 
 var $ = require('jquery');
 
@@ -133,4 +133,18 @@ $('.js-reaction-box').each(function() {
 $('.js-top-list').each(function() {
   var dataType = $(this).data('type');
   new TopList(this, dataType);
+});
+
+$('.js-ga-event').each(function() {
+  var eventName = $(this).data('ga-event');
+  $(this).on('click', function() {
+    if (helpers.trackerExists()) {
+      var gaEventData = {
+        hitType: 'event',
+        eventCategory: eventName,
+        eventValue: 1
+      };
+      ga('send', gaEventData);
+    }
+  });
 });


### PR DESCRIPTION
Adds the content from https://github.com/18F/openFEC-web-app/issues/1275 to the "About this data" sections.

![image](https://cloud.githubusercontent.com/assets/1696495/16246968/79023e1a-37bc-11e6-843f-838f528cb1fa.png)

A couple design thoughts: There's a lot of content here. I know we never squared away the rules for what goes in these boxes, and have talked about having a separate methodology page. I think that that makes sense to do in the future, but this is fine for now. 

In the interim, we could either keep this as-is or set a max-height on these accordions with an inner scroll. What do you think @jenniferthibault ?
