### PR TITLE
Adding printer-only logo

### DIFF
--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -54,6 +54,7 @@
           <img src="{{ url_for('static', filename='img/us_flag_small.png') }}" alt="US flag signifying that this is a United States Federal Government website">
         </span>
       </div>
+      <img src="{{ url_for('static', filename='img/print-logo.png') }}" class="u-print-only" alt="FEC logo">
       <a title="Home" href="{{ cms_url }}/" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
       <ul class="utility-nav list--flat">
         <li class="utility-nav__item is-disabled">About</li>


### PR DESCRIPTION
Adds the print logo from https://github.com/18F/fec-style/pull/496

Because certain browsers don't render background images it has to be included as an `img`.