### PR TITLE
Move feature flag to credential service

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -5,7 +5,6 @@ services:
   - fec-creds-dev
 env:
   FEC_CMS_URL: https://fec-proxy.18f.gov
-  FEC_FEATURE_LEGAL: true
   FEC_WEB_API_URL: https://fec-dev-api.18f.gov
   FEC_WEB_DEBUG: true
   FEC_WEB_ENVIRONMENT: dev

--- a/manifest_feature.yml
+++ b/manifest_feature.yml
@@ -5,7 +5,6 @@ services:
   - fec-creds-feature
 env:
   FEC_CMS_URL: https://fec-feature-proxy.18f.gov
-  FEC_FEATURE_LEGAL: true
   FEC_WEB_API_URL: https://fec-feature-api.18f.gov
   FEC_WEB_DEBUG: true
   FEC_WEB_ENVIRONMENT: dev

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -5,7 +5,6 @@ services:
   - fec-creds-stage
 env:
   FEC_CMS_URL: https://fec-stage-proxy.18f.gov
-  FEC_FEATURE_LEGAL: true
   FEC_WEB_API_URL: https://fec-stage-api.18f.gov
   FEC_WEB_DEBUG: true
   FEC_WEB_ENVIRONMENT: stage

--- a/openfecwebapp/config.py
+++ b/openfecwebapp/config.py
@@ -28,7 +28,7 @@ environment = (
 )
 
 features = {
-    'legal': os.getenv('FEC_FEATURE_LEGAL', '') == 'true',
+    'legal': bool(env.get_credential('FEC_FEATURE_LEGAL', '')),
 }
 
 # Whether the app should force HTTPS/HSTS.

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -242,8 +242,7 @@ def legal_search(query, result_type):
     if query:
         results = api_caller.load_legal_search_results(query, result_type, limit=3)
 
-    return views.render_legal_search_results(results, query,
-                    result_type, config.features['legal'])
+    return views.render_legal_search_results(results, query, result_type)
 
 @app.route('/legal/advisory-opinions/')
 @use_kwargs({

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -15,7 +15,7 @@
 {% block body %}
 <header class="page-header slab slab--primary">
   {{ breadcrumb.breadcrumbs('Search results', breadcrumb_links) }}
-  {{ legal_search.search('header', result_type, query, feature_flag) }}
+  {{ legal_search.search('header', result_type, query) }}
 </header>
 
 <div class="main">
@@ -29,7 +29,7 @@
               Regulations ({{ results.total_regulations|default(0) }})
               </a>
             </li>
-            {% if feature_flag %}
+            {% if features.legal %}
             <li class="side-nav__item">
               <a class="side-nav__link" href="#results-advisory-opinions">
               Advisory Opinions ({{ results.total_advisory_opinions|default(0) }})
@@ -93,7 +93,7 @@
             </div>
           {% endif %}
         </div>
-        {% if feature_flag %}
+        {% if features.legal %}
         <div id="results-advisory-opinions" class="content__section">
           <div class="results-info results-info--simple">
             <div class="results-info__left">

--- a/openfecwebapp/templates/macros/legal-search.html
+++ b/openfecwebapp/templates/macros/legal-search.html
@@ -1,10 +1,10 @@
-{% macro search(location, result_type, query, feature_flag, button_color="button--standard", select_class="select--alt-primary") %}
+{% macro search(location, result_type, query, button_color="button--standard", select_class="select--alt-primary") %}
 {% if location == 'hero' %}
   {% set size = 'combo--search--large' %}
 {% endif %}
 <form id="{{ location }}-search" action="{{ url_for('legal_search') }}" autocomplete="off" class="search__container">
   <div class="combo combo--search {{ size }}">
-    {% if feature_flag %}
+    {% if features.legal %}
     <select class="search__select {{select_class}}" name="search_type" aria-label="Select a document type">
       {% for value, name in (('all', 'All'),('regulations', 'Regulations'),('advisory_opinions', 'Advisory Opinions')) %}
       <option value="{{ value }}" {% if result_type == value %}selected{% endif %}>{{ name }}</option>

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -26,14 +26,13 @@ def render_search_results(results, query, result_type):
     )
 
 
-def render_legal_search_results(results, query, result_type, feature_flag):
+def render_legal_search_results(results, query, result_type):
     return render_template(
         'legal-search-results.html',
         legal_include_display_all=True, # includes the display-all link in results
         query=query,
         results=results,
         result_type=result_type,
-        feature_flag=feature_flag
     )
 
 


### PR DESCRIPTION
- Moves the feature flag to the credentials service, as per https://github.com/18F/fec-cms/pull/401
- Simplifies the feature flag variable using `config.features` directly in templates