### PR TITLE
Updates bulk URL

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -36,7 +36,7 @@ var DOWNLOAD_MESSAGES = {
     'Exports are limited to ' +
     downloadCapFormatted +
     ' records—add filters to narrow results, or export bigger ' +
-    'data sets with <a href="http://www.fec.gov/data/DataCatalog.do?cf=downloadable" target="_blank">FEC bulk data exporter</a>.',
+    'data sets with <a href="http://www.fec.gov/finance/disclosure/ftp_download.shtml" target="_blank">FEC bulk data exporter</a>.',
   downloadCap: 'Each user is limited to ' +
     MAX_DOWNLOADS +
     ' exports at a time. This helps us keep things running smoothly.',


### PR DESCRIPTION
Jeff pointed out that our export button says 

"Exports are limited to 100,000 records—add filters to narrow results, or export bigger data sets with FEC bulk data exporter."

But we link to the data catalog which doesn't have any bulk data export capability. 

This updates the URL to go to this page: http://www.fec.gov/finance/disclosure/ftp_download.shtml

Resolves: https://github.com/18F/FEC/issues/356

