### PR TITLE
Changing class from data-container__body to data-container__table

### DIFF
--- a/openfecwebapp/templates/datatable.html
+++ b/openfecwebapp/templates/datatable.html
@@ -19,7 +19,7 @@
         <div class="js-filter-tags data-container__tags">
         </div>
       </div>
-      <div id="{{slug}}" class="data-container__body fade-in">
+      <div id="{{slug}}" class="data-container__datatable">
         <table id="results" class="data-table" aria-live="polite">
           <thead>
             <tr>

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -50,7 +50,6 @@ var messageTimer;
 
 // Only show table after draw
 $(document.body).on('draw.dt', function() {
-  $('.data-container__body.fade-in').css('opacity', '1');
   $('.dataTable tbody td:first-child').attr('scope','row');
 });
 


### PR DESCRIPTION
Fixes padding on data-table pages vs legal resources search pages. Data tables are now wrapped in a `.data-container__table` class which only has padding on the left (and 0 padding on small screens). Search results have `.data-container__body` which has padding on both sides (including mobile).

cc @adborden 

Requires https://github.com/18F/fec-style/pull/469