### PR TITLE
Include archived MURs in legal search.

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -80,6 +80,9 @@ def load_legal_search_results(query, query_type='all', offset=0, limit=20):
             grouped_aos[ao_no].sort(key=lambda ao: ao['date'], reverse=True)
         results['advisory_opinions'] = grouped_aos
 
+    if 'murs' in results:
+        results['murs_returned'] = len(results['murs'])
+
     return results
 
 

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -56,8 +56,7 @@ def load_legal_search_results(query, query_type='all', offset=0, limit=20):
         filters['type'] = query_type
         filters['from_hit'] = offset
 
-    url = '/legal/search/'
-    results = _call_api(url, **filters)
+    results = _call_api('legal', 'search', **filters)
     results['limit'] = limit
     results['offset'] = offset
 

--- a/openfecwebapp/config.py
+++ b/openfecwebapp/config.py
@@ -28,7 +28,7 @@ environment = (
 )
 
 features = {
-
+    'legal_murs': bool(env.get_credential('FEC_FEATURE_LEGAL_MURS', '')),
 }
 
 # Whether the app should force HTTPS/HSTS.

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -309,6 +309,14 @@ def advisory_opinions(query, offset):
 def statutes(query, offset):
     return legal_doc_search(query, 'statutes', offset=offset)
 
+@app.route('/legal/search/enforcement-matters/')
+@use_kwargs({
+    'query': fields.Str(load_from='search'),
+    'offset': fields.Int(missing=0),
+})
+def murs(query, offset):
+    return legal_doc_search(query, 'murs', offset=offset)
+
 # TODO migrating from /legal/regulations -> /legal/search/regulations, eventually there will be a regulations landing page
 @app.route('/legal/regulations/')
 def regulations_landing(*args, **kwargs):

--- a/openfecwebapp/templates/legal-search-results-murs.html
+++ b/openfecwebapp/templates/legal-search-results-murs.html
@@ -1,0 +1,8 @@
+{% extends "layouts/legal-doc-search-results.html" %}
+{% set document_type_display_name = 'enforcement matters' %}
+
+{% block results %}
+{% with murs = results.murs %}
+{% include 'partials/legal-search-results-mur.html' %}
+{% endwith %}
+{% endblock %}

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -67,20 +67,7 @@
               <a class="button button--browse button--alt" href="{{ url_for('statutes', search=query, search_type='statutes') }}">View all results</a>
             </div>
           {% else %}
-            <div class="message message--alert">
-              <h2 class="message__title">No results</h2>
-              <p>Sorry, we didn&rsquo;t find any statutes matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your search{% endif %}.</p>
-              <div class="message--alert__bottom">
-                <p>Think this was a mistake?</p>
-                <ul class="list--buttons">
-                  {% if query %}
-                  <li><a class="button button--standard" href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources=Administrative_Fine%2CAdvisory_Opinion%2CAlternative_Dispute_Resolution%2CAudit_Reports%2CMatters_Under_Review%2CMatters_Under_Review_Archived%2CRulemaster%2CCandidate_Summary%2CCommittee_Summary%2Cfec.gov&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&">Try FEC.gov</a></li>
-                  {% endif %}
-                  <li><a class="button button--standard" href="mailto:{{ contact_email }}">Email our team</a></li>
-                  <li><a class="button button--standard" href="https://github.com/18f/fec/issues">File an issue</a></li>
-                </ul>
-              </div>
-            </div>
+          {{ legal.no_results('statutes', 'statutes', query, fec_resources=['fec.gov']) }}
           {% endif %}
         </div>
         <div id="results-regulations" class="content__section">
@@ -102,20 +89,7 @@
               <a class="button button--browse button--alt" href="{{ url_for('regulations', search=query, search_type='regulations') }}">View all results</a>
             </div>
           {% else %}
-            <div class="message message--alert">
-              <h2 class="message__title">No results</h2>
-              <p>Sorry, we didn&rsquo;t find any regulations matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your search{% endif %}.</p>
-              <div class="message--alert__bottom">
-                <p>Think this was a mistake?</p>
-                <ul class="list--buttons">
-                  {% if query %}
-                  <li><a class="button button--standard" href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources=Administrative_Fine%2CAdvisory_Opinion%2CAlternative_Dispute_Resolution%2CAudit_Reports%2CMatters_Under_Review%2CMatters_Under_Review_Archived%2CRulemaster%2CCandidate_Summary%2CCommittee_Summary%2Cfec.gov&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&">Try FEC.gov</a></li>
-                  {% endif %}
-                  <li><a class="button button--standard" href="mailto:{{ contact_email }}">Email our team</a></li>
-                  <li><a class="button button--standard" href="https://github.com/18f/fec/issues">File an issue</a></li>
-                </ul>
-              </div>
-            </div>
+          {{ legal.no_results('regulations', 'regulations', query, fec_resources=['Rulemaster', 'fec.gov']) }}
           {% endif %}
         </div>
         <div id="results-advisory-opinions" class="content__section">
