### PR TITLE
Fixing google analytics custom events

### DIFF
--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -204,12 +204,6 @@ function zeroPad(container, item, appendee) {
   });
 }
 
-function trackerExists() {
-  if (typeof ga !== 'undefined') {
-    return true;
-  }
-}
-
 module.exports = {
   buildAppUrl: buildAppUrl,
   buildUrl: buildUrl,
@@ -223,6 +217,5 @@ module.exports = {
   globals: globals,
   isLargeScreen: isLargeScreen,
   isMediumScreen: isMediumScreen,
-  trackerExists: trackerExists,
   zeroPad: zeroPad
 };

--- a/static/js/modules/reaction-box.js
+++ b/static/js/modules/reaction-box.js
@@ -31,12 +31,12 @@ ReactionBox.prototype.submitReaction = function(e) {
   this.reaction = $(e.target).data('reaction');
   if (helpers.trackerExists()) {
     var gaEventData = {
-      hitType: 'event',
       eventCategory: 'Reactions',
       eventAction: this.location + '-' + this.name + ': ' + this.reaction,
       eventValue: 1
     };
-    ga('send', gaEventData);
+    var trackerName = ga.getAll()[0].get('name');
+    ga(trackerName + '.send', 'event', gaEventData);
   }
 
   this.showTextarea();

--- a/static/js/modules/reaction-box.js
+++ b/static/js/modules/reaction-box.js
@@ -4,6 +4,7 @@
 
 var $ = require('jquery');
 var helpers = require('./helpers');
+var analytics = require('fec-style/js/analytics');
 
 function ReactionBox(selector) {
   this.$element = $(selector);
@@ -29,14 +30,13 @@ function ReactionBox(selector) {
 
 ReactionBox.prototype.submitReaction = function(e) {
   this.reaction = $(e.target).data('reaction');
-  if (helpers.trackerExists()) {
+  if (analytics.trackerExists()) {
     var gaEventData = {
       eventCategory: 'Reactions',
       eventAction: this.location + '-' + this.name + ': ' + this.reaction,
       eventValue: 1
     };
-    var trackerName = ga.getAll()[0].get('name');
-    ga(trackerName + '.send', 'event', gaEventData);
+    ga('notDAP.send', 'event', gaEventData);
   }
 
   this.showTextarea();

--- a/static/js/pages/landing.js
+++ b/static/js/pages/landing.js
@@ -8,6 +8,7 @@ var GroupedBarChart = require('../modules/bar-charts').GroupedBarChart;
 var TopList = require('../modules/top-list').TopList;
 var ReactionBox = require('../modules/reaction-box').ReactionBox;
 var helpers = require('../modules/helpers');
+var analytics = require('fec-style/js/analytics');
 
 var raisingData = [
   {
@@ -139,14 +140,13 @@ $('.js-top-list').each(function() {
 $('.js-ga-event').each(function() {
   var eventName = $(this).data('ga-event');
   $(this).on('click', function() {
-    if (helpers.trackerExists()) {
+    if (analytics.trackerExists()) {
       var gaEventData = {
         eventCategory: 'Misc. events',
         eventAction: eventName,
         eventValue: 1
       };
-      var trackerName = ga.getAll()[0].get('name');
-      ga(trackerName + '.send', 'event', gaEventData);
+      ga('nonDAP.send', 'event', gaEventData);
     }
   });
 });

--- a/static/js/pages/landing.js
+++ b/static/js/pages/landing.js
@@ -141,11 +141,12 @@ $('.js-ga-event').each(function() {
   $(this).on('click', function() {
     if (helpers.trackerExists()) {
       var gaEventData = {
-        hitType: 'event',
-        eventCategory: eventName,
+        eventCategory: 'Misc. events',
+        eventAction: eventName,
         eventValue: 1
       };
-      ga('send', gaEventData);
+      var trackerName = ga.getAll()[0].get('name');
+      ga(trackerName + '.send', 'event', gaEventData);
     }
   });
 });


### PR DESCRIPTION
This fixes a bug where custom events (fired by the chart reaction box and the "about this data" accordions) weren't getting sent to Google Analytics. With the Google Analytics Debugger Chrome extension, clicking one of those sent this error `Command ignored. Unknown target: undefined`. 

No idea why this started popping up. It was working before, but this seems to fix it.

This made use of the technique outlined [here](http://stackoverflow.com/questions/28765806/existing-google-analytics-events-and-google-tag-manager/29434548#29434548).
