### PR TITLE
Constrain document thumbnail grid to text-width

### DIFF
--- a/openfecwebapp/templates/legal-statutes-landing.html
+++ b/openfecwebapp/templates/legal-statutes-landing.html
@@ -18,7 +18,7 @@
   <div class="section__heading">
     <h2 class="heading__title">Full text of statutes</h2>
   </div>
-  <div class="content__section">
+  <div class="content__section content__section--narrow">
     <p>
       Specifically, the FEC interprets enforces the statutes found in Title 52, Subtitle III and Title 26, Subtitle H. There are two options for accessing these statutes:
     </p>


### PR DESCRIPTION
Depends on https://github.com/18F/fec-style/pull/493

@jenniferthibault pointed out that the document thumbnail grid should not overflow the text width.
![screenshot from 2016-08-31 14-47-49](https://cloud.githubusercontent.com/assets/509703/18147826/355d3a82-6f8b-11e6-8603-17b3a9f07e35.png)
