### PR TITLE
Update filter messaging

### DIFF
--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -227,5 +227,6 @@ module.exports = {
   isMediumScreen: isMediumScreen,
   LOADING_DELAY: helpers.LOADING_DELAY,
   SUCCESS_DELAY: helpers.SUCCESS_DELAY,
+  ERROR_DELAY: helpers.ERROR_DELAY,
   zeroPad: zeroPad
 };

--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -226,6 +226,6 @@ module.exports = {
   isLargeScreen: isLargeScreen,
   isMediumScreen: isMediumScreen,
   LOADING_DELAY: helpers.LOADING_DELAY,
-  SUCCESS_DELAY: helpers.SUCCESS_DELAY
+  SUCCESS_DELAY: helpers.SUCCESS_DELAY,
   zeroPad: zeroPad
 };

--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -226,7 +226,6 @@ module.exports = {
   isLargeScreen: isLargeScreen,
   isMediumScreen: isMediumScreen,
   LOADING_DELAY: helpers.LOADING_DELAY,
-  SUCCESS_DELAY: helpers.SUCCESS_DELAY,
-  ERROR_DELAY: helpers.ERROR_DELAY,
+  SUCCESS_DELAY: helpers.SUCCESS_DELAY
   zeroPad: zeroPad
 };

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -612,15 +612,18 @@ DataTable.prototype.fetchError = function() {
 
   $('.filter__message').remove();
 
-  $('.is-loading')
+  $('.filters .is-loading')
     .removeClass('is-loading')
     .addClass('is-unsuccessful')
     .after($('<div class="filter__message filter__message--error">' +
       '<strong>We had trouble processing your request</strong><br>' +
-      'Please try again. If you still have trouble let us know</div>'))
+      'Please try again. If you still have trouble ' +
+      '<span class="js-filter-feedback">let us know</a></div>'))
     .hide().fadeIn();
 
   self.$processing.hide();
