### PR TITLE
Adds following acronym

### DIFF
--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -76,7 +76,7 @@
                   <li><a href="#" class="is-disabled">Leadership PACs</a></li>
                   <li><a href="#" class="is-disabled">Joint fundraising committees</a></li>
                   <li><a href="#" class="is-disabled">Party committees</a></li>
-                  <li><a href="#" class="is-disabled">Separate segregated funds</a></li>
+                  <li><a href="#" class="is-disabled">Separate segregated funds (SSFs)</a></li>
                 </ul>
               </li>
             </ul>


### PR DESCRIPTION
Adds following acronym per our style guide. 
A super tiny edit that I wanted to get in before I forgot about it. 

Content only.