### PR TITLE
Bump fec-style version to 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "d3": "3.5.5",
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
-    "fec-style": "2.6",
+    "fec-style": "2.6.1",
     "glossary-panel": "0.1.2",
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",


### PR DESCRIPTION
This changeset accounts for the latest `fec-style` release (2.6.1).