### PR TITLE
update copy to be U.S.C.

### DIFF
--- a/openfecwebapp/templates/partials/legal-search-results-statute.html
+++ b/openfecwebapp/templates/partials/legal-search-results-statute.html
@@ -6,7 +6,7 @@
   <div class="simple-table__row-group">
   {% for statute in statutes %}
     <div class="simple-table__row legal-search-result">
-        <div class="simple-table__cell"><a title="{{ statute.title }}.{{statute.no}}" href="{{ statute.url }}">{{ statute.title }} USC §{{ statute.no }}</a></div>
+        <div class="simple-table__cell"><a title="{{ statute.title }}.{{statute.no}}" href="{{ statute.url }}">{{ statute.title }} U.S.C. §{{ statute.no }}</a></div>
       <div class="simple-table__cell">
         <div class="legal-search-result__name">{{ statute.name }}</div>
         <div class="t-serif legal-search-result__hit">


### PR DESCRIPTION
Per https://18f.slack.com/archives/fec-partners/p1467229654000403 should be `U.S.C.` instead of USC.