### PR TITLE
Bugfix/ao pagination

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -61,7 +61,14 @@ def load_legal_search_results(query, query_type='all', offset=0, limit=20):
     results['limit'] = limit
     results['offset'] = offset
 
+    if 'statutes' in results:
+        results['statutes_returned'] = len(results['statutes'])
+
+    if 'regulations' in results:
+        results['regulations_returned'] = len(results['regulations'])
+
     if 'advisory_opinions' in results:
+        results['advisory_opinions_returned'] = len(results['advisory_opinions'])
         grouped_aos = OrderedDict({})
         for ao in results['advisory_opinions']:
             if ao['no'] in grouped_aos:
@@ -91,11 +98,11 @@ def load_legal_advisory_opinion(ao_no):
     for document in documents:
         canonical_document = document
         if document['category'] == 'Final Opinion':
-            break        
-    
+            break
+
     if not canonical_document:
         return None
-    
+
     advisory_opinion = {
         'no' : ao_no,
         'date': canonical_document['date'],

--- a/openfecwebapp/templates/layouts/legal-doc-search-results.html
+++ b/openfecwebapp/templates/layouts/legal-doc-search-results.html
@@ -29,7 +29,7 @@
     {% if results.total_all %}
       {% block results %}{% endblock %}
       <div class="results-info">
-	<div class="dataTables_info">Showing {{ results.offset + 1 }}&ndash;{{ results.offset + result_entities|length }} of about {{ results.total_all }}</span></div>
+	<div class="dataTables_info">Showing {{ results.offset + 1 }}&ndash;{{ results.offset + results[result_type + '_returned'] }} of about {{ results.total_all }}</span></div>
 	<div class="dataTables_paginate">
 	  {% if results.offset > 0 %}
 	  <a class="paginate_button previous" href="{{ url_for(result_type, search=query, offset=(results.offset - results.limit)) }}#results-{{ result_type }}">Previous</a>

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -58,7 +58,7 @@
             </div>
             {% if results.total_statutes %}
             <div class="results-info__right">
-              <span class="results-info__details">1&ndash;{{ results.statutes|length }} of <a href="{{ url_for('statutes', search=query, search_type='statutes') }}"><strong>{{ results.total_statutes }}</strong> results</a></span>
+              <span class="results-info__details">1&ndash;{{ results.statutes_returned }} of <a href="{{ url_for('statutes', search=query, search_type='statutes') }}"><strong>{{ results.total_statutes }}</strong> results</a></span>
             </div>
             {% endif %}
           </div>
@@ -94,7 +94,7 @@
             </div>
             {% if results.total_regulations %}
             <div class="results-info__right">
-              <span class="results-info__details">1&ndash;{{ results.regulations|length }} of <a href="{{ url_for('regulations', search=query, search_type='regulations') }}"><strong>{{ results.total_regulations }}</strong> results</a></span>
+              <span class="results-info__details">1&ndash;{{ results.regulations_returned }} of <a href="{{ url_for('regulations', search=query, search_type='regulations') }}"><strong>{{ results.total_regulations }}</strong> results</a></span>
             </div>
             {% endif %}
           </div>
@@ -129,7 +129,7 @@
             </div>
             {% if results.total_advisory_opinions %}
             <div class="results-info__right">
-              <span class="results-info__details">1&ndash;{{ results.advisory_opinions|length }} of
+              <span class="results-info__details">1&ndash;{{ results.advisory_opinions_returned }} of
                 <a href="{{ url_for('advisory_opinions', search=query, search_type='advisory_opinions') }}">
                   <strong>{{ results.total_advisory_opinions }}</strong> results
                 </a></span>

--- a/tests/unit/test_legal_search.py
+++ b/tests/unit/test_legal_search.py
@@ -18,7 +18,7 @@ class TestLegalSearch(unittest.TestCase):
     @mock.patch.object(api_caller, 'load_legal_search_results')
     def test_no_query(self, load_legal_search_results):
         response = self.app.get('/legal/search/')
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         load_legal_search_results.assert_not_called()
 
     def test_search_type_regulations_redirects(self):
@@ -26,15 +26,15 @@ class TestLegalSearch(unittest.TestCase):
                 data={
                     'search': 'in kind donation',
                     'search_type': 'regulations'})
-        self.assertEqual(response.status_code, 302)
+        assert response.status_code == 302
 
         url = urlparse(response.location)
         query = parse_qs(url.query)
-        self.assertEqual(url.path, '/legal/search/regulations/')
-        self.assertIn('search', query)
-        self.assertIn('search_type', query)
-        self.assertEqual(query['search'], ['in kind donation'])
-        self.assertEqual(query['search_type'], ['regulations'])
+        assert url.path == '/legal/search/regulations/'
+        assert 'search' in query
+        assert 'search_type' in query
+        assert query['search'] == ['in kind donation']
+        assert query['search_type'] == ['regulations']
 
     @mock.patch.object(api_caller, 'load_legal_search_results')
     def test_search_universal(self, load_legal_search_results):
@@ -44,7 +44,7 @@ class TestLegalSearch(unittest.TestCase):
                     'search': 'in kind donation',
                     'search_type': 'all'})
 
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         load_legal_search_results.assert_called_once_with('in kind donation', 'all', limit=3)
 
     @mock.patch.object(api_caller, 'load_legal_search_results')
@@ -55,8 +55,9 @@ class TestLegalSearch(unittest.TestCase):
                     'search': 'in kind donation',
                     'search_type': 'regulations'})
 
-        self.assertEqual(response.status_code, 200)
-        load_legal_search_results.assert_called_once_with('in kind donation', 'regulations', offset=0)
+        assert response.status_code == 200
+        load_legal_search_results.assert_called_once_with('in kind donation',
+            'regulations', offset=0)
 
     @mock.patch.object(api_caller, 'load_legal_search_results')
     def test_search_advisory_opinions(self, load_legal_search_results):
@@ -65,9 +66,10 @@ class TestLegalSearch(unittest.TestCase):
                 data={
                     'search': 'in kind donation',
                     'search_type': 'advisory_opinions'})
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
-        load_legal_search_results.assert_called_once_with('in kind donation', 'advisory_opinions', offset=0)
+        load_legal_search_results.assert_called_once_with('in kind donation',
+            'advisory_opinions', offset=0)
 
     @mock.patch.object(api_caller, 'load_legal_search_results')
     def test_search_pagination(self, load_legal_search_results):
@@ -77,8 +79,9 @@ class TestLegalSearch(unittest.TestCase):
                     'search': 'in kind donation',
                     'search_type': 'regulations',
                     'offset': 20})
-        self.assertEqual(response.status_code, 200)
-        load_legal_search_results.assert_called_once_with('in kind donation', 'regulations', offset=20)
+        assert response.status_code == 200
+        load_legal_search_results.assert_called_once_with('in kind donation',
+         'regulations', offset=20)
 
     @mock.patch.object(api_caller, 'load_legal_search_results')
     def test_search_statutes(self, load_legal_search_results):
@@ -87,7 +90,7 @@ class TestLegalSearch(unittest.TestCase):
                 data={
                     'search': 'in kind donation',
                     'search_type': 'statutes'})
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         load_legal_search_results.assert_called_once_with('in kind donation', 'statutes', offset=0)
 
     @mock.patch.object(api_caller, '_call_api')


### PR DESCRIPTION
Web app now consistently returns number of documents, even in case of AOs. Resolves [#211](https://github.com/18F/fec-eregs/issues/211). This PR also tests some of the grouping logic we implemented last sprint and refactors older tests to use `assert` keyword syntax.