### PR TITLE
Makes "query" "search"

### DIFF
--- a/openfecwebapp/templates/legal-doc-search-results.html
+++ b/openfecwebapp/templates/legal-doc-search-results.html
@@ -67,7 +67,7 @@
     {% else %}
     <div class="message message--alert">
       <h2 class="message__title">No results</h2>
-      <p>Sorry, we didn&rsquo;t find any documents matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your query{% endif %}.</p>
+      <p>Sorry, we didn&rsquo;t find any documents matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your search{% endif %}.</p>
       <div class="message--alert__bottom">
         <p>Think this was a mistake?</p>
         <ul class="list--buttons">

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -71,7 +71,7 @@
           {% else %}
             <div class="message message--alert">
               <h2 class="message__title">No results</h2>
-              <p>Sorry, we didn&rsquo;t find any regulations matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your query{% endif %}.</p>
+              <p>Sorry, we didn&rsquo;t find any regulations matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your search{% endif %}.</p>
               <div class="message--alert__bottom">
                 <p>Think this was a mistake?</p>
                 <ul class="list--buttons">


### PR DESCRIPTION
All our other notifications on use the term "search" instead of "query." So this is just a small copyedit for consistency!

cc @adborden (or anyone else really; this is a super fast, content-only PR)