### PR TITLE
[MERGE WITH GITFLOW]: Hotfix/chart typo

### DIFF
--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -69,7 +69,7 @@
         {{ overviews.overview(totals['raising'], 'raised', 'landing')}}
       </div>
     </section>
-    <section class="content__secton--extra" id="spending">
+    <section class="content__section--extra" id="spending">
       <h3 class="u-no-margin">Spending</h3>
       <p>The total amount spent, by group, in all elections up until specific points in time. Calculated using total disbursements, which include all payments and purchases made by a committee.</p>
       <p>This chart is a static snapshot. Search the most up-to-date data in the <a href="{{ url_for('advanced') }}">advanced data secton</a>.</p>

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -53,7 +53,7 @@
     <section class="content__section" id="raising">
       <h3 class="u-no-margin">Raising</h3>
       <p>The total amount raised, by group, until specific points in time.</p>
-      <p>This chart is a static snapshot. Search the most up-to-date data in the <a href="{{ url_for('advanced') }}">advanced data secton</a>.</p>
+      <p>This chart is a static snapshot. Search the most up-to-date data in the <a href="{{ url_for('advanced') }}">advanced data section</a>.</p>
       <div class="content__section">
         <div class="section__heading">
           <h4 class="heading__title heading__title--with-action t-upper">Cumulative amount raised in all elections, 2015–2016</h4>
@@ -72,7 +72,7 @@
     <section class="content__section--extra" id="spending">
       <h3 class="u-no-margin">Spending</h3>
       <p>The total amount spent, by group, in all elections up until specific points in time. Calculated using total disbursements, which include all payments and purchases made by a committee.</p>
-      <p>This chart is a static snapshot. Search the most up-to-date data in the <a href="{{ url_for('advanced') }}">advanced data secton</a>.</p>
+      <p>This chart is a static snapshot. Search the most up-to-date data in the <a href="{{ url_for('advanced') }}">advanced data section</a>.</p>
       <div class="content__section">
         <div class="section__heading">
           <h4 class="heading__title heading__title--with-action t-upper">Cumulative amount spent in all elections, 2015–2016</h4>


### PR DESCRIPTION
For @ccostino to review:

This fixes the typo in the chart copy, but I _also_ found the same typo in a style class surrounding it. Correcting the typo in the class adds more space between the chart elements, which is OK.

