### PR TITLE
Fix/remove-setheight

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -323,9 +323,6 @@ function DataTable(selector, opts) {
   if (!_.isEmpty(this.filterPanel)) {
     updateOnChange(this.filterSet.$body, this.api);
     urls.updateQuery(this.filterSet.serialize(), this.filterSet.fields);
-    this.$body.on('draw.dt', this, function(e) {
-      e.data.filterPanel.setHeight();
-    });
   }
 
   this.$body.css('width', '100%');


### PR DESCRIPTION
Since https://github.com/18F/fec-style/pull/404 removed the `filterPanel.setHeight()` method, this removes the one instance in the web app where that method was called.

AFAIK, that fix in fec-style, while merged, hasn't been pushed to NPM, so this shouldn't be merged just yet. 
