### PR TITLE
Adding source filing link to committee financial summary

### DIFF
--- a/openfecwebapp/templates/partials/candidate/financial-summary.html
+++ b/openfecwebapp/templates/partials/candidate/financial-summary.html
@@ -32,8 +32,13 @@
           aggregate.cash != 0 or
           aggregate.debt != 0
          %}
+          {% if office == 'P' %}
+            {% set form_type = 'F3P' %}
+          {% else %}
+            {% set form_type = 'F3' %}
+          {% endif %}
            <a href="{{ url_for('filings',
-             form_type=['F3', 'F3P'],
+             form_type=[form_type],
              committee_id=committee_ids,
              cycle=aggregate_cycles,
              ) }}">

--- a/openfecwebapp/templates/partials/committee/financial-summary.html
+++ b/openfecwebapp/templates/partials/committee/financial-summary.html
@@ -1,4 +1,9 @@
 {% import 'macros/missing.html' as missing %}
+{% if committee_type == 'P' %}
+  {% set form_type = 'F3P' %}
+{% else %}
+  {% set form_type = 'F3' %}
+{% endif %}
 
 <section class="main" id="section-1" role="tabpanel" aria-hidden="true" aria-labelledby="section-1-heading">
   <div class="container">
@@ -7,6 +12,13 @@
         <h2 class="heading__title" id="section-1-heading">
           Financial summary: {{ cycle|fmt_year_range }}
         </h2>
+        <a class="button button--alt button--browse heading__action" href="{{ url_for('filings',
+           form_type=[form_type],
+           committee_id=committee_id,
+           cycle=cycle,
+           ) }}">
+           View source filings
+         </a>
       </div>
       <p>Get the full picture of all of the money received and spent by this <span class="term" data-term="Committee">committee</span>.</p>
     </div>


### PR DESCRIPTION
Adds the link to the source filings for the committee financial
summaries, restricted to only the form types relevant to this type of
committee.

Similarly, restricts the candidates source filings link to only the
ones relevant to that type of office.

Fixes https://github.com/18F/openFEC-web-app/issues/1381

![image](https://cloud.githubusercontent.com/assets/1696495/17234821/10c7bc7e-54f1-11e6-93b8-87a2d943ed8c.png)

cc @LindsayYoung 
