### PR TITLE
Fix/transaction period urls

### DIFF
--- a/openfecwebapp/templates/macros/filters/date.html
+++ b/openfecwebapp/templates/macros/filters/date.html
@@ -31,14 +31,14 @@
 {% macro partition_field(name, label, dates) %}
   {% set current_year = dates['year'][1] | date(fmt='%Y') %}
   <div class="filter js-filter js-select-filter js-filter-control" data-modifies-filter="{{ name }}" data-modifies-property="data-transaction-year" data-required-default="{{ current_year }}">
+    <label class="label t-inline-block" for="two-year-transaction-period">Transaction period</label>
     <div class="tooltip__container">
-      <label class="label tooltip__trigger-text" for="transaction-year">Transaction period</label>
       <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
       <div id="year-tooltip" role="tooltip" class="tooltip tooltip--under">
         <p class="tooltip__content">The two-year period in which the transaction was made. Due to the large number of itemized transactions, you can only view one period at a time.</p>
       </div>
     </div>
-    <select id="transaction-year" name="transaction_year" aria-describedby="unique-tooltip">
+    <select id="two-year-transaction-period" name="two_year_transaction_period" aria-describedby="unique-tooltip">
       {% for year in range(current_year | int, 1978, -2) %}
         <option value="{{year}}" >{{ year | fmt_year_range }}</option>
       {% endfor %}

--- a/openfecwebapp/templates/macros/filters/date.html
+++ b/openfecwebapp/templates/macros/filters/date.html
@@ -34,7 +34,7 @@
     <label class="label t-inline-block" for="two-year-transaction-period">Transaction period</label>
     <div class="tooltip__container">
       <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
-      <div id="year-tooltip" role="tooltip" class="tooltip tooltip--under">
+      <div id="year-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
         <p class="tooltip__content">The two-year period in which the transaction was made. Due to the large number of itemized transactions, you can only view one period at a time.</p>
       </div>
     </div>

--- a/openfecwebapp/templates/partials/committee/disbursements-tab.html
+++ b/openfecwebapp/templates/partials/committee/disbursements-tab.html
@@ -10,6 +10,7 @@
           href="{{ url_for(
             'disbursements',
             committee_id=committee_id,
+            two_year_transaction_period=cycle,
             min_date=cycle_start(cycle) | date(fmt='%m-%d-%Y'),
             max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y'),
           ) }}">All disbursements data

--- a/openfecwebapp/templates/partials/committee/receipts-tab.html
+++ b/openfecwebapp/templates/partials/committee/receipts-tab.html
@@ -12,6 +12,7 @@
           href="{{ url_for(
             'receipts',
             committee_id=committee_id,
+            two_year_transaction_period=cycle,
             min_date=cycle_start(cycle) | date(fmt='%m-%d-%Y'),
             max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y'),
             is_individual='true'

--- a/openfecwebapp/templates/partials/committee/receipts-tab.html
+++ b/openfecwebapp/templates/partials/committee/receipts-tab.html
@@ -15,7 +15,7 @@
             two_year_transaction_period=cycle,
             min_date=cycle_start(cycle) | date(fmt='%m-%d-%Y'),
             max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y')
-          ) }}">All individual contributions</a>
+          ) }}">All individual contributions data</a>
     </div>
     <div class="content__section">
       <div class="row filters--horizontal">

--- a/openfecwebapp/templates/partials/committee/receipts-tab.html
+++ b/openfecwebapp/templates/partials/committee/receipts-tab.html
@@ -10,13 +10,12 @@
       </h2>
       <a class="heading__action button--alt button--browse"
           href="{{ url_for(
-            'receipts',
+            'individual_contributions',
             committee_id=committee_id,
             two_year_transaction_period=cycle,
             min_date=cycle_start(cycle) | date(fmt='%m-%d-%Y'),
-            max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y'),
-            is_individual='true'
-          ) }}">All receipts data</a>
+            max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y')
+          ) }}">All individual contributions</a>
     </div>
     <div class="content__section">
       <div class="row filters--horizontal">

--- a/openfecwebapp/templates/partials/filters/unique-receipts.html
+++ b/openfecwebapp/templates/partials/filters/unique-receipts.html
@@ -4,7 +4,7 @@
     <ul>
       <li>
         <input id="is-individual" name="is_individual" type="checkbox" value="true" class="tooltip-trigger" aria-describedby="unique-tooltip" checked>
-        <label for="is-individual" class="tooltip__trigger-text">Unique only</label>
+        <label for="is-individual" class="t-inline-block">Unique only</label>
         <div class="tooltip__container">
           <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
           <div id="unique-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">