@@ -142,20 +116,7 @@
               View all results</a>
             </div>
           {% else %}
-            <div class="message message--alert">
-              <h2 class="message__title">No results</h2>
-              <p>Sorry, we didn&rsquo;t find any advisory opinions matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your query{% endif %}.</p>
-              <div class="message--alert__bottom">
-                <p>Think this was a mistake?</p>
-                <ul class="list--buttons">
-                  {% if query %}
-                  <li><a class="button button--standard" href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources=Administrative_Fine%2CAdvisory_Opinion%2CAlternative_Dispute_Resolution%2CAudit_Reports%2CMatters_Under_Review%2CMatters_Under_Review_Archived%2CRulemaster%2CCandidate_Summary%2CCommittee_Summary%2Cfec.gov&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&">Try FEC.gov</a></li>
-                  {% endif %}
-                  <li><a class="button button--standard" href="mailto:{{ contact_email }}">Email our team</a></li>
-                  <li><a class="button button--standard" href="https://github.com/18f/fec/issues">File an issue</a></li>
-                </ul>
-              </div>
-            </div>
+          {{ legal.no_results('advisory opinions', 'advisory_opinions', query, fec_resources=['Advisory_Opinion', 'fec.gov']) }}
           {% endif %}
         </div>
       </section>

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -39,8 +39,15 @@
               Advisory opinions ({{ results.total_advisory_opinions|default(0) }})
               </a>
             </li>
-            <li class="is-disabled side-nav__item"><span class="side-nav__link">Enforcement Matters (TBD)</span></li>
-            <li class="is-disabled side-nav__item"><span class="side-nav__link">(Resource TBD)</span></li>
+            {% if features.legal_murs %}
+            <li class="side-nav__item">
+              <a class="side-nav__link" href="#results-murs">
+              Enforcement matters ({{ results.total_murs|default(0) }})
+              </a>
+            </li>
+            {% else %}
+            <li class="is-disabled side-nav__item"><span class="side-nav__link">Enforcement matters (TBD)</span></li>
+            {% endif %}
           </ul>
         </nav>
       </div>
@@ -119,6 +126,35 @@
           {{ legal.no_results('advisory opinions', 'advisory_opinions', query, fec_resources=['Advisory_Opinion', 'fec.gov']) }}
           {% endif %}
         </div>
+        {% if features.legal_murs %}
+        <div id="results-murs" class="content__section">
+          <div class="results-info results-info--simple">
+            <div class="results-info__left">
+              <h2 class="results-info__title">Enforcement matters</h2>
+            </div>
+            {% if results.total_murs %}
+            <div class="results-info__right">
+              <span class="results-info__details">1&ndash;{{ results.murs_returned }} of
+                <a href="{{ url_for('murs', search=query, search_type='murs') }}">
+                  <strong>{{ results.total_murs }}</strong> results
+                </a></span>
+            </div>
+            {% endif %}
+          </div>
+          {% if results.total_murs %}
+            {% with murs = results.murs %}
+            {% include 'partials/legal-search-results-mur.html' %}
+            {% endwith %}
+            <div class="results-info">
+              <a class="button button--browse button--alt"
+              href="{{ url_for('murs', search=query, search_type='murs') }}">
+              View all results</a>
+            </div>
+          {% else %}
+          {{ legal.no_results('enforcement matters', 'murs', query, fec_resources=['Administrative_Fine', 'Alternative_Dispute_Resolution', 'Audit_Reports', 'Matters_Under_Review', 'Matters_Under_Review_Archived', 'fec.gov']) }}
+          {% endif %}
+        </div>
+        {% endif %}
       </section>
     </div>
   </div>

--- a/openfecwebapp/templates/macros/legal.html
+++ b/openfecwebapp/templates/macros/legal.html
@@ -28,7 +28,11 @@
 {% endif %}
 <form id="{{ location }}-search" action="{{ url_for('legal_search') }}" autocomplete="off" class="search__container">
   <div class="combo combo--search {{ size }}">
