### PR TITLE
Fix fundraising comparison on election page

### DIFF
--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -484,7 +484,7 @@ $(document).ready(function() {
     .value();
   var url = helpers.buildUrl(
     ['elections'],
-    _.extend(query, {per_page: 0})
+    _.extend(query, {per_page: 0, sort_hide_null: true})
   );
   $.getJSON(url).done(function(response) {
     $table.dataTable(_.extend({}, defaultOpts, {


### PR DESCRIPTION
Depends on https://github.com/18F/openFEC/pull/1825
Fixes #1355 

This changeset adds a missing flag to the query that is used for pulling the candidates for the fundraising comparison section.  It was missing the `sort_null_hide` parameter.

/cc @noahmanger, @jenniferthibault