### PR TITLE
add disclaimers to search results pages

### DIFF
--- a/openfecwebapp/templates/layouts/legal-doc-search-results.html
+++ b/openfecwebapp/templates/layouts/legal-doc-search-results.html
@@ -61,6 +61,7 @@
     {% endif %}
   </div>
 </section>
+{% include 'partials/legal-disclaimer.html' %}
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
Currently the disclaimer is on the legal resource landing pages.  But we should have the standard beta disclaimer on our search results pages as well.