-      {% set document_types = (('all', 'All'),('statutes', 'Statutes'),('regulations', 'Regulations'),('advisory_opinions', 'Advisory opinions')) %}
+    {% if features.legal_murs %}
+    {% set document_types = (('all', 'All'),('statutes', 'Statutes'),('regulations', 'Regulations'),('advisory_opinions', 'Advisory opinions'),('murs', 'Enforcement matters')) %}
+    {% else %}
+    {% set document_types = (('all', 'All'),('statutes', 'Statutes'),('regulations', 'Regulations'),('advisory_opinions', 'Advisory opinions')) %}
+    {% endif %}
     <select class="search__select {{select_class}}" name="search_type" aria-label="Select a document type">
       {% for value, name in document_types %}
       <option value="{{ value }}" {% if result_type == value %}selected{% endif %}>{{ name }}</option>

--- a/openfecwebapp/templates/macros/legal.html
+++ b/openfecwebapp/templates/macros/legal.html
@@ -45,3 +45,20 @@
   </div>
 </form>
 {% endmacro %}
+
+{% macro no_results(display_name, result_type, query, fec_resources=None) %}
+<div class="message message--alert">
+  <h2 class="message__title">No results</h2>
+  <p>Sorry, we didn&rsquo;t find any {{ display_name }} matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your query{% endif %}.</p>
+  <div class="message--alert__bottom">
+    <p>Think this was a mistake?</p>
+    <ul class="list--buttons">
+      {% if query %}
+      <li><a class="button button--standard" href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources={{ '%2C'.join(fec_resources or []) }}&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&">Try FEC.gov</a></li>
+      {% endif %}
+      <li><a class="button button--standard" href="mailto:{{ contact_email }}">Email our team</a></li>
+      <li><a class="button button--standard" href="https://github.com/18f/fec/issues">File an issue</a></li>
+    </ul>
+  </div>
+</div>
+{% endmacro %}

--- a/openfecwebapp/templates/partials/legal-search-results-mur.html
+++ b/openfecwebapp/templates/partials/legal-search-results-mur.html
@@ -10,7 +10,7 @@
         <div class="legal-search-result__name"><a title="{{ mur.name }}" href="{{ mur.url }}">MUR #{{ mur.no }}</a></div>
         <div><a title="{{ mur.name }}" href="{{ mur.url }}">{{ mur.name }}</a></div>
         {% if mur.archived or 1 %}
-        <div class="legal-mur__archive"><span class="legal-mur__archive-icon"><span class="u-visually-hidden">Icon representing an archived case</span></span> Archived case</div>
+        <div class="legal-mur__archive"><span class="legal-mur__archive-icon"><span class="u-visually-hidden">Icon representing an archived case</span></span>Archived case</div>
         {% endif %}
       </div>
       <div class="simple-table__cell">

--- a/openfecwebapp/templates/partials/legal-search-results-mur.html
+++ b/openfecwebapp/templates/partials/legal-search-results-mur.html
@@ -1,0 +1,28 @@
+<div class="simple-table simple-table--responsive simple-table--display legal-search-results">
+  <div class="simple-table__header">
+    <div class="simple-table__header-cell cell--25">Name</div>
+    <div class="simple-table__header-cell">Matches</div>
+  </div>
+  <div class="simple-table__row-group">
+  {% for mur in murs %}
+    <div class="simple-table__row legal-search-result">
+      <div class="simple-table__cell">
+        <div class="legal-search-result__name"><a title="{{ mur.name }}" href="{{ mur.url }}">MUR #{{ mur.no }}</a></div>
+        <div><a title="{{ mur.name }}" href="{{ mur.url }}">{{ mur.name }}</a></div>
+        {% if mur.archived or 1 %}
+        <div class="legal-mur__archive"><span class="legal-mur__archive-icon"><span class="u-visually-hidden">Icon representing an archived case</span></span> Archived case</div>
+        {% endif %}
+      </div>
+      <div class="simple-table__cell">
+        <div class="t-serif legal-search-result__hit">
+          &hellip;
+          {% for highlight in mur.highlights %}
+            {{ highlight|safe }} &hellip;
+          {% endfor %}
+        </div>
+        <div><strong>Date closed:</strong> {{ mur.close_date | date('%Y') | default('Unknown', True) }}</div>
+      </div>
+    </div>
+  {% endfor %}
+  </div>
+</div>


### PR DESCRIPTION
This makes progress on https://github.com/18F/fec-eregs/issues/225 using the existing styles. My next pass will be to align them better with the mockups.
- Uses a placeholder icon for the archived case.
- MURs are hidden behind the FEC_FEATURE_LEGAL_MURS feature flag.
- [x] depends on https://github.com/18F/fec-style/pull/500

![screenshot from 2016-09-08 16-58-20](https://cloud.githubusercontent.com/assets/509703/18370926/7e51e02a-75e5-11e6-949f-29425d04fe4f.png)
