### PR TITLE
Use document specific count

### DIFF
--- a/openfecwebapp/templates/legal-doc-search-results.html
+++ b/openfecwebapp/templates/legal-doc-search-results.html
@@ -5,6 +5,8 @@
 {% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources')] %}
 {% set result_entities = results.get(result_type, []) %}
 
+{% set total_count = results.get('total_%s' % result_type, 0) %}
+
 {% block title %}
   {% if query %}
   Searching {{ document_type_display_name.lower() }} for &ldquo;{{ query }}&rdquo;
@@ -26,7 +28,7 @@
         <h2 class="results-info__title">Searching {{ document_type_display_name.lower() }}{% if query %} for &ldquo;{{ query }}&rdquo;{% endif %}</h2>
       </div>
     </div>
-    {% if results.total_all %}
+    {% if total_count %}
       {% if result_type == 'regulations' %}
         <table class="data-table data-table--text data-table--heading-borders">
             <thead>
@@ -51,14 +53,14 @@
         {% endfor %}
       {% endif %}
     <div class="results-info">
-      <div class="dataTables_info">Showing {{ results.offset + 1 }}&ndash;{{ results.offset + result_entities|length }} of about {{ results.total_all }}</span></div>
+      <div class="dataTables_info">Showing {{ results.offset + 1 }}&ndash;{{ results.offset + result_entities|length }} of about {{ total_count }}</span></div>
       <div class="dataTables_paginate">
         {% if results.offset > 0 %}
 	<a class="paginate_button previous" href="{{ url_for(result_type, search=query, offset=(results.offset - results.limit)) }}#results-{{ result_type }}">Previous</a>
         {% else %}
         <span class="paginate_button previous is-disabled">Previous</span>
         {% endif %}
-        {% if results.offset + results.limit < results.total_all %}
+        {% if results.offset + results.limit < total_count %}
 	<a class="paginate_button next" href="{{ url_for(result_type, search=query, offset=(results.offset + results.limit)) }}#results-{{ result_type }}">Next</a>
         {% else %}
         <span class="paginate_button next is-disabled">Next</span>


### PR DESCRIPTION
In case the API returns a different count for `total_all` vs `total_%(result_type)s`, go for the safe bet and use the document specific count.
