### PR TITLE
Fix/accessibility fixes

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -75,7 +75,7 @@ parties_extended = OrderedDict([
     ('COM', 'Communist Party'),
     ('CRV', 'Conservative Party'),
     ('CST', 'Constitutional'),
-    ('D/C', 'Democratic/Conservative'),
+    ('DC', 'Democratic/Conservative'),
     ('DFL', 'Democratic-Farm-Labor'),
     ('FLP', 'Freedom Labor Party'),
     ('GRE', 'Green Party'),

--- a/openfecwebapp/templates/datatable.html
+++ b/openfecwebapp/templates/datatable.html
@@ -21,19 +21,21 @@
       </div>
     </div>
   </div>
-  {% include 'partials/' + slug + '-filter.html' %}
-  <div class="data-container">
-    <div id="{{slug}}" class="data-container__body fade-in">
-      <table id="results" class="data-table">
-        <thead>
-          <tr>
-            {% for column in columns %}
-              <th scope="col">{{ column }}</th>
-            {% endfor %}
-            <th scope="col"></th>
-          </tr>
-        </thead>
-      </table>
+  <div class="data-container__wrapper">
+    {% include 'partials/' + slug + '-filter.html' %}
+    <div class="data-container">
+      <div id="{{slug}}" class="data-container__body fade-in">
+        <table id="results" class="data-table" aria-live="polite">
+          <thead>
+            <tr>
+              {% for column in columns %}
+                <th scope="col">{{ column }}</th>
+              {% endfor %}
+              <th scope="col"></th>
+            </tr>
+          </thead>
+        </table>
+      </div>
     </div>
   </div>
 </section>

--- a/openfecwebapp/templates/macros/overviews.html
+++ b/openfecwebapp/templates/macros/overviews.html
@@ -5,14 +5,14 @@
     <div class="overview__totals js-totals">
       <div class="overview__total">
         <span class="overview__total-title">Total {{ verb }}</span>
-        <span class="overview__total-number"><span class="figure__decimals"></span>{{ data['total'] | currency }}</span>
+        <span class="overview__total-number"><span class="figure__decimals" aria-hidden="true"></span>{{ data['total'] | currency }}</span>
       </div>
       <div class="overview__total">
         <div class="overview__total-title">
           <span class="term" data-term="candidate"><span class="swatch candidates"></span>Candidates</span>
         </div>
         <span class="overview__total-number">
-          <span class="figure__decimals"></span>{{ data['candidates'] | currency }}
+          <span class="figure__decimals" aria-hidden="true"></span>{{ data['candidates'] | currency }}
         </span>
       </div>
       <div class="overview__total">
@@ -20,7 +20,7 @@
           <span class="term" data-term="political action committee (pac)"><span class="swatch pacs"></span>PACs</span>
         </div>
         <span class="overview__total-number">
-          <span class="figure__decimals"></span>{{ data['pacs'] | currency }}
+          <span class="figure__decimals" aria-hidden="true"></span>{{ data['pacs'] | currency }}
         </span>
       </div>
       <div class="overview__total">
@@ -28,7 +28,7 @@
           <span class="term" data-term="party committee"><span class="swatch parties"></span>Party committees</span>
         </div>
         <span class="overview__total-number">
-          <span class="figure__decimals"></span>{{ data['parties'] | currency }}
+          <span class="figure__decimals" aria-hidden="true"></span>{{ data['parties'] | currency }}
         </span>
       </div>
       <div class="overview__total">
@@ -36,7 +36,7 @@
           <span class="swatch other"></span>Other
         </div>
         <span class="overview__total-number">
-          <span class="figure__decimals"></span>{{ data['other'] | currency }}</a>
+          <span class="figure__decimals" aria-hidden="true"></span>{{ data['other'] | currency }}</a>
         </span>
       </div>
     </div>
@@ -62,7 +62,7 @@
         <span class="figure__label">
           <a href="/candidate/{{data['candidate_id']}}" title="{{ data['name'] }}">{{ loop.index }}. {{ data['name'] }}</a>
         </span>
-        <span class="figure__number"><span class="figure__decimals"></span>{{ data['receipts'] | currency }}</span>
+        <span class="figure__number"><span class="figure__decimals" aria-hidden="true"></span>{{ data['receipts'] | currency }}</span>
       </li>
       {% endfor %}
     </ol>
@@ -72,7 +72,7 @@
         <span class="figure__label">
           <a href="/candidate/{{data['candidate_id']}}" title="{{ data['name'] }}">{{ loop.index }}. {{ data['name'] }}</a>
         </span>
-        <span class="figure__number"><span class="figure__decimals"></span>{{ data['disbursements'] | currency }}</span>
+        <span class="figure__number"><span class="figure__decimals" aria-hidden="true"></span>{{ data['disbursements'] | currency }}</span>
       </li>
       {% endfor %}
     </ol>

--- a/openfecwebapp/templates/macros/reaction-box.html
+++ b/openfecwebapp/templates/macros/reaction-box.html
@@ -14,7 +14,7 @@
             <button type="button" class="button--standard button--not-interested js-reaction" data-reaction="not-interested">Not interested</button>
           </li>
           <li>
-            <button type="button" class="button--standard js-reaction" data-reaction="none">None of these</button>
+            <button type="button" class="button--standard js-reaction" data-reaction="none">None of the above</button>
           </li>
         </ul>
       </div>

--- a/openfecwebapp/templates/macros/reaction-box.html
+++ b/openfecwebapp/templates/macros/reaction-box.html
@@ -1,31 +1,27 @@
 {% macro reaction_box(name, location) %}
   <div class="reaction-box js-reaction-box" data-name="{{ name }}" data-location="{{ location }}">
     <form>
-      <fieldset class="js-reaction-step-1">
+      <div class="js-reaction-step-1">
+        <span class="reaction-box__heading">What do you think of this chart?</span>
         <ul>
-          <legend class="reaction-box__heading">What do you think of this chart?</legend>
           <li>
-            <input type="radio" value="informative" name="reaction" id="{{name}}-reaction-informative">
-            <label class="reaction--informative" for="{{name}}-reaction-informative">Informative</label>
+            <button type="button" class="button--standard button--informative js-reaction" data-reaction="informative">Informative</button>
           </li>
           <li>
-            <input type="radio" value="confusing" name="reaction" id="{{name}}-reaction-confusing">
-            <label class="reaction--confusing" for="{{name}}-reaction-confusing">Confusing</label>
+            <button type="button" class="button--standard button--confusing js-reaction" data-reaction="confusing">Confusing</button>
           </li>
           <li>
-            <input type="radio" value="not-interested" name="reaction" id="{{name}}-reaction-not-interested">
-            <label class="reaction--not-interested" for="{{name}}-reaction-not-interested">Not interested</label>
+            <button type="button" class="button--standard button--not-interested js-reaction" data-reaction="not-interested">Not interested</button>
           </li>
           <li>
-            <input type="radio" value="none" name="reaction" id="{{name}}-reaction-none">
-            <label class="reaction--none" for="{{name}}-reaction-none">None of these</label>
+            <button type="button" class="button--standard js-reaction" data-reaction="none">None of these</button>
           </li>
         </ul>
-      </fieldset>
+      </div>
       <div class="js-reaction-step-2 u-fade-in" aria-hidden="true">
-        <span class="reaction-box__heading t-block">What do you think of this chart?</span>
-        <p><label for="reaction-more"></label></p>
-        <textarea id="reaction-more"></textarea>
+        <span class="reaction-box__heading">What do you think of this chart?</span>
+        <p><label for="reaction-more-{{ name }}"></label></p>
+        <textarea id="reaction-more-{{ name }}"></textarea>
         <ul class="list--buttons">
           <li><button type="button" class="button--standard js-skip">Skip</button></li>
           <li><button type="submit" class="button--cta">Submit</button></li>

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "d3": "3.5.5",
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
-    "fec-style": "2.5.2",
+    "fec-style": "2.5.3",
     "glossary-panel": "0.1.2",
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",

--- a/static/js/modules/bar-charts.js
+++ b/static/js/modules/bar-charts.js
@@ -15,15 +15,18 @@ var stripes =
   '</svg>';
 
 
-function GroupedBarChart(selector, data) {
+function GroupedBarChart(selector, data, index) {
   this.element = d3.select(selector);
   this.data = data;
+  this.index = index;
 
   this.margin = {top: 0, right: 20, bottom: 50, left: 40};
   this.height = 320 - this.margin.top - this.margin.bottom;
   this.width = 500 - this.margin.left - this.margin.right;
 
-  $('body').append(stripes);
+  if ($('#stripes').length === 0) {
+    $('body').append(stripes);
+  }
 
   this.chart = this.buildChart();
   this.tooltip = this.appendTooltip();
@@ -106,6 +109,7 @@ GroupedBarChart.prototype.buildChart = function() {
     .enter()
       .append('g')
       .attr('class', function(d) { return 'period ' + d.status; })
+      .attr('aria-labelledby', 'bar-chart-tooltip')
       .attr('transform', function(d) { return 'translate(' + x0(d.period) + ',0)'; })
       .attr('tabindex', '0')
       .on('focus', this.showTooltip.bind(this, x0))
@@ -191,7 +195,7 @@ GroupedBarChart.prototype.appendTooltip = function() {
     .style({'position': 'relative'})
     .append('div')
     .attr('class', 'tooltip tooltip--under tooltip--chart')
-    .attr('id', 'tooltip');
+    .attr('id', 'bar-chart-tooltip-' + this.index);
 };
 
 GroupedBarChart.prototype.populateTooltip = function(d) {

--- a/static/js/modules/bar-charts.js
+++ b/static/js/modules/bar-charts.js
@@ -216,7 +216,7 @@ GroupedBarChart.prototype.populateTooltip = function(d) {
           entityDisplayNames[datum.name] +
         '</span>' +
         '<span class="t-inline-block">' +
-          '<span class="figure__decimals"></span>' +
+          '<span class="figure__decimals" aria-hidden="true"></span>' +
           value +
         '</span>' +
       '</li>';

--- a/static/js/modules/bar-charts.js
+++ b/static/js/modules/bar-charts.js
@@ -109,7 +109,7 @@ GroupedBarChart.prototype.buildChart = function() {
     .enter()
       .append('g')
       .attr('class', function(d) { return 'period ' + d.status; })
-      .attr('aria-labelledby', 'bar-chart-tooltip')
+      .attr('aria-labelledby', 'bar-chart-tooltip-' + this.index)
       .attr('transform', function(d) { return 'translate(' + x0(d.period) + ',0)'; })
       .attr('tabindex', '0')
       .on('focus', this.showTooltip.bind(this, x0))

--- a/static/js/modules/reaction-box.js
+++ b/static/js/modules/reaction-box.js
@@ -8,7 +8,6 @@ var helpers = require('./helpers');
 function ReactionBox(selector) {
   this.$element = $(selector);
   this.$form = this.$element.find('form');
-  this.$fieldset = this.$element.find('fieldset');
   this.$textarea = this.$element.find('textarea');
 
   this.$step1 = this.$element.find('.js-reaction-step-1');
@@ -21,17 +20,15 @@ function ReactionBox(selector) {
 
   this.url = helpers.buildAppUrl(['issue']);
 
-  this.$fieldset.on('change', this.handleChange.bind(this));
+  this.$element.on('click', '.js-reaction', this.submitReaction.bind(this));
   this.$element.on('click', '.js-skip', this.handleSuccess.bind(this));
   this.$element.on('click', '.js-reset', this.handleReset.bind(this));
 
   this.$form.on('submit', this.handleSubmit.bind(this));
 }
 
-ReactionBox.prototype.handleChange = function(e) {
-  var $target = $(e.target);
-  this.reaction = $target.val();
-
+ReactionBox.prototype.submitReaction = function(e) {
+  this.reaction = $(e.target).data('reaction');
   if (helpers.trackerExists()) {
     var gaEventData = {
       hitType: 'event',

--- a/static/js/pages/landing.js
+++ b/static/js/pages/landing.js
@@ -109,9 +109,10 @@ var spendingData = [
   }
 ];
 
-function Overview(selector, data) {
+function Overview(selector, data, index) {
   this.$element = $(selector);
   this.data = data;
+  this.index = index;
 
   this.totals = this.$element.find('.js-total');
   this.reactionBox = this.$element.find('.js-reaction-box');
@@ -119,12 +120,12 @@ function Overview(selector, data) {
   helpers.zeroPad('.js-totals', '.overview__total-number', '.figure__decimals');
 
   if (helpers.isLargeScreen()) {
-    new GroupedBarChart(selector + ' .js-chart', this.data);
+    new GroupedBarChart(selector + ' .js-chart', this.data, this.index);
   }
 }
 
-new Overview('.js-raised-overview', raisingData);
-new Overview('.js-spent-overview', spendingData);
+new Overview('.js-raised-overview', raisingData, 1);
+new Overview('.js-spent-overview', spendingData, 2);
 
 $('.js-reaction-box').each(function() {
   new ReactionBox(this);

--- a/static/js/pages/landing.js
+++ b/static/js/pages/landing.js
@@ -117,7 +117,7 @@ function Overview(selector, data, index) {
   this.totals = this.$element.find('.js-total');
   this.reactionBox = this.$element.find('.js-reaction-box');
 
-  helpers.zeroPad('.js-totals', '.overview__total-number', '.figure__decimals');
+  helpers.zeroPad(selector + ' .js-totals', '.overview__total-number', '.figure__decimals');
 
   if (helpers.isLargeScreen()) {
     new GroupedBarChart(selector + ' .js-chart', this.data, this.index);


### PR DESCRIPTION
- Wraps data tables to ensure correct sizing
- Adds `aria-hidden` to `figure__decimals` so they won't be read by screen readers
- Replaces reaction radio buttons with regular buttons
- Fixes duplicate IDs on the bar chart components
- Removes a slash from a checkbox ID that was throwing an HTML_CodeSniffer error

Goes with https://github.com/18F/fec-style/pull/411

In response to https://github.com/18F/Accessibility_Reviews/issues/15#issuecomment-228167208