### PR TITLE
[MERGE WITH GITFLOW] Emptying tooltip on hide

### DIFF
--- a/static/js/modules/bar-charts.js
+++ b/static/js/modules/bar-charts.js
@@ -269,7 +269,9 @@ GroupedBarChart.prototype.showTooltip = function(x0, d) {
 };
 
 GroupedBarChart.prototype.hideTooltip = function() {
-  this.tooltip.style({'display': 'none'});
+  this.tooltip
+    .style({'display': 'none'})
+    .html('');
 };
 
 module.exports = {

--- a/static/js/modules/bar-charts.js
+++ b/static/js/modules/bar-charts.js
@@ -271,7 +271,7 @@ GroupedBarChart.prototype.showTooltip = function(x0, d) {
 GroupedBarChart.prototype.hideTooltip = function() {
   this.tooltip
     .style({'display': 'none'})
-    .html('');
+    .html(null);
 };
 
 module.exports = {


### PR DESCRIPTION
Fixes a bug on /data where hovering over the "Spending" chart and then hovering over the "Raising" chart would cause the page to crash. 