### PR TITLE
Tests for load_legal_advisory_opinion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
 before_script:
   - travis_retry pip install -U pip wheel
   - travis_retry pip install -r requirements.txt
+  - travis_retry pip install -r requirements.test.txt
+
 
   # Use production version of node.js
   - . $HOME/.nvm/nvm.sh

--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ Install Python dependencies:
 
     pip install -r requirements.txt
 
+Dependencies for test:
+
+    pip install -r requirements.test.txt
+
 Install client side dependencies:
 
-    $ npm install
+    npm install
 
 ### Configuration
 

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,4 +1,4 @@
-Faker==0.1.4
+fake-factory==0.6.0
 mock>=1.3.0
 pytest>=2.7.0
 pytest-cov>=1.8.1

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,0 +1,5 @@
+Faker==0.1.4
+mock>=1.3.0
+pytest>=2.7.0
+pytest-cov>=1.8.1
+WebTest>=2.0.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,3 @@ slacker==0.8.6
 # Development
 invoke==0.10.1
 GitPython==1.0.1
-
-# Testing
-mock>=1.3.0
-pytest>=2.7.0
-pytest-cov>=1.8.1
-WebTest>=2.0.18

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -1,0 +1,31 @@
+from faker import Faker
+
+faker = Faker()
+
+
+def factory(f):
+    """Decorator to wrap your data function as a test factory."""
+    def decorator(**data):
+        d = f()
+        assert type(d) is dict
+        d.update(data)
+        return d
+
+    return decorator
+
+@factory
+def advisory_opinion():
+    return {
+        'no': '2014-%00d' % faker.random_int(max=100),
+        'date': faker.date_time(),
+        'name': faker.name(),
+        'summary': faker.sentence(),
+        'description': faker.sentence(4),
+        'url': faker.url(),
+        'category': faker.random_element((
+            'AO Request, Supplemental Material, and Extensions of Time',
+            'Final Opinion',
+            'Draft Documents',
+            'Votes',
+        )),
+    }

--- a/tests/unit/test_legal_advisory_opinion_page.py
+++ b/tests/unit/test_legal_advisory_opinion_page.py
@@ -1,0 +1,48 @@
+from unittest import mock, TestCase
+from urllib.parse import urlparse, parse_qs
+
+import flask
+
+from tests import factory
+from openfecwebapp import api_caller
+from openfecwebapp.app import app
+
+
+class TestLoadAdvisoryOpinion(TestCase):
+
+    def setUp(self):
+        self.app = app.test_client()
+
+    @mock.patch.object(api_caller, '_call_api')
+    def test_load_advisory_opinion(self, call_api):
+        final_opinion = factory.advisory_opinion(category='Final Opinion')
+        call_api.return_value = {
+            'docs': [
+                factory.advisory_opinion(category='Draft'),
+                final_opinion,
+                factory.advisory_opinion(category='Votes'),
+            ]
+        }
+
+        canonical_document = api_caller.load_legal_advisory_opinion('2014-01')
+        self.assertEqual(canonical_document.get('no'), '2014-01')
+        self.assertEqual(canonical_document.get('category'), 'Final Opinion')
+        self.assertEqual(canonical_document.get('name'), final_opinion.get('name'))
+        self.assertEqual(canonical_document.get('summary'), final_opinion.get('summary'))
+        self.assertEqual(canonical_document.get('description'), final_opinion.get('description'))
+        self.assertEqual(canonical_document.get('url'), final_opinion.get('url'))
+        self.assertEqual(len(canonical_document.get('documents')), 3)
+
+    @mock.patch.object(api_caller, '_call_api')
+    def test_given_no_final_opinion(self, call_api):
+        call_api.return_value = {
+            'docs': [
+                factory.advisory_opinion(category='Draft'),
+                factory.advisory_opinion(category='Votes'),
+            ]
+        }
+
+        canonical_document = api_caller.load_legal_advisory_opinion('2014-01')
+        self.assertEqual(canonical_document.get('no'), '2014-01')
+        self.assertNotEqual(canonical_document.get('category'), 'Final Opinion')
+        self.assertEqual(len(canonical_document.get('documents')), 2)


### PR DESCRIPTION
- Introduces a `factory` decorator to easily generate test data for testing the API.
- Moves test dependencies into a test-specific `requirements.test.txt` file.
