### PR TITLE
[MERGE WITH GITFLOW] Don't include the loading overlay in the selector

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -286,7 +286,7 @@ function filterSuccessUpdates(changeCount) {
       }
       // text input search
       else {
-        $label = $('.is-loading');
+        $label = $('.is-loading:not(.overlay)');
 
         if ($(updateChangedEl).val()) {
           filterAction = '"' + $(updateChangedEl).val() + '" applied.';


### PR DESCRIPTION
Super crude fix for a bug where `$label` selection was also including the `<div class="overlay is-loading">`, which meant that the message was being appended after the overlay, instead of whatever was the loading element for the filter.

This should be refactored, but it will do the trick for now.

cc @xtine 