### PR TITLE
Removing references to FEC_WEB_STYLE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 
 ## Campaign finance for everyone
 
-The Federal Election Commission (FEC) releases information to the public about money that’s raised and spent in federal elections — that’s elections for US president, Senate, and House of Representatives. 
+The Federal Election Commission (FEC) releases information to the public about money that’s raised and spent in federal elections — that’s elections for US president, Senate, and House of Representatives.
 
 Are you interested in seeing how much money a candidate raised? Or spent? How much debt they took on? Who contributed to their campaign? The FEC is the authoritative source for that information.
 
-betaFEC is a collaboration between [18F](http://18f.gsa.gov) and the FEC. It aims to make campaign finance information more accessible (and understandable) to all users. 
+betaFEC is a collaboration between [18F](http://18f.gsa.gov) and the FEC. It aims to make campaign finance information more accessible (and understandable) to all users.
 
 ## FEC repositories
-We welcome you to explore, make suggestions, and contribute to our code. 
+We welcome you to explore, make suggestions, and contribute to our code.
 
 This repository, [openFEC-web-app](https://github.com/18f/openfec-web-app), houses the betaFEC web app for exploring campaign finance data.
 
@@ -29,7 +29,7 @@ This repository, [openFEC-web-app](https://github.com/18f/openfec-web-app), hous
 - [fec-cms](https://github.com/18F/fec-cms): the content management system (CMS) for betaFEC
 
 ## Get involved
-We’re thrilled you want to get involved! 
+We’re thrilled you want to get involved!
 - Read our [contributing guidelines](https://github.com/18F/openfec/blob/master/CONTRIBUTING.md). Then, [file an issue](https://github.com/18F/fec/issues) or submit a pull request.
 - [Send us an email](mailto:betafeedback@fec.gov).
 - If you’re a developer, follow the installation instructions in the README.md page of each repository to run the apps on your computer.
@@ -73,14 +73,15 @@ To run the server in debug mode set:
 
     export FEC_WEB_DEBUG=true
 
-To use styles served from a custom location (e.g., if developing against a local `fec-style`):
+### Developing with fec-style (optional)
+If you're developing with a local instance of [fec-style](https://github.com/18F/fec-style) and want to pull in styles and script changes as you go, use `npm link` to create a symbolic link to your local fec-style repo:
 
-    export FEC_WEB_STYLE_URL=http://localhost:8080/css/styles.css
+    npm link fec-style > ~/[path to fec-style]/fec-style
 
-To be able to have links between this app and a local installation of the cms:
+### Developing with fec-cms (optional)
+To be able to have links between this app and a local installation of [fec-cms](https://github.com/18F/fec-cms):
 
     export FEC_CMS_URL=http://localhost:8000
-
 
 ### Features
 

--- a/openfecwebapp/config.py
+++ b/openfecwebapp/config.py
@@ -13,7 +13,6 @@ api_key_public = env.get_credential('FEC_WEB_API_KEY_PUBLIC', '')
 cache = os.getenv('FEC_WEB_CACHE')
 cache_size = int(os.getenv('FEC_WEB_CACHE_SIZE', 1000))
 
-style_url = os.getenv('FEC_WEB_STYLE_URL')
 cms_url = os.getenv('FEC_CMS_URL', '')
 
 # you can only give a var a string using set-env with Cloud Foundry

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -8,12 +8,8 @@
   {% include 'partials/meta-tags.html' %}
 
   <link rel="stylesheet" href="{{ asset_for('dist/styles/styles.css') }}" />
-
-  {% if style_url %}
-  <link rel="stylesheet" href="{{ style_url }}" />
-  {% else %}
   <link rel="stylesheet" href="{{ asset_for('dist/styles/fec.css') }}" />
-  {% endif %}
+
   {% if api_location %}
   <script>
     BASE_PATH = '{{ base_path() }}';


### PR DESCRIPTION
In order to simplify development and bring parity with fec-cms, this removes references to FEC_WEB_STYLE_URL, in favor of using `npm link` to develop with a local instance of fec-style, rather than serving the stylesheet.

cc @xtine @adborden for thoughts if this makes sense. If so, cc @emileighoutlaw for language and @jenniferthibault for visibility.