### PR TITLE
Fix/report-fixes

### DIFF
--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -429,7 +429,7 @@ var reports = {
     render: renderCommitteeColumn
   },
   pdf_url: columnHelpers.urlColumn('pdf_url', {
-    data: 'report_type',
+    data: 'document_description',
     className: 'all column--medium',
     orderable: false
   }),

--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -25,7 +25,7 @@ function currency(value) {
   if (!isNaN(parseInt(value))) {
     return currencyFormatter.format(value);
   } else {
-    return null;
+    return '--';
   }
 }
 Handlebars.registerHelper('currency', currency);

--- a/static/templates/reports/candidate.hbs
+++ b/static/templates/reports/candidate.hbs
@@ -1,6 +1,6 @@
 <div class="panel__row">
   <div class="panel__heading">
-    <h4 class="panel__title">{{report_type_full}}
+    <h4 class="panel__title">{{document_description}}
     {{#if is_amended}}
       (This report has been amended)
     {{/if}}

--- a/static/templates/reports/candidate.hbs
+++ b/static/templates/reports/candidate.hbs
@@ -111,9 +111,6 @@
     {{#panelRow "Total loans received"}}
       {{{currency total_loans_received_period}}}
     {{/panelRow}}
-    {{#panelRow "Total loans received from candidates"}}
-      {{{currency loans_received_from_candidate_period}}}
-    {{/panelRow}}
     {{#panelRow "Loan repayments made"}}
       {{{currency total_loan_repayments_made_period}}}
     {{/panelRow}}

--- a/static/templates/reports/ie-only.hbs
+++ b/static/templates/reports/ie-only.hbs
@@ -1,6 +1,10 @@
 <div class="panel__row">
   <div class="panel__heading">
-    <h4 class="panel__title">{{report_type_full}}</h4>
+    <h4 class="panel__title">{{document_description}}
+    {{#if is_amended}}
+      (This report has been amended)
+    {{/if}}
+    </h4>
     <span class="panel__subtitle t-bold"><a href="{{basePath}}/committee/{{committee_id}}">{{ committee_name }}</a></span>
   </div>
   <table>

--- a/static/templates/reports/pac.hbs
+++ b/static/templates/reports/pac.hbs
@@ -1,6 +1,10 @@
 <div class="panel__row">
   <div class="panel__heading">
-    <h4 class="panel__title">{{report_type_full}}</h4>
+    <h4 class="panel__title">{{document_description}}
+    {{#if is_amended}}
+      (This report has been amended)
+    {{/if}}
+    </h4>
     <span class="panel__subtitle t-bold"><a href="{{basePath}}/committee/{{committee_id}}">{{ committee_name }}</a></span>
   </div>
   <table>


### PR DESCRIPTION
Adds `document_description` to tables and details panels.

Adds a default character `--` to show up in the tables and detail panels if a given record does not have the associated field, which seems to happen on efiling due to the data not being processed. 

![image](https://cloud.githubusercontent.com/assets/1696495/18142445/697f613c-6f72-11e6-8089-ba244a898d20.png)

![image](https://cloud.githubusercontent.com/assets/1696495/18142422/55c95d5a-6f72-11e6-9f34-258533f6d8b0.png)

This is done in the `currency` handlebars helper by detecting if the value passed is not a number, and if so, returning `--`. This way, `0` will still show up as `$0`, but instead of a bunch of mysteriously blank fields, it's clearer that the field is just missing.

I know we've talked about the trickiness of displaying 0s vs. nulls, and I think this is a good solution, but @LindsayYoung let me know if you disagree. 