### PR TITLE
Adds advanced content

### DIFF
--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -33,7 +33,7 @@
         <h2>Candidates</h2>
         <div class="option__content">
           <p>Search <span class="term" data-term="candidate">candidate</span> data, including money raised, money spent, cash on hand and debt.</p>
-          <p>Statements of Candidacy (Form 2) contain basic information about individuals running 
+          <p>Statements of Candidacy (Form 2) contain basic information about individuals running
           for federal office, including their names, addresses and authorized campaign committees.</p>
           <div class="grid--2-wide">
           <ul class="grid__item list--spacious t-sans">
@@ -134,11 +134,9 @@
         <h2>Spending</h2>
         <div class="option__content">
           <p>Spending includes all the types of <span class="term" data-term="disbursement">dibsursements</span> candidates and committees make.</p>
-          <p>Search all disbursements to candidates and committees by the recipient, purpose, amount and date.</p>
-          <p>Search <span class="term" data-term="independent expenditure">independent expenditures</span> to find specific spenders, 
-          candidates mentioned and transaction information.</p>
-          <p>Search communication costs and <span class="term" data-term="electioneering communication">electioneering communications</span> 
-          for communications that support or oppose specific candidates. Search by date and amount spent.</p>
+          <p>Search all disbursements from committees by the recipient, purpose, amount and date.</p>
+          <p>Search <span class="term" data-term="independent expenditure">independent expenditures</span> to find specific spenders, candidates mentioned and transaction information.</p>
+          <p>Search communication costs and <span class="term" data-term="electioneering communication">electioneering communications</span> for communications that support or oppose specific candidates. Search by date and amount spent.</p>
           <div class="grid--2-wide">
             <ul class="grid__item list--spacious t-sans">
               <li><a class="t-all-data" href="{{ url_for('disbursements', max_date=today() | date(fmt='%m-%d-%Y')) }}">All disbursements</a>

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -62,12 +62,10 @@
       <div id="committees" class="option">
         <h2>Committees</h2>
         <div class="option__content">
-          <p>The term <span class="term" data-term="political committee">committee</span> encompasses several different political groups that receive and spend money in federal elections. 
+          <p>The term <span class="term" data-term="political committee">committee</span> encompasses several different political groups that receive and spend money in federal elections.
           Search for committees by type, years active, political party, location and treasurer.</p>
           <p>Statements of Organization (Form 1) contain basic information about committees, including type, address and treasurer.</p>
-          <p>Requests for Additional Information (RFAIs) are sent to committees when a Campaign Finance Analyst needs additional 
-          clarification on a committee’s filing or identifies an error, omission or possible prohibited activity. Search RFAIs by 
-          committee or date.</p>
+          <p>Requests for Additional Information (RFAIs) are sent to committees when a Campaign Finance Analyst needs additional clarification on a committee’s filing or identifies an error, omission or possible prohibited activity. Search RFAIs by committee or date.</p>
           <div class="grid--2-wide">
             <ul class="grid__item list--spacious t-sans">
               <li><a class="t-all-data" href="{{ url_for('committees', election_year=default_cycles) }}">All committees</a>
@@ -106,10 +104,8 @@
       <div id="receipts" class="option">
         <h2>Receipts</h2>
         <div class="option__content">
-          <p><span class="term" data-term="receipt">Receipts</span> are anything of value, like money, services or property. Search 
-          candidate and committee receipt data by contributor, amount and date.</p>
-          <p>Search individual contributions to see who is donating to candidates and committees. Search for contributors by name, location, 
-          employer and occupation.</p>
+          <p><span class="term" data-term="receipt">Receipts</span> are anything of value, like money, services or property. Search candidate and committee receipt data by contributor, amount and date.</p>
+          <p>Search individual contributions to see who is donating to candidates and committees. Search for contributors by name, location, employer and occupation.</p>
           <div class="grid--2-wide">
           <ul class="grid__item list--spacious t-sans">
             <li><a class="t-all-data" href="{{ url_for('receipts', is_individual=true, max_date=today() | date(fmt='%m-%d-%Y')) }}">All receipts</a>
@@ -165,8 +161,7 @@
       <div id="filings" class="option">
         <h2>Filings</h2>
         <div class="option__content">
