### PR TITLE
Adding presidential public funds flag filter

### DIFF
--- a/openfecwebapp/templates/partials/candidates-office-filter.html
+++ b/openfecwebapp/templates/partials/candidates-office-filter.html
@@ -26,6 +26,10 @@
   <div class="accordion__content">
     {{ text.field('min_receipts', 'Minimum receipts', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
     {{ text.field('max_receipts', 'Maximum receipts', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
+    <div class="js-filter">
+      <input id="federal-funds-flag" name="federal_funds_flag" type="checkbox" value="true">
+      <label class="dropdown__value" for="federal-funds-flag">Has accepted presidential public funds</label>
+    </div>
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Money spent</button>
   <div class="accordion__content">


### PR DESCRIPTION
Adds the "Has received presidential public funds" filter to the frontend:

![image](https://cloud.githubusercontent.com/assets/1696495/16248112/0432353a-37c2-11e6-9957-fd639901867c.png)

## Dependency
It appears, though, that this flag isn't included in the response. @jontours can you add it?

Resolves https://github.com/18F/openFEC-web-app/issues/1243