### PR TITLE
Feature/data landing mobile

### DIFF
--- a/static/js/modules/bar-charts.js
+++ b/static/js/modules/bar-charts.js
@@ -14,15 +14,16 @@ var stripes =
       '</defs>' +
   '</svg>';
 
-
 function GroupedBarChart(selector, data, index) {
   this.element = d3.select(selector);
   this.data = data;
   this.index = index;
 
   this.margin = {top: 0, right: 20, bottom: 50, left: 40};
-  this.height = 320 - this.margin.top - this.margin.bottom;
-  this.width = 500 - this.margin.left - this.margin.right;
+  this.baseWidth = $(selector).width();
+  this.baseHeight = this.baseWidth * 0.7;
+  this.height = this.baseHeight - this.margin.top - this.margin.bottom;
+  this.width = this.baseWidth - this.margin.left - this.margin.right;
 
   if ($('#stripes').length === 0) {
     $('body').append(stripes);
@@ -46,6 +47,7 @@ GroupedBarChart.prototype.buildChart = function() {
   var xAxis = d3.svg.axis()
       .scale(x0)
       .innerTickSize([10])
+
       .orient('bottom');
 
   var yAxis = d3.svg.axis()
@@ -263,6 +265,22 @@ GroupedBarChart.prototype.showTooltip = function(x0, d) {
       'left': left.toString() + 'px'
     })
     .html(content);
+
+  if (!helpers.isMediumScreen()) {
+    left = x0(d.period) + 50;
+    this.tooltip
+      .attr('class', 'tooltip tooltip--chart')
+      .style({
+        'left': 0,
+        'width': '100%'
+      });
+
+    this.tooltip.append('span')
+      .attr('class', 'tooltip__point')
+      .style({
+        'left': left.toString() + 'px'
+      });
+  }
 
   helpers.zeroPad('.tooltip__content', '.figure__item', '.figure__decimals');
 

--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -196,7 +196,7 @@ function getTimePeriod(electionYear, cycle, electionFull, office) {
 function zeroPad(container, item, appendee) {
   // Subtract 2 so if it's close we don't go over
   var maxWidth = $(container).width() - 6;
-
+  $(container).find(appendee).empty();
   $(container).find(item).each(function() {
     var itemWidth = $(this).width();
     // $appendee is where the period will be appended to

--- a/static/js/modules/top-list.js
+++ b/static/js/modules/top-list.js
@@ -11,13 +11,18 @@ function TopList(selector, dataType) {
   this.$topType = this.$element.find('.js-top-type');
   this.raisingID = this.$topRaising.attr('id');
   this.spendingID = this.$topSpending.attr('id');
+  this.$visibleList = this.$topRaising;
   this.dataType = dataType;
-
   this.setAria();
-  helpers.zeroPad(this.$topRaising, '.figure__number', '.figure__decimals');
+  this.zeroPad();
 
   this.$toggles.on('click', this.handleToggle.bind(this));
+  $(window).on('resize', this.zeroPad.bind(this));
 }
+
+TopList.prototype.zeroPad = function() {
+  helpers.zeroPad(this.$visibleList, '.figure__number', '.figure__decimals');
+};
 
 TopList.prototype.handleToggle = function(e) {
   var $target = $(e.target);
@@ -39,13 +44,15 @@ TopList.prototype.showRaising = function() {
   this.$topRaising.attr('aria-hidden', 'false');
   this.$topSpending.attr('aria-hidden', 'true');
   this.$topType.text('raising');
+  this.$visibleList = this.$topRaising;
 };
 
 TopList.prototype.showSpending = function() {
   this.$topSpending.attr('aria-hidden', 'false');
   this.$topRaising.attr('aria-hidden', 'true');
   this.$topType.text('spending');
-  helpers.zeroPad(this.$topSpending, '.figure__number', '.figure__decimals');
+  this.$visibleList = this.$topSpending;
+  this.zeroPad();
 };
 
 

--- a/static/js/pages/landing.js
+++ b/static/js/pages/landing.js
@@ -43,22 +43,6 @@ var raisingData = [
     'pacs': 359289.27,
     'other': 0
   },
-  {
-    'period': 'Jul 1 - Sep 30, 2016',
-    'status': 'not-started',
-    'candidates': 0,
-    'parties': 0,
-    'pacs': 0,
-    'other': 0
-  },
-  {
-    'period': 'Oct 1 - Dec 31, 2016',
-    'status': 'not-started',
-    'candidates': 0,
-    'parties': 0,
-    'pacs': 0,
-    'other': 0
-  }
 ];
 
 var spendingData = [
@@ -93,20 +77,6 @@ var spendingData = [
     'parties': 35904262.78,
     'pacs': 263191.92,
     'other': 242687
-  },
-  {
-    'period': 'Jul 1 - Sep 30, 2016',
-    'status': 'not-started',
-    'candidates': 0,
-    'parties': 0,
-    'pacs': 0,
-  },
-  {
-    'period': 'Oct 1 - Dec 31, 2016',
-    'status': 'not-started',
-    'candidates': 0,
-    'parties': 0,
-    'pacs': 0,
   }
 ];
 

--- a/static/js/pages/landing.js
+++ b/static/js/pages/landing.js
@@ -111,6 +111,7 @@ var spendingData = [
 ];
 
 function Overview(selector, data, index) {
+  this.selector = selector;
   this.$element = $(selector);
   this.data = data;
   this.index = index;
@@ -118,12 +119,16 @@ function Overview(selector, data, index) {
   this.totals = this.$element.find('.js-total');
   this.reactionBox = this.$element.find('.js-reaction-box');
 
-  helpers.zeroPad(selector + ' .js-totals', '.overview__total-number', '.figure__decimals');
+  this.zeroPadTotals();
 
-  if (helpers.isLargeScreen()) {
-    new GroupedBarChart(selector + ' .js-chart', this.data, this.index);
-  }
+  $(window).on('resize', this.zeroPadTotals.bind(this));
+
+  new GroupedBarChart(selector + ' .js-chart', this.data, this.index);
 }
+
+Overview.prototype.zeroPadTotals = function() {
+  helpers.zeroPad(this.selector + ' .js-totals', '.overview__total-number', '.figure__decimals');
+};
 
 new Overview('.js-raised-overview', raisingData, 1);
 new Overview('.js-spent-overview', spendingData, 2);


### PR DESCRIPTION
Fixes various things about the data landing page so it displays better on smaller screens:
- Decimal-padding of numbers now adjusts when the screen size adjusts.
- Removes the empty data periods since usability testing revealed them to be confusing and not helpful and it gives the labels more breathing room on mobile
- Positions the tooltip differently on small screens vs medium and larger. The tooltip is now full-width, but the point adjusts like so:
  ![gif](http://g.recordit.co/twbPo1JUsQ.gif)

Requires https://github.com/18F/fec-style/pull/441
Resolves https://github.com/18F/openFEC/issues/1743

cc @xtine 
