### PR TITLE
Adding the missing data attribute for the efiling filter

### DIFF
--- a/openfecwebapp/templates/partials/filters/efiling.html
+++ b/openfecwebapp/templates/partials/filters/efiling.html
@@ -1,4 +1,4 @@
-  <fieldset class="filter toggles toggles--vertical js-filter js-toggle-filter js-table-switcher">
+  <fieldset class="filter toggles toggles--vertical js-filter js-table-switcher" data-filter="toggle">
     <legend class="label t-inline-block">Data type</legend>
     <div class="tooltip__container">
       <button class="tooltip__trigger" type="button" aria-controls="data-type-tooltip"><span class="u-visually-hidden">Learn more</span></button>


### PR DESCRIPTION
Fixes the bug that was causing the broken filings and reports pages.