+
+  clearTimeout(messageTimer);
 
   messageTimer = setTimeout(function() {
     $('.is-unsuccessful').removeClass('is-unsuccessful');
@@ -628,7 +631,7 @@ DataTable.prototype.fetchError = function() {
     $('.filter__message').fadeOut(function () {
       $(this).remove();
     });
-  }, helpers.LOADING_DELAY);
+  }, helpers.ERROR_DELAY);
 };
 
 /**

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -275,7 +275,7 @@ function filterSuccessUpdates(changeCount) {
         // show message after generated checkbox (last item in list)
         $label = $('.js-typeahead-filter li').last();
 
-        filterAction = 'Filter applied';
+        filterAction = 'Filter added';
       }
       // text input search
       else {

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -300,13 +300,13 @@ function filterSuccessUpdates(changeCount) {
     // build message with number of results returned
 
     if (changeCount > 0) {
-      filterResult = 'Expanded by ' + changeCount.toLocaleString() + ' results';
+      filterResult = changeCount.toLocaleString() + ' more results';
     }
     else if (changeCount === 0) {
       filterResult = 'No change in results';
     }
     else {
-      filterResult = 'Narrowed by ' + Math.abs(changeCount).toLocaleString() + ' results';
+      filterResult = Math.abs(changeCount).toLocaleString() + ' less results';
     }
 
     message = '<strong>' + filterAction + '</strong><br>' + filterResult;

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -610,14 +610,25 @@ DataTable.prototype.fetchSuccess = function(resp) {
 DataTable.prototype.fetchError = function() {
   var self = this;
 
-  setTimeout(function() {
-    $('.is-loading').removeClass('is-loading').addClass('is-unsuccessful');
-    self.$processing.hide();
-  }, helpers.LOADING_DELAY);
+  $('.filter__message').remove();
 
-  setTimeout(function() {
+  $('.is-loading')
+    .removeClass('is-loading')
+    .addClass('is-unsuccessful')
+    .after($('<div class="filter__message filter__message--error">' +
+      '<strong>We had trouble processing your request</strong><br>' +
+      'Please try again. If you still have trouble let us know</div>'))
+    .hide().fadeIn();
+
+  self.$processing.hide();
+
+  messageTimer = setTimeout(function() {
     $('.is-unsuccessful').removeClass('is-unsuccessful');
-  }, helpers.SUCCESS_DELAY);
+
+    $('.filter__message').fadeOut(function () {
+      $(this).remove();
+    });
+  }, helpers.LOADING_DELAY);
 };
 
 /**

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -631,16 +631,6 @@ DataTable.prototype.fetchError = function() {
   $('button.is-loading').removeClass('is-loading');
 
   self.$processing.hide();
-
-  clearTimeout(messageTimer);
-
-  messageTimer = setTimeout(function() {
-    $('.is-unsuccessful').removeClass('is-unsuccessful');
-
-    $('.filter__message').fadeOut(function () {
-      $(this).remove();
-    });
-  }, helpers.ERROR_DELAY);
 };
 
 /**

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -609,17 +609,26 @@ DataTable.prototype.fetchSuccess = function(resp) {
 
 DataTable.prototype.fetchError = function() {
   var self = this;
+  var errorMessage = '<div class="filter__message filter__message--error">' +
+      '<strong>We had trouble processing your request</strong><br>' +
+      'Please try again. If you still have trouble, ' +
+      '<button class="js-filter-feedback">let us know</button></div>';
 
   $('.filter__message').remove();
 
-  $('.filters .is-loading')
-    .removeClass('is-loading')
-    .addClass('is-unsuccessful')
-    .after($('<div class="filter__message filter__message--error">' +
-      '<strong>We had trouble processing your request</strong><br>' +
-      'Please try again. If you still have trouble, ' +
-      '<button class="js-filter-feedback">let us know</button></div>'))
-    .hide().fadeIn();
+  // text search error message
+  if (updateChangedEl.type === 'text' && $(updateChangedEl).hasClass('tt-input') === false) {
+    $(updateChangedEl).parent().after($(errorMessage));
+  }
+  else {
+    $('label.is-loading')
+      .removeClass('is-loading')
+      .addClass('is-unsuccessful')
+      .after($(errorMessage))
+      .hide().fadeIn();
+  }
+
+  $('button.is-loading').removeClass('is-loading');
 
   self.$processing.hide();
 

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -254,6 +254,7 @@ function filterSuccessUpdates(changeCount) {
     var type = $(updateChangedEl).attr('type');
     var message = '';
     var filterAction = '';
+    var filterResult = '';
     var $filterMessage = $('.filter__message');
 
     $('.is-successful').removeClass('is-successful');
@@ -262,10 +263,10 @@ function filterSuccessUpdates(changeCount) {
     if (type === 'checkbox' || type === 'radio') {
       $label = $('label[for="' + updateChangedEl.id + '"]');
 
-      filterAction = 'Filter applied.';
+      filterAction = 'Filter added';
 
       if (!$(updateChangedEl).is(':checked')) {
-        filterAction = 'Filter removed.';
+        filterAction = 'Filter removed';
       }
     }
     else if (type === 'text') {
@@ -274,7 +275,7 @@ function filterSuccessUpdates(changeCount) {
         // show message after generated checkbox (last item in list)
         $label = $('.js-typeahead-filter li').last();
 
-        filterAction = 'Filter applied.';
+        filterAction = 'Filter applied';
       }
       // text input search
       else {
@@ -284,7 +285,7 @@ function filterSuccessUpdates(changeCount) {
           filterAction = '"' + $(updateChangedEl).val() + '" applied.';
         }
         else {
-          filterAction = 'Search term removed.';
+          filterAction = 'Search term removed';
         }
       }
     }
@@ -297,14 +298,18 @@ function filterSuccessUpdates(changeCount) {
     $('.is-loading').removeClass('is-loading').addClass('is-successful');
 
     // build message with number of results returned
+
     if (changeCount > 0) {
-      message = filterAction + '<br>' +
-      '<strong>Added  ' + changeCount.toLocaleString() + '</strong> results.';
+      filterResult = 'Expanded by ' + changeCount.toLocaleString() + ' results';
+    }
+    else if (changeCount === 0) {
+      filterResult = 'No change in results';
     }
     else {
-      message = filterAction + '<br>' +
-      '<strong>Removed ' + Math.abs(changeCount).toLocaleString() + '</strong> results.';
+      filterResult = 'Narrowed by ' + Math.abs(changeCount).toLocaleString() + ' results';
     }
+
+    message = '<strong>' + filterAction + '</strong><br>' + filterResult;
 
     if ($filterMessage.length) {
       $filterMessage.fadeOut().remove();

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -306,7 +306,7 @@ function filterSuccessUpdates(changeCount) {
       filterResult = 'No change in results';
     }
     else {
-      filterResult = Math.abs(changeCount).toLocaleString() + ' less results';
+      filterResult = Math.abs(changeCount).toLocaleString() + ' fewer results';
     }
 
     message = '<strong>' + filterAction + '</strong><br>' + filterResult;

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -617,7 +617,7 @@ DataTable.prototype.fetchError = function() {
   $('.filter__message').remove();
 
   // text search error message
-  if (updateChangedEl.type === 'text' && $(updateChangedEl).hasClass('tt-input') === false) {
+  if ($(updateChangedEl).attr('type') === 'text' && $(updateChangedEl).hasClass('tt-input') === false) {
     $(updateChangedEl).parent().after($(errorMessage));
   }
   else {

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -618,7 +618,7 @@ DataTable.prototype.fetchError = function() {
     .after($('<div class="filter__message filter__message--error">' +
       '<strong>We had trouble processing your request</strong><br>' +
       'Please try again. If you still have trouble ' +
-      '<span class="js-filter-feedback">let us know</a></div>'))
+      '<button class="js-filter-feedback">let us know</button></div>'))
     .hide().fadeIn();
 
   self.$processing.hide();


### PR DESCRIPTION
Based on the discussions on #1397, update filter success messaging to more/less:

<img width="293" alt="screen shot 2016-08-17 at 3 47 58 pm" src="https://cloud.githubusercontent.com/assets/24054/17755994/1f594504-6492-11e6-9769-b4f623071f9a.png"> <img width="298" alt="screen shot 2016-08-17 at 3 48 02 pm" src="https://cloud.githubusercontent.com/assets/24054/17755995/1f6b8476-6492-11e6-94bb-4c3af3db809f.png">

Include a message after filter errors:

<img width="1217" alt="screen shot 2016-08-17 at 3 43 38 pm" src="https://cloud.githubusercontent.com/assets/24054/17756052/6993dada-6492-11e6-9b4d-535a3afb8be9.png">

Goes along with 18F/fec-style#478

cc: @noahmanger 