### PR TITLE
adding indentation and sorting docs by date

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -84,7 +84,9 @@ def load_legal_search_results(query, query_type='all', offset=0, limit=20):
             else:
                 grouped_aos[ao['no']] = [ao]
 
-        results['advisory_opinions'] = grouped_aos
+    for ao_no in grouped_aos:
+        grouped_aos[ao_no].sort(key=lambda ao: ao['date'], reverse=True)
+    results['advisory_opinions'] = grouped_aos
     return results
 
 

--- a/openfecwebapp/templates/partials/legal-search-results-advisory-opinion.html
+++ b/openfecwebapp/templates/partials/legal-search-results-advisory-opinion.html
@@ -1,5 +1,4 @@
-<table>
-  <h3 class="cal-list__title">
+<h3 class="cal-list__title">
   <a title="{{ advisory_opinion_docs[0].description }}"
     href="{{ advisory_opinion_docs[0].url }}">
     <span class="font-bolt">AO {{ advisory_opinion_docs[0].no }}: </span></a>
@@ -10,6 +9,8 @@
 </span>
 </p>
 </h3>
+<div class="u-padding-left">
+<table>
   <tbody>
   {% for advisory_opinion_doc in advisory_opinion_docs %}
   <tr class="legal-search-result">
@@ -27,3 +28,4 @@
   {% endfor %}
   <tbody>
 <table>
+</div>


### PR DESCRIPTION
This addresses two of the four comments @porta-antiporta made concerning AOs. It sorts by date and adds a small indentation. It does not add the expand / collapse feature, which @jenniferthibault agreed was not necessary for this release considering other architectural compromises made (ie, all docs are known to be relevant to search and are limited in number), and it does not remove the right padding of the `Summary` paragraph, since that would require significant refactoring of the `cal-list__title` class in fec-style.