### PR TITLE
Filter currency

### DIFF
--- a/openfecwebapp/templates/partials/disbursements-filter.html
+++ b/openfecwebapp/templates/partials/disbursements-filter.html
@@ -26,7 +26,7 @@ Filter disbursements
   <div class="accordion__content">
     {{ text.field('disbursement_description', 'Description') }}
     {% include 'partials/filters/disbursement-purpose.html' %}
-    {{ text.field('min_amount', 'Minimum expenditure', {'data-suffix': 'or more',  'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
+    {{ text.field('min_amount', 'Minimum expenditure', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
     {{ text.field('max_amount', 'Maximum expenditure', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
     {{ date.partition_field('date', 'Disbursement date', dates ) }}
     <div class="message message--info message--small">

--- a/openfecwebapp/templates/partials/disbursements-filter.html
+++ b/openfecwebapp/templates/partials/disbursements-filter.html
@@ -26,8 +26,8 @@ Filter disbursements
   <div class="accordion__content">
     {{ text.field('disbursement_description', 'Description') }}
     {% include 'partials/filters/disbursement-purpose.html' %}
-    {{ text.field('min_amount', 'Minimum expenditure', {'data-suffix': 'or more'}) }}
-    {{ text.field('max_amount', 'Maximum expenditure', {'data-suffix': 'or less'}) }}
+    {{ text.field('min_amount', 'Minimum expenditure', {'data-suffix': 'or more',  'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
+    {{ text.field('max_amount', 'Maximum expenditure', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
     {{ date.partition_field('date', 'Disbursement date', dates ) }}
     <div class="message message--info message--small">
       <span class="t-block">Disbursements are reported periodically, according to the filer's reporting schedule. Disbursements are updated as they’re processed— that time can vary.</span>

--- a/openfecwebapp/templates/partials/operating-expenditures-filter.html
+++ b/openfecwebapp/templates/partials/operating-expenditures-filter.html
@@ -31,8 +31,8 @@ Filter operating expenditures
   <div class="accordion__content">
     {{ text.field('disbursement_description', 'Description') }}
     {% include 'partials/filters/disbursement-purpose.html' %}
-    {{ text.field('min_amount', 'Minimum expenditure', {'data-suffix': 'or more'}) }}
-    {{ text.field('max_amount', 'Maximum expenditure', {'data-suffix': 'or less'}) }}
+    {{ text.field('min_amount', 'Minimum expenditure', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
+    {{ text.field('max_amount', 'Maximum expenditure', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
     {{ date.field('date', 'Disbursement date', dates ) }}
     <div class="message message--info message--small">
       <span class="t-block">Disbursements are reported periodically, according to the filer's reporting schedule. Disbursements are updated as they’re processed— that time can vary.</span>


### PR DESCRIPTION
Hey @noahmanger and @xtine! 

I noticed that the filters for disbursements and operating expenditures weren't currency inputs. Like so:

<img width="296" alt="disbursements filter" src="https://cloud.githubusercontent.com/assets/10552702/16959596/b58acd9a-4d9a-11e6-9c8c-6ab53599f93e.png">


I was going to file an issue, but I thought I'd try to fix it myself (I want to be better at this kind of thing!) All that's to say I'm 50/50 on whether I did this perfectly or completely wrong. 

<3 ,
Emileigh