-          <p>Filings contain all the statements, reports and notices that candidates and committees file. Search by date, type and 
-          filing candidate or committee.</p>
+          <p>Filings contain all the statements, reports and notices that candidates and committees file. Search by date, type and filing candidate or committee.</p>
           <div class="grid--2-wide">
             <ul class="grid__item list--spacious t-sans">
               <li><a class="t-all-data" href="{{ url_for('filings') }}">All filings</a></li>

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -32,6 +32,9 @@
       <div id="candidates" class="option">
         <h2>Candidates</h2>
         <div class="option__content">
+          <p>Search <span class="term" data-term="candidate">candidate</span> data, including money raised, money spent, cash on hand and debt.</p>
+          <p>Statements of Candidacy (Form 2) contain basic information about individuals running 
+          for federal office, including their names, addresses and authorized campaign committees.</p>
           <div class="grid--2-wide">
           <ul class="grid__item list--spacious t-sans">
             <li><a class="t-all-data" href="{{ url_for('candidates', election_year=default_cycles, has_raised_funds='true') }}">All candidates</a>
@@ -59,6 +62,12 @@
       <div id="committees" class="option">
         <h2>Committees</h2>
         <div class="option__content">
+          <p>The term <span class="term" data-term="political committee">committee</span> encompasses several different political groups that receive and spend money in federal elections. 
+          Search for committees by type, years active, political party, location and treasurer.</p>
+          <p>Statements of Organization (Form 1) contain basic information about committees, including type, address and treasurer.</p>
+          <p>Requests for Additional Information (RFAIs) are sent to committees when a Campaign Finance Analyst needs additional 
+          clarification on a committee’s filing or identifies an error, omission or possible prohibited activity. Search RFAIs by 
+          committee or date.</p>
           <div class="grid--2-wide">
             <ul class="grid__item list--spacious t-sans">
               <li><a class="t-all-data" href="{{ url_for('committees', election_year=default_cycles) }}">All committees</a>
@@ -97,6 +106,10 @@
       <div id="receipts" class="option">
         <h2>Receipts</h2>
         <div class="option__content">
+          <p><span class="term" data-term="receipt">Receipts</span> are anything of value, like money, services or property. Search 
+          candidate and committee receipt data by contributor, amount and date.</p>
+          <p>Search individual contributions to see who is donating to candidates and committees. Search for contributors by name, location, 
+          employer and occupation.</p>
           <div class="grid--2-wide">
           <ul class="grid__item list--spacious t-sans">
             <li><a class="t-all-data" href="{{ url_for('receipts', is_individual=true, max_date=today() | date(fmt='%m-%d-%Y')) }}">All receipts</a>
@@ -120,6 +133,12 @@
       <div id="spending" class="option">
         <h2>Spending</h2>
         <div class="option__content">
+          <p>Spending includes all the types of <span class="term" data-term="disbursement">dibsursements</span> candidates and committees make.</p>
+          <p>Search all disbursements to candidates and committees by the recipient, purpose, amount and date.</p>
+          <p>Search <span class="term" data-term="independent expenditure">independent expenditures</span> to find specific spenders, 
+          candidates mentioned and transaction information.</p>
+          <p>Search communication costs and <span class="term" data-term="electioneering communication">electioneering communications</span> 
+          for communications that support or oppose specific candidates. Search by date and amount spent.</p>
           <div class="grid--2-wide">
             <ul class="grid__item list--spacious t-sans">
               <li><a class="t-all-data" href="{{ url_for('disbursements', max_date=today() | date(fmt='%m-%d-%Y')) }}">All disbursements</a>
@@ -146,8 +165,10 @@
         </div>
       </div>
       <div id="filings" class="option">
-        <h2>Reports and filings</h2>
+        <h2>Filings</h2>
         <div class="option__content">
+          <p>Filings contain all the statements, reports and notices that candidates and committees file. Search by date, type and 
+          filing candidate or committee.</p>
           <div class="grid--2-wide">
             <ul class="grid__item list--spacious t-sans">
               <li><a class="t-all-data" href="{{ url_for('filings') }}">All filings</a></li>


### PR DESCRIPTION
I took a stab at adding the advanced data content. There were lots of `<div>`s on this page, so please let me know if I put these paragraphs in the wrong section. 

This PR:
- Adds content to "Candidates," "Committees," "Receipts," "Spending," and "Filings"
- Links terms in the new content to the glossary
- Makes "Filings and Reports" header "Filings," which is our preferred blanket term for all types of filings (this is also explained in the section's new subtext).


cc @noahmanger @jenniferthibault 