### PR TITLE
Updates example text to use real, complete examples

### DIFF
--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -19,7 +19,7 @@
 <section class="slab slab--neutral slab--spacious">
   <div class="container">
     {{ search.search('hero', button_color="button--standard", select_class="select--alt") }}
-    <span class="t-note t-sans search__example">Examples: George Bush; Obama for America; C045378</span>
+    <span class="t-note t-sans search__example">Examples: Obama for America, C00431445; Bush, George W., P00003335</span>
   </div>
 </section>
 


### PR DESCRIPTION
### Summary:

- Updates the example text to use real pairs of a committee and candidate, with their ID numbers.

![screen shot 2016-06-23 at 10 30 14 am](https://cloud.githubusercontent.com/assets/11636908/16307155/4062d326-392e-11e6-9aaf-0ac0edd47cb0.png)


### Review:
@emileighoutlaw 

Resolves https://github.com/18F/openFEC-web-app/issues/1297