--- a/static/js/modules/column-helpers.js
+++ b/static/js/modules/column-helpers.js
@@ -14,7 +14,7 @@ var sizeInfo = {
 
 function getSizeParams(size) {
   var limits = sizeInfo[size].limits;
-  var params = {is_individual: 'true'};
+  var params = {};
   if (limits[0] !== null) {
     params.min_amount = helpers.currency(limits[0]);
   }

--- a/static/js/modules/column-helpers.js
+++ b/static/js/modules/column-helpers.js
@@ -92,6 +92,7 @@ function buildEntityLink(data, url, category, opts) {
 function buildAggregateUrl(cycle) {
   var dates = helpers.cycleDates(cycle);
   return {
+    two_year_transaction_period: cycle,
     min_date: dates.min,
     max_date: dates.max
   };

--- a/static/js/modules/column-helpers.js
+++ b/static/js/modules/column-helpers.js
@@ -89,13 +89,18 @@ function buildEntityLink(data, url, category, opts) {
   return anchor.outerHTML;
 }
 
-function buildAggregateUrl(cycle) {
+function buildAggregateUrl(cycle, includeTransactionPeriod) {
   var dates = helpers.cycleDates(cycle);
-  return {
-    two_year_transaction_period: cycle,
-    min_date: dates.min,
-    max_date: dates.max
-  };
+  if (includeTransactionPeriod) {
+    return {
+      two_year_transaction_period: cycle
+    };
+  } else {
+    return {
+      min_date: dates.min,
+      max_date: dates.max
+    };
+  }
 }
 
 function buildTotalLink(path, getParams) {
@@ -103,15 +108,19 @@ function buildTotalLink(path, getParams) {
     data = data || 0;
     var params = getParams(data, type, row, meta);
     var span = document.createElement('div');
+    var includeTransactionPeriod = false;
     span.setAttribute('data-value', data);
     span.setAttribute('data-row', meta.row);
     if (params) {
       var link = document.createElement('a');
       link.textContent = helpers.currency(data);
       link.setAttribute('title', 'View individual transactions');
+      if (path.indexOf('receipts') > -1 || path.indexOf('disbursements') > -1) {
+        includeTransactionPeriod = true;
+      }
       var uri = helpers.buildAppUrl(path, _.extend(
         {committee_id: row.committee_id},
-        buildAggregateUrl(_.extend({}, row, params).cycle),
+        buildAggregateUrl(_.extend({}, row, params).cycle, includeTransactionPeriod),
         params
       ));
       link.setAttribute('href', uri);

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -36,7 +36,7 @@ var sizeColumns = [
     width: '50%',
     className: 'all',
     orderSequence: ['desc', 'asc'],
-    render: columnHelpers.buildTotalLink(['receipts'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['receipts', 'individual-contributions'], function(data, type, row, meta) {
       return columnHelpers.getSizeParams(row.size);
     })
   }
@@ -87,10 +87,9 @@ var stateColumns = [
     width: '50%',
     className: 'all',
     orderSequence: ['desc', 'asc'],
-    render: columnHelpers.buildTotalLink(['receipts'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['receipts', 'individual-contributions'], function(data, type, row, meta) {
       return {
         contributor_state: row.state,
-        is_individual: 'true'
       };
     })
   },
@@ -103,11 +102,10 @@ var employerColumns = [
     className: 'all',
     orderable: false,
     orderSequence: ['desc', 'asc'],
-    render: columnHelpers.buildTotalLink(['receipts'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['receipts', 'individual-contributions'], function(data, type, row, meta) {
       if (row.employer) {
         return {
           contributor_employer: row.employer,
-          is_individual: 'true'
         };
       } else {
         return null;
@@ -123,11 +121,10 @@ var occupationColumns = [
     className: 'all',
     orderable: false,
     orderSequence: ['desc', 'asc'],
-    render: columnHelpers.buildTotalLink(['receipts'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['receipts', 'individual-contributions'], function(data, type, row, meta) {
       if (row.occupation) {
         return {
           contributor_occupation: row.occupation,
-          is_individual: 'true'
         };
       } else {
         return null;

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -389,6 +389,7 @@ $(document).ready(function() {
     case 'filing':
       path = ['committee', committeeId, 'filings'];
       tables.DataTable.defer($table, {
+        autoWidth: false,
         path: path,
         query: query,
         columns: filingsColumns,

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -117,7 +117,7 @@ function makeCommitteeColumn(opts, factory) {
   return _.extend({}, {
     orderSequence: ['desc', 'asc'],
     className: 'column--number',
-    render: columnHelpers.buildTotalLink(['receipts'], function(data, type, row, meta) {
+    render: columnHelpers.buildTotalLink(['receipts', 'individual-contributions'], function(data, type, row, meta) {
       row.cycle = context.election.cycle;
       var column = meta.settings.aoColumns[meta.col].data;
       return _.extend({

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -121,7 +121,8 @@ function makeCommitteeColumn(opts, factory) {
       row.cycle = context.election.cycle;
       var column = meta.settings.aoColumns[meta.col].data;
       return _.extend({
-        committee_id: (context.candidates[row.candidate_id] || {}).committee_ids
+        committee_id: (context.candidates[row.candidate_id] || {}).committee_ids,
+        two_year_transaction_period: row.cycle,
       }, factory(data, type, row, meta, column));
     })
   }, opts);


### PR DESCRIPTION
This does the following: 
- Adds `two_year_transaction_period` to all aggregate links of individual contributions on committee and election pages
- Instead of the aggregate links going to /receipts/ they now go to /receipts/individual-contributions/ 
- Fixes an issue where the transaction period filter `name` attribute was reverted back to the old name
- Fixes an issue with tooltip placement caused by some style adjustments 

Resolves https://github.com/18F/openFEC-web-app/issues/1334