### PR TITLE
Using the correct numbers and labels for size buckets

### DIFF
--- a/openfecwebapp/templates/partials/elections/candidate-comparison-tab.html
+++ b/openfecwebapp/templates/partials/elections/candidate-comparison-tab.html
@@ -62,7 +62,7 @@
               <th scope="col">$200.01—$499.99</th>
               <th scope="col">$500—$999.99</th>
               <th scope="col">$1,000—$1,999.99</th>
-              <th scope="col">$2,000+</th>
+              <th scope="col">$2,000 and over</th>
             </thead>
           </table>
         </div>

--- a/static/js/modules/column-helpers.js
+++ b/static/js/modules/column-helpers.js
@@ -5,11 +5,11 @@ var _ = require('underscore');
 var helpers = require('./helpers');
 
 var sizeInfo = {
-  0: {limits: [0, 199.99], label: 'Under $200'},
-  200: {limits: [200, 499.99], label: '$200—$499'},
+  0: {limits: [0, 200], label: '$200 and under'},
+  200: {limits: [200.01, 499.99], label: '$200.01—$499'},
   500: {limits: [500, 999.99], label: '$500—$999'},
-  1000: {limits: [1000, 1999.99], label: '$1000—$1999'},
-  2000: {limits: [2000, null], label: 'Over $2000'},
+  1000: {limits: [1000, 1999.99], label: '$1,000—$1,999'},
+  2000: {limits: [2000, null], label: '$2,000 and over'},
 };
 
 function getSizeParams(size) {

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -27,6 +27,7 @@ var sizeColumns = [
     data: 'size',
     width: '50%',
     className: 'all',
+    orderable: false,
     render: function(data, type, row, meta) {
       return columnHelpers.sizeInfo[data].label;
     }
@@ -35,7 +36,7 @@ var sizeColumns = [
     data: 'total',
     width: '50%',
     className: 'all',
-    orderSequence: ['desc', 'asc'],
+    orderable: false,
     render: columnHelpers.buildTotalLink(['receipts'], function(data, type, row, meta) {
       return columnHelpers.getSizeParams(row.size);
     })
@@ -317,7 +318,7 @@ $(document).ready(function() {
         columns: sizeColumns,
         callbacks: aggregateCallbacks,
         dom: 't',
-        order: [[1, 'desc']],
+        order: false,
         pagingType: 'simple',
         lengthChange: false,
         pageLength: 10,


### PR DESCRIPTION
As reported in https://github.com/18F/openFEC-web-app/issues/1268, we used different language and logic for the contribution size buckets on committee pages vs election pages. This makes them consistent.

On committee pages:
![image](https://cloud.githubusercontent.com/assets/1696495/16601740/9e9ff646-42c3-11e6-9538-2097289e1905.png)

On election pages:
![image](https://cloud.githubusercontent.com/assets/1696495/16601754/be342c20-42c3-11e6-937d-a6b7e98b6460.png)

Resolves https://github.com/18F/openFEC-web-app/issues/1268

CC @LindsayYoung 
