### PR TITLE
Switching links from source filings to source reports

### DIFF
--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -99,7 +99,7 @@
   <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide></div>
   <div role="dialog" class="modal__content" aria-lablledby="raised-modal-title">
     <div role="document">
-      <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide aria-label="Close this dialog window"></button>
+      <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide title="Close this dialog window"></button>
       <h2 id="raised-modal-title" tabindex="0">Methodology</h2>
       <p>This data includes Forms 3, 3P, 3X, 5, 7 and 9 from January 1, 2015 to July 31, 2016.</p>
       <h5>Methodology overview</h5>
@@ -130,7 +130,7 @@
   <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide></div>
   <div role="dialog" class="modal__content" aria-lablledby="spending-modal-title">
     <div role="document">
-      <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide aria-label="Close this dialog window"></button>
+      <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide title="Close this dialog window"></button>
       <h2 id="spending-modal-title">Methodology</h2>
       <p>This data includes Forms 3, 3P, 3X, 5, 7 and 9 from January 1, 2015 to July 31, 2016.</p>
       <h5>Methodology overview</h5>

--- a/openfecwebapp/templates/partials/candidate/financial-summary.html
+++ b/openfecwebapp/templates/partials/candidate/financial-summary.html
@@ -32,12 +32,7 @@
           aggregate.cash != 0 or
           aggregate.debt != 0
          %}
-         {% if office == 'P' %}
-          {% set form_type = 'presidential' %}
-         {% else %}
-          {% set form_type = 'house-senate'  %}
-         {% endif %}
-           <a href="{{ url_for('reports', form_type=form_type, committee_id=committee_ids, cycle=aggregate_cycles, is_amended='false' ) }}">
+           <a href="{{ url_for('reports', form_type=report_type, committee_id=committee_ids, cycle=aggregate_cycles, is_amended='false' ) }}">
              View source reports
            </a>
          {% endif %}

--- a/openfecwebapp/templates/partials/committee/financial-summary.html
+++ b/openfecwebapp/templates/partials/committee/financial-summary.html
@@ -1,9 +1,4 @@
 {% import 'macros/missing.html' as missing %}
-{% if committee_type == 'P' %}
-  {% set form_type = 'F3P' %}
-{% else %}
-  {% set form_type = 'F3' %}
-{% endif %}
 
 <section class="main" id="section-1" role="tabpanel" aria-hidden="true" aria-labelledby="section-1-heading">
   <div class="container">
@@ -11,13 +6,16 @@
       <div class="section__heading">
         <h2 class="heading__title heading__title--with-action" id="section-1-heading">
           Financial summary: {{ cycle|fmt_year_range }}
+          {{ committee_type }}
+          {{ committee_designation }}
+          {{ report_type }}
         </h2>
-        <a class="button button--alt button--browse heading__action" href="{{ url_for('filings',
-           form_type=[form_type],
+        <a class="button button--alt button--browse heading__action" href="{{ url_for('reports',
+           form_type=report_type,
            committee_id=committee_id,
            cycle=cycle,
            ) }}">
-           View source filings
+           View source reports
          </a>
       </div>
       <p>Get the full picture of all of the money received and spent by this <span class="term" data-term="Committee">committee</span>.</p>

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -77,15 +77,16 @@ def render_committee(committee, candidates, cycle):
 
     # add related candidates a level below
     tmpl_vars['candidates'] = candidates
-
     financials = api_caller.load_cmte_financials(committee['committee_id'], cycle=cycle)
+
+    tmpl_vars['report_type'] = report_types.get(committee['committee_type'], 'pac-party')
     tmpl_vars['reports'] = financials['reports']
     tmpl_vars['totals'] = financials['totals']
 
     tmpl_vars['context_vars'] = {
         'cycle': cycle,
         'timePeriod': str(cycle - 1) + '–' + str(cycle),
-        'name': committee['name']
+        'name': committee['name'],
     }
     return render_template('committees-single.html', **tmpl_vars)
 
@@ -102,6 +103,13 @@ election_durations = {
     'P': 4,
     'S': 6,
     'H': 2,
+}
+
+report_types = {
+    'P': 'presidential',
+    'S': 'house-senate',
+    'H': 'house-senate',
+    'I': 'ie-only'
 }
 
 def render_candidate(candidate, committees, cycle, election_full=True):

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -158,6 +158,7 @@ def render_candidate(candidate, committees, cycle, election_full=True):
         None,
     )
 
+    tmpl_vars['report_type'] = report_types.get(candidate['office'])
     tmpl_vars['context_vars'] = {'cycles': candidate['cycles'], 'name': candidate['name']}
 
     return render_template('candidates-single.html', **tmpl_vars)


### PR DESCRIPTION
Replaces the one instance where "source filings" still linked to /filings/ rather than /reports/

Also moves the logic for determining the `report_type` to the `render_candidate` function in views.py

Resolves https://github.com/18F/openFEC-web-app/issues/1560

cc @LindsayYoung
