### PR TITLE
Removing loading state / setting success state

### DIFF
--- a/openfecwebapp/templates/macros/filters/text.html
+++ b/openfecwebapp/templates/macros/filters/text.html
@@ -1,13 +1,15 @@
 {% macro field(name, title, attrs={}) %}
 <div class="filter js-filter" id="{{ name }}-field">
   <label class="label" for="{{ name }}">{{ title }}</label>
-  <div class="input--removable">
-    <input id="{{ name }}" type="text" name="{{ name }}"
+  <div class="input--removable combo combo--filter--mini">
+    <input id="{{ name }}" type="text" name="{{ name }}" class="combo__input"
       {% for attr, value in attrs.items() %}
         {{ attr }}="{{ value }}"
       {% endfor %}
     />
-    <button type="button" class="button--remove button" data-removes="{{ name }}"><span class="u-visually-hidden">Remove</span></button>
+    <button class="combo__button button--go button--standard is-disabled" type="button">
+      <span class="u-visually-hidden">Search</span>
+    </button>
   </div>
 </div>
 {% endmacro %}

--- a/openfecwebapp/templates/macros/filters/typeahead-filter.html
+++ b/openfecwebapp/templates/macros/filters/typeahead-filter.html
@@ -1,7 +1,7 @@
 {% macro field(name, title, instructions=False, dataset='committees', allow_text=False) %}
 <div class="filter js-filter js-typeahead-filter" id="{{ name }}-field" data-name="{{ name }}" data-dataset="{{ dataset }}" {% if allow_text %}data-allow-text{% endif %}>
   <label class="label" for="{{ name }}">{{ title }}</label>
-  <div class="combo combo--search--mini">
+  <div class="combo combo--search--mini filter__typeahead">
     <ul class="dropdown__selected"></ul>
     <input id="{{ name }}" type="text" class="combo__input">
     <button class="combo__button button--search button--standard" type="button">

