### PR TITLE
updating URL for Final Opinion

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -93,10 +93,6 @@ def load_legal_advisory_opinion(ao_no):
     
     if not canonical_document:
         return None
-
-    # manipulating category for display purposes
-    canonical_document['category'] = canonical_document['category'].lower()
-    canonical_document['category'] = canonical_document['category'].capitalize()
     
     advisory_opinion = {
         'no' : ao_no,

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -88,8 +88,15 @@ def load_legal_advisory_opinion(ao_no):
 
     for document in documents:
         canonical_document = document
-        if (document['category'] == 'Final Opinion'):
+        if document['category'] == 'Final Opinion':
             break        
+    
+    if not canonical_document:
+        return None
+
+    # manipulating category for display purposes
+    canonical_document['category'] = canonical_document['category'].lower()
+    canonical_document['category'] = canonical_document['category'].capitalize()
     
     advisory_opinion = {
         'no' : ao_no,

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -86,7 +86,11 @@ def load_legal_advisory_opinion(ao_no):
     if not (documents and len(documents)):
         return None
 
-    canonical_document = documents[0]
+    for document in documents:
+        canonical_document = document
+        if (document['category'] == 'Final Opinion'):
+            break        
+    
     advisory_opinion = {
         'no' : ao_no,
         'date': canonical_document['date'],
@@ -94,6 +98,7 @@ def load_legal_advisory_opinion(ao_no):
         'summary': canonical_document['summary'],
         'description': canonical_document['description'],
         'url': canonical_document['url'],
+        'category' : canonical_document['category'],
         'documents': documents,
         'entities': [],
     }

--- a/openfecwebapp/templates/legal-advisory-opinion.html
+++ b/openfecwebapp/templates/legal-advisory-opinion.html
@@ -33,7 +33,7 @@
     <section class="content__section">
       <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
       <div class="content__section">
-        <a class="button button--cta button--document button--lg" href="{{ advisory_opinion.url }}"> View {{ advisory_opinion.category }}</a>
+        <a class="button button--cta button--document button--lg" href="{{ advisory_opinion.url }}">{{ advisory_opinion.category }}</a>
       </div>
       <table class="data-table data-table--text">
         <thead>

--- a/openfecwebapp/templates/legal-advisory-opinion.html
+++ b/openfecwebapp/templates/legal-advisory-opinion.html
@@ -33,7 +33,9 @@
     <section class="content__section">
       <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
       <div class="content__section">
-        <a class="button button--cta button--document button--lg" href="{{ advisory_opinion.url }}">{{ advisory_opinion.category }}</a>
+      {% if advisory_opinion.category == "Final Opinion" %}
+        <a class="button button--cta button--document button--lg" href="{{ advisory_opinion.url }}">{{ advisory_opinion.category | lower | capitalize }}</a>
+      {% endif %}
       </div>
       <table class="data-table data-table--text">
         <thead>

--- a/openfecwebapp/templates/legal-advisory-opinion.html
+++ b/openfecwebapp/templates/legal-advisory-opinion.html
@@ -33,7 +33,7 @@
     <section class="content__section">
       <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
       <div class="content__section">
-        <a class="button button--cta button--document button--lg" href="{{ advisory_opinion.url }}">Final opinion</a>
+        <a class="button button--cta button--document button--lg" href="{{ advisory_opinion.url }}"> View {{ advisory_opinion.category }}</a>
       </div>
       <table class="data-table data-table--text">
         <thead>


### PR DESCRIPTION
The current AO canonical page has a "Final Opinion" button that does not pull up the Final Opinion.
This PR addresses that and the edge cases where there is no Final Opinion.