### PR TITLE
Adding support for efiling views of reports

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -264,7 +264,7 @@ table_columns = OrderedDict([
     ('communication-costs', ['Committee', 'Support / oppose', 'Candidate', 'Amount', 'Date']),
     ('disbursements', ['Spender', 'Recipient', 'State', 'Purpose', 'Disbursement date', 'Amount']),
     ('electioneering-communications', ['Spender', 'Candidate mentioned','Number of candidates', 'Amount per candidate', 'Date', 'Disbursement amount' ]),
-    ('filings', ['Filer name', 'Document', 'Amendment indicator', 'Pages', 'Receipt date']),
+    ('filings', ['Filer name', 'Document', 'Amendment indicator', 'Receipt date']),
     ('independent-expenditures', ['Spender', 'Support / oppose', 'Candidate', 'Description', 'Expenditure date', 'Amount']),
     ('individual-contributions', ['Recipient', 'Contributor name', 'State', 'Employer', 'Receipt date', 'Amount']),
     ('receipts', ['Recipient', 'Contributor name', 'State', 'Receipt date', 'Amount']),

--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -268,8 +268,8 @@ table_columns = OrderedDict([
     ('independent-expenditures', ['Spender', 'Support / oppose', 'Candidate', 'Description', 'Expenditure date', 'Amount']),
     ('individual-contributions', ['Recipient', 'Contributor name', 'State', 'Employer', 'Receipt date', 'Amount']),
     ('receipts', ['Recipient', 'Contributor name', 'State', 'Receipt date', 'Amount']),
-    ('reports-presidential', ['Committee ID', 'Report type', 'Coverage start date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
-    ('reports-house-senate', ['Committee ID', 'Report type', 'Coverage start date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
-    ('reports-pac-party', ['Committee ID', 'Report type', 'Coverage start date', 'Coverage end date', 'Total receipts', 'Total disbursements', 'Total independent expenditures']),
-    ('reports-ie-only', ['Committee ID', 'Report type', 'Coverage start date', 'Coverage end date', 'Total contributions', 'Total independent expenditures'])
+    ('reports-presidential', ['Committee ID', 'Report type', 'Receipt date', 'Coverage start date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
+    ('reports-house-senate', ['Committee ID', 'Report type', 'Receipt date', 'Coverage start date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
+    ('reports-pac-party', ['Committee ID', 'Report type', 'Receipt date', 'Coverage start date', 'Coverage end date', 'Total receipts', 'Total disbursements', 'Total independent expenditures']),
+    ('reports-ie-only', ['Committee ID', 'Report type', 'Receipt date', 'Coverage start date', 'Coverage end date', 'Total contributions', 'Total independent expenditures'])
 ])

--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -264,7 +264,7 @@ table_columns = OrderedDict([
     ('communication-costs', ['Committee', 'Support / oppose', 'Candidate', 'Amount', 'Date']),
     ('disbursements', ['Spender', 'Recipient', 'State', 'Purpose', 'Disbursement date', 'Amount']),
     ('electioneering-communications', ['Spender', 'Candidate mentioned','Number of candidates', 'Amount per candidate', 'Date', 'Disbursement amount' ]),
-    ('filings', ['Filer name', 'Document', 'Amendment indicator', 'Receipt date']),
+    ('filings', ['Filer name', 'Document', 'Amendment indicator', 'Pages', 'Receipt date']),
     ('independent-expenditures', ['Spender', 'Support / oppose', 'Candidate', 'Description', 'Expenditure date', 'Amount']),
     ('individual-contributions', ['Recipient', 'Contributor name', 'State', 'Employer', 'Receipt date', 'Amount']),
     ('receipts', ['Recipient', 'Contributor name', 'State', 'Receipt date', 'Amount']),

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -170,7 +170,7 @@
               <li><a href="{{ url_for('reports', form_type='ie-only', is_amended='false') }}">Independent expenditure (Form 5) filer reports</a></li>
             </ul>
             <ul class="grid__item list--spacious t-sans">
-              <li><a class="t-all-data" href="{{ url_for('filings', max_receipt_date=today() | date(fmt='%m-%d-%Y')) }}">All filings</a></li>
+              <li><a class="t-all-data" href="{{ url_for('filings'}}">All filings</a></li>
             </ul>
           </div>
         </div>

--- a/openfecwebapp/templates/partials/filings-filter.html
+++ b/openfecwebapp/templates/partials/filings-filter.html
@@ -12,28 +12,7 @@ Filter reports
 
 {% block filters %}
 <div class="filters__inner">
-  <fieldset class="filter toggles toggles--vertical js-filter js-toggle-filter js-table-switcher">
-    <legend class="label t-inline-block">Data type</legend>
-    <div class="tooltip__container">
-      <button class="tooltip__trigger" type="button" aria-controls="data-type-tooltip"><span class="u-visually-hidden">Learn more</span></button>
-      <div id="data-type-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
-        <div class="tooltip__content">
-          <strong>eFiling data</strong>
-          <p class="tooltip__content">eFiling data is made available to the public quickly after a committee files a report electronically with the Commission. The information available in these files comes directly from the committee's report in a raw data format. Use processed data to access more comprehensive search options and all years of data.</p>
-          <strong>Processed data</strong>
-          <p class="tooltip__content">Processed data has been reviewed by the FEC using a multi-step process. This process can take days (for electronic filings) or weeks (for paper filings). Use processed data to comprehensively search all FEC data, which includes eFilings, once they're processed. Use eFiling data to access the most recent, raw information.</p>
-        </div>
-      </div>
-    </div>
-    <label for="switcher-processed" class="toggle">
-      <input type="radio" class="toggle" value="processed" id="switcher-processed" checked name="data_type">
-      <span class="button--alt">Processed data</span>
-    </label>
-    <label for="switcher-efilings" class="toggle">
-      <input type="radio" class="toggle" value="efiling" id="switcher-efilings" name="data_type">
-      <span class="button--alt">eFilings</span>
-    </label>
-  </fieldset>
+{% include 'partials/filters/efiling.html' %}
 </div>
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
   <button type="button" class="js-accordion-trigger accordion__button">Filer</button>

--- a/openfecwebapp/templates/partials/filters/efiling.html
+++ b/openfecwebapp/templates/partials/filters/efiling.html
@@ -1,0 +1,22 @@
+  <fieldset class="filter toggles toggles--vertical js-filter js-toggle-filter js-table-switcher">
+    <legend class="label t-inline-block">Data type</legend>
+    <div class="tooltip__container">
+      <button class="tooltip__trigger" type="button" aria-controls="data-type-tooltip"><span class="u-visually-hidden">Learn more</span></button>
+      <div id="data-type-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
+        <div class="tooltip__content">
+          <strong>eFiling data</strong>
+          <p class="tooltip__content">eFiling data is made available to the public quickly after a committee files a report electronically with the Commission. The information available in these files comes directly from the committee's report in a raw data format. Use processed data to access more comprehensive search options and all years of data.</p>
+          <strong>Processed data</strong>
+          <p class="tooltip__content">Processed data has been reviewed by the FEC using a multi-step process. This process can take days (for electronic filings) or weeks (for paper filings). Use processed data to comprehensively search all FEC data, which includes eFilings, once they're processed. Use eFiling data to access the most recent, raw information.</p>
+        </div>
+      </div>
+    </div>
+    <label for="switcher-processed" class="toggle">
+      <input type="radio" class="toggle" value="processed" id="switcher-processed" checked name="data_type">
+      <span class="button--alt">Processed data</span>
+    </label>
+    <label for="switcher-efilings" class="toggle">
+      <input type="radio" class="toggle" value="efiling" id="switcher-efilings" name="data_type">
+      <span class="button--alt">eFilings</span>
+    </label>
+  </fieldset>

--- a/openfecwebapp/templates/partials/reports-filter.html
+++ b/openfecwebapp/templates/partials/reports-filter.html
@@ -13,6 +13,9 @@ Filter reports
 {% endblock %}
 
 {% block filters %}
+<div class="filters__inner">
+{% include 'partials/filters/efiling.html' %}
+</div>
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
   <button type="button" class="js-accordion-trigger accordion__button">Filer</button>
   <div class="accordion__content">

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -42,8 +42,7 @@ var receiptDateColumn = {
   render: function(data, type, row, meta) {
     if (meta.settings.oInit.path.indexOf('efile') >= 0) {
       var parsed = moment(row.receipt_date, 'YYYY-MM-DDTHH:mm:ss');
-      // return parsed.isValid() ? parsed.format('MM-DD-YYYY, h:mma') : 'Invalid date';
-      return parsed;
+      return parsed.isValid() ? parsed.format('MM-DD-YYYY, h:mma') : 'Invalid date';
     } else {
       return data;
     }
@@ -413,7 +412,7 @@ var reports = {
     render: renderCommitteeColumn
   },
   pdf_url: columnHelpers.urlColumn('pdf_url', {
-    data: 'report_type_full',
+    data: 'report_type',
     className: 'all column--medium',
     orderable: false
   }),

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -49,6 +49,15 @@ var receiptDateColumn = {
   }
 };
 
+var pagesColumn = {
+  data: 'beginning_image_number',
+  orderable: false,
+  className: 'min-tablet hide-panel column--small',
+  render: function(data, type, row) {
+    return row.ending_image_number - row.beginning_image_number + 1;
+  }
+};
+
 var candidateColumn = columnHelpers.formattedColumn(function(data, type, row) {
   if (row) {
     return columnHelpers.buildEntityLink(row.candidate_name, helpers.buildAppUrl(['candidate', row.candidate_id]), 'candidate');
@@ -260,11 +269,7 @@ var filings = {
       }
     }
   },
-  pages: {
-    data: 'pages',
-    className: 'min-tablet hide-efiling column--small',
-    orderable: true,
-  },
+  pages: pagesColumn,
   amendment_indicator: amendmentIndicatorColumn,
   receipt_date: receiptDateColumn,
   coverage_start_date: dateColumn({data: 'coverage_start_date', className: 'min-tablet hide-panel column--med', orderable: false}),

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -35,6 +35,21 @@ var modalTriggerColumn = {
   }
 };
 
+var receiptDateColumn = {
+  data: 'receipt_date',
+  className: 'min-tablet hide-panel column--med',
+  orderable: true,
+  render: function(data, type, row, meta) {
+    if (meta.settings.oInit.path.indexOf('efile') >= 0) {
+      var parsed = moment(row.receipt_date, 'YYYY-MM-DDTHH:mm:ss');
+      // return parsed.isValid() ? parsed.format('MM-DD-YYYY, h:mma') : 'Invalid date';
+      return parsed;
+    } else {
+      return data;
+    }
+  }
+};
+
 var candidateColumn = columnHelpers.formattedColumn(function(data, type, row) {
   if (row) {
     return columnHelpers.buildEntityLink(row.candidate_name, helpers.buildAppUrl(['candidate', row.candidate_id]), 'candidate');
@@ -252,19 +267,7 @@ var filings = {
     orderable: true,
   },
   amendment_indicator: amendmentIndicatorColumn,
-  receipt_date: {
-    data: 'receipt_date',
-    className: 'min-tablet hide-panel column--med',
-    orderable: true,
-    render: function(data, type, row, meta) {
-      if (meta.settings.oInit.path.indexOf('efile') >= 0) {
-        var parsed = moment(row.receipt_date, 'YYYY-MM-DDTHH:mm:ss');
-        return parsed.isValid() ? parsed.format('MM-DD-YYYY, h:mma') : 'Invalid date';
-      } else {
-        return data;
-      }
-    }
-  },
+  receipt_date: receiptDateColumn,
   coverage_start_date: dateColumn({data: 'coverage_start_date', className: 'min-tablet hide-panel column--med', orderable: false}),
   coverage_end_date: dateColumn({data: 'coverage_end_date', className: 'min-tablet hide-panel column--med', orderable: false}),
   total_receipts: currencyColumn({data: 'total_receipts', className: 'min-desktop hide-panel column--number'}),
@@ -414,6 +417,7 @@ var reports = {
     className: 'all column--medium',
     orderable: false
   }),
+  receipt_date: receiptDateColumn,
   coverage_start_date: dateColumn({
     data: 'coverage_start_date',
     className: 'min-tablet hide-panel column--med',
@@ -423,11 +427,6 @@ var reports = {
     data: 'coverage_end_date',
     className: 'min-tablet hide-panel column--med',
     orderable: true
-  }),
-  receipt_date: dateColumn({
-    data: 'receipt_date',
-    className: 'min-tablet hide-panel column--med',
-    orderable: false
   }),
   receipts: currencyColumn({
     data: 'total_receipts_period',

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -40,11 +40,13 @@ var receiptDateColumn = {
   className: 'min-tablet hide-panel column--med',
   orderable: true,
   render: function(data, type, row, meta) {
+    var parsed;
     if (meta.settings.oInit.path.indexOf('efile') >= 0) {
-      var parsed = moment(row.receipt_date, 'YYYY-MM-DDTHH:mm:ss');
+      parsed = moment(row.receipt_date, 'YYYY-MM-DDTHH:mm:ss');
       return parsed.isValid() ? parsed.format('MM-DD-YYYY, h:mma') : 'Invalid date';
     } else {
-      return data;
+      parsed = moment(row.receipt_date, 'YYYY-MM-DDTHH:mm:ss');
+      return parsed.isValid() ? parsed.format('MM-DD-YYYY') : 'Invalid date';
     }
   }
 };

--- a/static/js/pages/filings.js
+++ b/static/js/pages/filings.js
@@ -13,7 +13,7 @@ var TableSwitcher = require('../modules/table-switcher').TableSwitcher;
 var columns = columnHelpers.getColumns(
   columns.filings,
   [
-    'filer_name', 'pdf_url', 'amendment_indicator', 'receipt_date', 'modal_trigger'
+    'filer_name', 'pdf_url', 'amendment_indicator', 'pages', 'receipt_date', 'modal_trigger'
   ]
 );
 
@@ -27,7 +27,7 @@ $(document).ready(function() {
     path: ['filings'],
     columns: columns,
     rowCallback: filings.renderRow,
-    order: [[3, 'desc']],
+    order: [[4, 'desc']],
     hideColumns: '.hide-processed',
     useFilters: true,
     useExport: true,

--- a/static/js/pages/filings.js
+++ b/static/js/pages/filings.js
@@ -13,7 +13,7 @@ var TableSwitcher = require('../modules/table-switcher').TableSwitcher;
 var columns = columnHelpers.getColumns(
   columns.filings,
   [
-    'filer_name', 'pdf_url', 'amendment_indicator', 'pages', 'receipt_date', 'modal_trigger'
+    'filer_name', 'pdf_url', 'amendment_indicator', 'receipt_date', 'modal_trigger'
   ]
 );
 
@@ -27,7 +27,7 @@ $(document).ready(function() {
     path: ['filings'],
     columns: columns,
     rowCallback: filings.renderRow,
-    order: [[4, 'desc']],
+    order: [[3, 'desc']],
     hideColumns: '.hide-processed',
     useFilters: true,
     useExport: true,

--- a/static/js/pages/reports.js
+++ b/static/js/pages/reports.js
@@ -7,6 +7,7 @@ var $ = require('jquery');
 var tables = require('../modules/tables');
 var columns = require('../modules/columns');
 var columnHelpers = require('../modules/column-helpers');
+var TableSwitcher = require('../modules/table-switcher').TableSwitcher;
 
 var candidateTemplate = require('../../templates/reports/candidate.hbs');
 var pacPartyTemplate = require('../../templates/reports/pac.hbs');
@@ -15,7 +16,7 @@ var ieOnlyTemplate = require('../../templates/reports/ie-only.hbs');
 var pageTitle,
     pageTemplate,
     pageColumns,
-    columnKeys = ['committee', 'pdf_url', 'coverage_start_date', 'coverage_end_date'];
+    columnKeys = ['committee', 'pdf_url', 'receipt_date', 'coverage_start_date', 'coverage_end_date'];
 
 if (context.form_type === 'presidential') {
   pageTitle = 'Presidential committee reports';
@@ -44,6 +45,7 @@ $(document).ready(function() {
   var $table = $('#results');
   new tables.DataTable($table, {
     autoWidth: false,
+    tableSwitcher: true,
     title: pageTitle,
     path: ['reports', context.form_type],
     columns: pageColumns,
@@ -57,4 +59,17 @@ $(document).ready(function() {
       afterRender: tables.modalRenderFactory(pageTemplate)
     }
   });
+
+  new TableSwitcher('.js-table-switcher', {
+    efiling: {
+      path: ['efile', 'reports', context.form_type],
+      disableFilters: true,
+      enabledFilters: ['committee_id', 'data_type', 'receipt_date'],
+      disableExport: true
+    },
+    processed: {
+      path: ['reports', context.form_type],
+      disableExport: false
+    }
+  }).init();
 });

--- a/static/js/pages/reports.js
+++ b/static/js/pages/reports.js
@@ -51,7 +51,7 @@ $(document).ready(function() {
     columns: pageColumns,
     rowCallback: tables.modalRenderRow,
     // Order by coverage date descending
-    order: [[3, 'desc']],
+    order: [[2, 'desc']],
     useFilters: true,
     useExport: true,
     disableExport: true,


### PR DESCRIPTION
This adds support for toggling between efile data and processed data on the new reports pages. Here's what it does:
- Moves the efile toggle to a partial so filings filters and reports filters can share it
- Adds a column to reports tables for "receipt date"
- Initializes the `TableSwitcher` component for the reports tables

After taking a first pass at this I found a few inconsistencies between the end points that shouldn't be hard to change. 