--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -225,5 +225,7 @@ module.exports = {
   globals: globals,
   isLargeScreen: isLargeScreen,
   isMediumScreen: isMediumScreen,
+  LOADING_DELAY: helpers.LOADING_DELAY,
+  SUCCESS_DELAY: helpers.SUCCESS_DELAY,
   zeroPad: zeroPad
 };

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -528,22 +528,32 @@ DataTable.prototype.fetchSuccess = function(resp) {
     }
 
     if (type === 'text') {
-      $label = $('.button--loading');
+      // typeahead
+      if ($(updateChangedEl).hasClass('tt-input')) {
+        $label = $(updateChangedEl);
 
-      if ($(updateChangedEl).val()) {
-        filterAction = '"' + $(updateChangedEl).val() + '" applied.';
+        filterAction = 'Filter applied.';
       }
+      // text input search
       else {
-        filterAction = 'Search term removed.';
+        $label = $('.button--loading');
+
+        if ($(updateChangedEl).val()) {
+          filterAction = '"' + $(updateChangedEl).val() + '" applied.';
+        }
+        else {
+          filterAction = 'Search term removed.';
+        }
+
+        $label.removeClass('button--loading').addClass('button--check');
+
+        setTimeout(function () {
+          $label.removeClass('button--check');
+        }, helpers.SUCCESS_DELAY);
       }
-
-      $label.removeClass('button--loading').addClass('button--check');
-
-      setTimeout(function () {
-        $label.removeClass('button--check');
-      }, helpers.SUCCESS_DELAY);
     }
 
+    // build message with number of results returned
     if (changeCount > 0) {
       message = filterAction + '<br>' +
       '<strong>Added  ' + changeCount.toLocaleString() + '</strong> results.';
@@ -555,7 +565,8 @@ DataTable.prototype.fetchSuccess = function(resp) {
 
     if ($filterMessage.length) {
       $filterMessage.fadeOut().remove();
-
+      // if there is a message already, cancel existing message timeout
+      // to avoid timing weirdness
       clearTimeout(messageTimer);
     }
 

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -507,11 +507,11 @@ DataTable.prototype.fetchError = function() {
   setTimeout(function() {
     $('.is-loading').removeClass('is-loading').addClass('is-unsuccessful');
     self.$processing.hide();
-  }, 500);
+  }, helpers.LOADING_DELAY);
 
   setTimeout(function() {
     $('.is-error').removeClass('is-unsuccessful');
-  }, 2000);
+  }, helpers.SUCCESS_DELAY);
 };
 
 /**

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -455,9 +455,6 @@ DataTable.prototype.fetch = function(data, callback) {
   self.xhr = $.getJSON(url);
   self.xhr.done(self.fetchSuccess.bind(self));
   self.xhr.fail(self.fetchError.bind(self));
-  self.xhr.always(function() {
-    self.$processing.hide();
-  });
 };
 
 DataTable.prototype.export = function() {
@@ -483,6 +480,7 @@ DataTable.prototype.buildUrl = function(data, paginate) {
 };
 
 DataTable.prototype.fetchSuccess = function(resp) {
+  var self = this;
   this.paginator.handleResponse(this.fetchContext.data, resp);
   this.fetchContext.callback(mapResponse(resp));
   this.callbacks.afterRender(this.api, this.fetchContext.data, resp);
@@ -492,10 +490,28 @@ DataTable.prototype.fetchSuccess = function(resp) {
   if (this.opts.hideEmpty) {
     this.hideEmpty(resp);
   }
+
+  setTimeout(function() {
+    $('.is-loading').removeClass('is-loading').addClass('is-successful');
+    self.$processing.hide();
+  }, 1000);
+
+  setTimeout(function() {
+    $('.is-successful').removeClass('is-successful');
+  }, 5000);
 };
 
 DataTable.prototype.fetchError = function() {
+  var self = this;
 
+  setTimeout(function() {
+    $('.is-loading').removeClass('is-loading').addClass('is-unsuccessful');
+    self.$processing.hide();
+  }, 500);
+
+  setTimeout(function() {
+    $('.is-error').removeClass('is-unsuccessful');
+  }, 2000);
 };
 
 /**

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -250,6 +250,8 @@ function filterSuccessUpdates(changeCount) {
   // on filter change update:
   // - loading/success status
   // - count change message
+
+  // check if there is a changed form element
   if (updateChangedEl) {
     var $label;
     var type = $(updateChangedEl).attr('type');
@@ -260,7 +262,10 @@ function filterSuccessUpdates(changeCount) {
     if (type === 'checkbox' || type === 'radio') {
       $label = $('label[for="' + updateChangedEl.id + '"]');
       $('.is-successful').removeClass();
-      $label.removeClass('is-loading').addClass('is-successful');
+
+      $('.is-loading').removeClass('is-loading');
+
+      $label.addClass('is-successful');
 
       setTimeout(function () {
         $label.removeClass('is-successful');
@@ -281,7 +286,7 @@ function filterSuccessUpdates(changeCount) {
       }
       // text input search
       else {
-        $label = $('.button--loading');
+        $label = $('.is-loading');
 
         if ($(updateChangedEl).val()) {
           filterAction = '"' + $(updateChangedEl).val() + '" applied.';
@@ -290,10 +295,10 @@ function filterSuccessUpdates(changeCount) {
           filterAction = 'Search term removed.';
         }
 
-        $label.removeClass('button--loading').addClass('button--check');
+        $label.removeClass('is-loading').addClass('is-successful');
 
         setTimeout(function () {
-          $label.removeClass('button--check');
+          $label.removeClass('is-successful');
         }, helpers.SUCCESS_DELAY);
       }
     }

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -552,6 +552,10 @@ DataTable.prototype.fetch = function(data, callback) {
   self.xhr = $.getJSON(url);
   self.xhr.done(self.fetchSuccess.bind(self));
   self.xhr.fail(self.fetchError.bind(self));
+
+  self.xhr.always(function() {
+    self.$processing.hide();
+  });
 };
 
 DataTable.prototype.export = function() {
@@ -591,8 +595,6 @@ DataTable.prototype.fetchSuccess = function(resp) {
   if (this.opts.hideEmpty) {
     this.hideEmpty(resp);
   }
-
-  self.$processing.hide();
 
   this.currentCount = this.newCount;
 };

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -500,12 +500,6 @@ DataTable.prototype.fetchSuccess = function(resp) {
   this.newCount = getCount(resp);
   this.refreshExport();
 
-  var successEvent = new CustomEvent('table:update', {
-    detail : this.newCount - this.currentCount
-  });
-
-  window.dispatchEvent(successEvent);
-
   // FILTER UPDATES:
   // - loading/success/fail status
   // - count change message

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -504,10 +504,15 @@ DataTable.prototype.fetchSuccess = function(resp) {
   // - loading/success/fail status
   // - count change message
   if (updateChangedEl) {
+    var $label;
     var type = $(updateChangedEl).attr('type');
+    var changeCount = this.newCount - this.currentCount;
+    var message = '';
+    var filterAction = '';
+    var $filterMessage = $('.filter__message');
 
     if (type === 'checkbox' || type === 'radio') {
-      var $label = $('label[for="' + updateChangedEl.id + '"]');
+      $label = $('label[for="' + updateChangedEl.id + '"]');
       $('.is-successful').removeClass();
       $label.removeClass('is-loading').addClass('is-successful');
 
@@ -515,39 +520,53 @@ DataTable.prototype.fetchSuccess = function(resp) {
         $label.removeClass('is-successful');
       }, helpers.SUCCESS_DELAY);
 
-      var changeCount = this.newCount - this.currentCount;
-      var message = '';
-      var filterAction = 'applied';
-      var $filterMessage = $('.filter__message');
+      filterAction = 'Filter applied.';
 
       if (!$(updateChangedEl).is(':checked')) {
-        filterAction = 'removed';
+        filterAction = 'Filter removed.';
       }
+    }
 
-      if (changeCount > 0) {
-        message = 'Filter ' + filterAction + '.<br>' +
-        '<strong>Added  ' + changeCount.toLocaleString() + '</strong> results.';
+    if (type === 'text') {
+      $label = $('.button--loading');
+
+      if ($(updateChangedEl).val()) {
+        filterAction = '"' + $(updateChangedEl).val() + '" applied.';
       }
       else {
-        message = 'Filter ' + filterAction + '.<br>' +
-        '<strong>Removed ' + Math.abs(changeCount).toLocaleString() + '</strong> results.';
+        filterAction = 'Search term removed.';
       }
 
-      if ($filterMessage.length) {
-        $filterMessage.fadeOut().remove();
+      $label.removeClass('button--loading').addClass('button--check');
 
-        clearTimeout(messageTimer);
-      }
-
-      $label.after($('<div class="filter__message filter__message--success">' + message + '</div>')
-        .hide().fadeIn());
-
-      messageTimer = setTimeout(function() {
-        $('.filter__message').fadeOut(function () {
-          $(this).remove();
-        });
+      setTimeout(function () {
+        $label.removeClass('button--check');
       }, helpers.SUCCESS_DELAY);
     }
+
+    if (changeCount > 0) {
+      message = filterAction + '<br>' +
+      '<strong>Added  ' + changeCount.toLocaleString() + '</strong> results.';
+    }
+    else {
+      message = filterAction + '<br>' +
+      '<strong>Removed ' + Math.abs(changeCount).toLocaleString() + '</strong> results.';
+    }
+
+    if ($filterMessage.length) {
+      $filterMessage.fadeOut().remove();
+
+      clearTimeout(messageTimer);
+    }
+
+    $label.after($('<div class="filter__message filter__message--success">' + message + '</div>')
+      .hide().fadeIn());
+
+    messageTimer = setTimeout(function() {
+      $('.filter__message').fadeOut(function () {
+        $(this).remove();
+      });
+    }, helpers.SUCCESS_DELAY);
   }
 
   if (this.opts.hideEmpty) {

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -169,7 +169,7 @@ function stateColumns(results) {
   return [stateColumn].concat(columns);
 }
 
-function refreshTables() {
+function refreshTables(e) {
   var $comparison = $('#comparison');
   var selected = $comparison.find('input[type="checkbox"]:checked').map(function(_, input) {
     var $input = $(input);
@@ -181,6 +181,18 @@ function refreshTables() {
   if (selected.length > 0) {
     drawSizeTable(selected);
     drawStateTable(selected);
+  }
+
+  if (e) {
+    $(e.target).next('label').addClass('is-loading');
+
+    setTimeout(function() {
+      $comparison.find('.is-loading').removeClass('is-loading').addClass('is-successful');
+    }, helpers.LOADING_DELAY);
+
+    setTimeout(function() {
+      $comparison.find('.is-successful').removeClass('is-successful');
+    }, helpers.SUCCESS_DELAY);
   }
 }
 

--- a/tests/unit/modules/tables.js
+++ b/tests/unit/modules/tables.js
@@ -84,8 +84,8 @@ describe('data table', function() {
     it('only adds widgets once', function() {
       this.table.ensureWidgets();
       this.table.ensureWidgets();
-      var prev = this.table.$body.prev('.is-loading');
-      expect(prev.length).to.equal(1);
+      var $exportButton = $('.js-export');
+      expect($exportButton.length).to.equal(1);
     });
   });
 


### PR DESCRIPTION
This adds support for removing the loading class and adding success / error classes to filters. 

I was thinking about where the best place for these calls to live was and I think it's here rather than having event listeners on the individual filter elements, but would like @xtine 's thoughts.

![example](http://g.recordit.co/MY4IjVV3gP.gif)

Depends on https://github.com/18F/fec-style/pull/435

cc @xtine 