### PR TITLE
Feature/filter accessibility

### DIFF
--- a/openfecwebapp/templates/partials/filters.html
+++ b/openfecwebapp/templates/partials/filters.html
@@ -8,11 +8,11 @@
       Filter {{ result_type }}
       {% endblock %}
     </h2>
-    <form id="category-filters">
+    <div id="category-filters">
       <div class="filters__message-container">
         {% block message %}{% endblock %}
       </div>
       {% block filters %}{% endblock %}
-    </form>
+    </div>
   </div>
 </div>

--- a/static/js/modules/bar-charts.js
+++ b/static/js/modules/bar-charts.js
@@ -253,7 +253,7 @@ GroupedBarChart.prototype.populateTooltip = function(d) {
 
 GroupedBarChart.prototype.showTooltip = function(x0, d) {
   var top = this.height + this.margin.top + this.margin.bottom;
-  var left = x0(d.period);
+  var left = x0(d.period) - 100;
   var content = this.populateTooltip(d);
 
   this.tooltip


### PR DESCRIPTION
Replaces `form` with `div`, per https://github.com/18F/Accessibility_Reviews/issues/15#issuecomment-228167208

Also fixes an issue where the tooltip on bar charts is misaligned.

Requires https://github.com/18F/fec-style/pull/424