### PR TITLE
Fix/release fixes

### DIFF
--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -167,7 +167,8 @@
               <li><a href="{{ url_for('reports', form_type='presidential', is_amended='false') }}">Presidential committee reports</a></li>
               <li><a href="{{ url_for('reports', form_type='house-senate', is_amended='false') }}">House and Senate committee reports</a></li>
               <li><a href="{{ url_for('reports', form_type='pac-party', is_amended='false') }}">PAC and party committee reports</a></li>
-              <li><a href="{{ url_for('reports', form_type='ie-only', is_amended='false') }}">Independent expenditure (Form 5) filer reports</a></li>
+              <!-- Commenting out while page is in progress -->
+              <!--<li><a href="{{ url_for('reports', form_type='ie-only', is_amended='false') }}">Independent expenditure (Form 5) filer reports</a></li>-->
             </ul>
             <ul class="grid__item list--spacious t-sans">
               <li><a class="t-all-data" href="{{ url_for('filings') }}">All filings</a></li>

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -170,7 +170,7 @@
               <li><a href="{{ url_for('reports', form_type='ie-only', is_amended='false') }}">Independent expenditure (Form 5) filer reports</a></li>
             </ul>
             <ul class="grid__item list--spacious t-sans">
-              <li><a class="t-all-data" href="{{ url_for('filings'}}">All filings</a></li>
+              <li><a class="t-all-data" href="{{ url_for('filings') }}">All filings</a></li>
             </ul>
           </div>
         </div>

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -99,7 +99,7 @@
   <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide></div>
   <div role="dialog" class="modal__content" aria-lablledby="raised-modal-title">
     <div role="document">
-      <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide aria-label="Close this dialog window"></button>
+      <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide title="Close this dialog window"></button>
       <h2 id="raised-modal-title" tabindex="0">Methodology</h2>
       <p>This data includes Forms 3, 3P, 3X, 5, 7 and 9 from January 1, 2015 to July 31, 2016.</p>
       <h5>Methodology overview</h5>
@@ -130,7 +130,7 @@
   <div tabindex="-1" class="modal__overlay" data-a11y-dialog-hide></div>
   <div role="dialog" class="modal__content" aria-lablledby="spending-modal-title">
     <div role="document">
-      <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide aria-label="Close this dialog window"></button>
+      <button type="button" class="modal__close button--close--primary" data-a11y-dialog-hide title="Close this dialog window"></button>
       <h2 id="spending-modal-title">Methodology</h2>
       <p>This data includes Forms 3, 3P, 3X, 5, 7 and 9 from January 1, 2015 to July 31, 2016.</p>
       <h5>Methodology overview</h5>

--- a/static/js/pages/reports.js
+++ b/static/js/pages/reports.js
@@ -69,7 +69,7 @@ $(document).ready(function() {
     },
     processed: {
       path: ['reports', context.form_type],
-      disableExport: false
+      disableExport: true
     }
   }).init();
 });


### PR DESCRIPTION
Fixes a couple things for the release:
- Fixes a missing closing parentheses that was causing /data/advanced/ to not load
- Comments out the link to /reports/ie-only/ because that table is still missing the committee name column (I chose to comment it out rather than remove it, but can remove it if anyone prefers)
- Adds missing `title` attributes to modal close buttons to make HTML code sniffer happy
- Ensures that the export button on reports data pages is always disabled
