### PR TITLE
Canonical MUR page (archive MURs)

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -120,6 +120,17 @@ def load_legal_advisory_opinion(ao_no):
     return advisory_opinion
 
 
+def load_legal_mur(mur_no):
+    #TODO use mur API
+    results = load_legal_search_results(mur_no, query_type='murs', offset=0, limit=1)
+    mur = results['murs'][0]
+
+    if not mur:
+        abort(404)
+
+    return mur
+
+
 def load_single_type(data_type, c_id, *path, **filters):
     data = _call_api(data_type, c_id, *path, **filters)
     return result_or_404(data)

--- a/openfecwebapp/filters.py
+++ b/openfecwebapp/filters.py
@@ -34,6 +34,16 @@ def date_filter(value, fmt='%m/%d/%Y'):
 def json_filter(value):
     return json.dumps(value)
 
+@app.template_filter('filesize')
+def filesize_filter(value):
+    units = ['B', 'KB', 'MB', 'GB']
+    unit = 0
+    while value > 1024 and unit < len(units):
+        value = value / 1024
+        unit += 1
+
+    return '%d %s' % (value, units[unit])
+
 def _unique(values):
     ret = []
     for value in values:

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -338,3 +338,12 @@ def advisory_opinion_page(ao_no):
         abort(404)
 
     return views.render_legal_advisory_opinion(advisory_opinion)
+
+@app.route('/legal/matter-under-review/<mur_no>/')
+def mur_page(mur_no):
+    mur = api_caller.load_legal_mur(mur_no)
+
+    if not mur:
+        abort(404)
+
+    return views.render_legal_mur(mur)

--- a/openfecwebapp/templates/legal-mur.html
+++ b/openfecwebapp/templates/legal-mur.html
@@ -11,7 +11,7 @@
   {{ breadcrumb.breadcrumbs('MUR #%s' % (mur.no,), breadcrumb_links) }}
 </header>
 
-<div class="container main">
+<div class="container main legal-mur">
   <div class="content__section">
     <div class="section__heading">
       <h1 class="heading__title heading__title--main">MUR #{{ mur.no }}</h1>
@@ -29,8 +29,8 @@
   </div>
   <div class="main__content--right">
     <section id="summary" class="content__section">
-      <div class="main__content legal-mur">
-        <h2>Summary</h2>
+      <div class="main__content">
+        <h2 class="t-ruled--bold t-ruled--bottom">Summary</h2>
         {% if mur.mur_type == 'archived' %}
         <div class="legal-mur__archive"><span class="legal-mur__archive-icon"><span class="u-visually-hidden">Icon representing an archived case</span></span>Archived case</div>
         {% endif %}
@@ -72,13 +72,13 @@
     <section id="documents" class="content__section">
       <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
       <div class="content__section">
-        <a class="button button--cta button--document button--lg" href="{{ mur.url }}" target="_blank">View case</a>
+        <a class="legal-mur__document-button button button--cta button--document button--lg" href="{{ mur.url }}" target="_blank">View case</a>
         (<a class="t-sans" href="{{ mur.url }}" target="_blank">{{ mur.pdf_size | filesize}}</a>)
       </div>
     </section>
     <section id="participants" class="content__section">
-      <h2 class="t-ruled--bold t-ruled--bottom">Participants</h2>
-      <table class="data-table data-table--text">
+      <h2 class="t-ruled--bold t-ruled--bottom u-no-margin">Participants</h2>
+      <table class="data-table data-table--text data-table--heading-borders">
         <thead>
           <tr>
             <th>Relationship</th>
@@ -108,6 +108,9 @@
           {% endif %}
         </tbody>
       </table>
+      <div class="results-info results-info--bottom">
+        <a class="legal-top" href="#">Top of page</a>
+      </div>
     </section>
   </div>
 </div>

--- a/openfecwebapp/templates/legal-mur.html
+++ b/openfecwebapp/templates/legal-mur.html
@@ -8,7 +8,7 @@
 
 {% block body %}
 <header class="page-header slab slab--primary">
-  {{ breadcrumb.breadcrumbs('MUR %s' % (mur.no,), breadcrumb_links) }}
+  {{ breadcrumb.breadcrumbs('MUR #%s' % (mur.no,), breadcrumb_links) }}
 </header>
 
 <div class="container main">
@@ -56,13 +56,13 @@
             <h5>Regulations</h5>
             <ul>
               {% for citation in mur.citations.regulations %}
-              <li><a href="{{ citation.url }}">{{ citation.text }}</a></li>
+              <li><a href="{{ citation.url }}" target="_blank">{{ citation.text }}</a></li>
               {% endfor %}
             </ul>
             <h5>Statutes</h5>
             <ul>
               {% for citation in mur.citations.us_code %}
-              <li><a href="{{ citation.url }}">{{ citation.text }}</a></li>
+              <li><a href="{{ citation.url }}" target="_blank">{{ citation.text }}</a></li>
               {% endfor %}
             </ul>
           </div>
@@ -72,8 +72,8 @@
     <section id="documents" class="content__section">
       <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
       <div class="content__section">
-        <a class="button button--cta button--document button--lg" href="{{ mur.url }}">View case</a>
-        (<a href="{{ mur.url }}">{{ mur.pdf_size | filesize}}</a>)
+        <a class="button button--cta button--document button--lg" href="{{ mur.url }}" target="_blank">View case</a>
+        (<a class="t-sans" href="{{ mur.url }}" target="_blank">{{ mur.pdf_size | filesize}}</a>)
       </div>
     </section>
     <section id="participants" class="content__section">

--- a/openfecwebapp/templates/legal-mur.html
+++ b/openfecwebapp/templates/legal-mur.html
@@ -1,0 +1,88 @@
+{% extends "layouts/main.html" %}
+{% import 'macros/breadcrumbs.html' as breadcrumb %}
+{% import 'macros/legal.html' as legal %}
+
+{% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources'), (url_for('advisory_opinions_landing'), 'Enforcement')] %}
+
+{% block title %}MUR #{{ mur.no }}{% endblock %}
+
+{% block body %}
+<header class="page-header slab slab--primary">
+  {{ breadcrumb.breadcrumbs('MUR %s' % (mur.no,), breadcrumb_links) }}
+</header>
+
+<div class="main">
+<div class="container">
+  <div class="row">
+    <div class="section__heading">
+      <h1 class="heading__title heading__title--main">MUR #{{ mur.no }}</h1>
+      <span class="heading__subtitle">{{ mur.name }}</span>
+    </div>
+    <section class="content__section">
+      <div class="main__content">
+        {% if mur.mur_type == 'archived' %}
+        <div class="legal-mur__archive"><span class="legal-mur__archive-icon"><span class="u-visually-hidden">Icon representing an archived case</span></span>Archived case</div>
+        {% endif %}
+        <div>
+        OPEN DATE: {{ mur.open_date }}
+        </div>
+        <div>
+        CLOSE DATE: {{ mur.close_date }}
+        </div>
+        <div>
+        SUBJECT:
+        {% for node in mur.subject %}
+        <div>
+          {{ legal.mur_subject(node) }}
+        </div>
+        {% endfor %}
+        </div>
+      </div>
+      <div class="sidebar-container">
+        <aside class="sidebar sidebar--primary">
+          <h4 class="sidebar__title">Cited in this case</h4>
+          <div class="sidebar__content">
+            <h5>Regulations</h5>
+            <ul>
+              {% for citation in mur.citations.regulations %}
+              <li><a href="{{ citation.url }}">{{ citation.text }}</a></li>
+              {% endfor %}
+            </ul>
+            <h5>Statutes</h5>
+            <ul>
+              {% for citation in mur.citations.us_code %}
+              <li><a href="{{ citation.url }}">{{ citation.text }}</a></li>
+              {% endfor %}
+            </ul>
+          </div>
+        </aside>
+      </div>
+    </section>
+    <section class="content__section">
+      <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
+      <div class="content__section">
+        <a class="button button--cta button--document button--lg" href="{{ mur.url }}">View case</a>
+        (<a href="{{ mur.url }}">{{ mur.pdf_size | filesize}}</a>)
+      </div>
+    </section>
+    <section class="content__section">
+      <h2 class="t-ruled--bold t-ruled--bottom">Participants</h2>
+      <table class="data-table data-table--text">
+        <thead>
+          <tr>
+            <th>Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for respondent in mur.respondents %}
+          <tr>
+            <td>{{ respondent }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </section>
+  </div>
+</div>
+</div>
+{% endblock %}

--- a/openfecwebapp/templates/legal-mur.html
+++ b/openfecwebapp/templates/legal-mur.html
@@ -80,15 +80,21 @@
       <table class="data-table data-table--text">
         <thead>
           <tr>
+            <th>Relationship</th>
             <th>Name</th>
           </tr>
         </thead>
         <tbody>
-          {% for respondent in mur.respondents %}
-          <tr>
-            <td>{{ respondent }}</td>
-          </tr>
-          {% endfor %}
+          {% if 'respondents' in mur and mur.respondents %}
+            {% for respondent in mur.respondents %}
+            <tr>
+              {% if loop.first %}
+              <td rowspan="{{ mur.respondents | length }}">Respondent(s)</td>
+              {% endif %}
+              <td>{{ respondent }}</td>
+            </tr>
+            {% endfor %}
+          {% endif %}
         </tbody>
       </table>
     </section>

--- a/openfecwebapp/templates/legal-mur.html
+++ b/openfecwebapp/templates/legal-mur.html
@@ -49,25 +49,31 @@
         {% endfor %}
         </div>
       </div>
+      {% if mur.citations.regulations or mur.citations.us_code %}
       <div class="sidebar-container">
         <aside class="sidebar sidebar--primary">
           <h4 class="sidebar__title">Cited in this case</h4>
           <div class="sidebar__content">
-            <h5>Regulations</h5>
-            <ul>
-              {% for citation in mur.citations.regulations %}
-              <li><a href="{{ citation.url }}" target="_blank">{{ citation.text }}</a></li>
-              {% endfor %}
-            </ul>
-            <h5>Statutes</h5>
-            <ul>
-              {% for citation in mur.citations.us_code %}
-              <li><a href="{{ citation.url }}" target="_blank">{{ citation.text }}</a></li>
-              {% endfor %}
-            </ul>
+            {% if mur.citations.regulations %}
+              <h5>Regulations</h5>
+              <ul>
+                {% for citation in mur.citations.regulations %}
+                <li><a href="{{ citation.url }}" target="_blank">{{ citation.text }}</a></li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+            {% if mur.citations.us_code %}
+              <h5>Statutes</h5>
+              <ul>
+                {% for citation in mur.citations.us_code %}
+                <li><a href="{{ citation.url }}" target="_blank">{{ citation.text }}</a></li>
+                {% endfor %}
+              </ul>
+            {% endif %}
           </div>
         </aside>
       </div>
+      {% endif %}
     </section>
     <section id="documents" class="content__section">
       <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>

--- a/openfecwebapp/templates/legal-mur.html
+++ b/openfecwebapp/templates/legal-mur.html
@@ -11,14 +11,24 @@
   {{ breadcrumb.breadcrumbs('MUR %s' % (mur.no,), breadcrumb_links) }}
 </header>
 
-<div class="main">
-<div class="container">
-  <div class="row">
+<div class="container main">
+  <div class="content__section">
     <div class="section__heading">
       <h1 class="heading__title heading__title--main">MUR #{{ mur.no }}</h1>
       <span class="heading__subtitle">{{ mur.name }}</span>
     </div>
-    <section class="content__section">
+  </div>
+  <div class="sidebar-container sidebar-container--left js-sticky-side" data-sticky-container="main">
+      <nav class="sidebar sidebar--neutral sidebar--left side-nav js-toc">
+        <ul class="sidebar__content">
+          <li class="side-nav__item"><a class="side-nav__link" href="#summary">Summary</a></li>
+          <li class="side-nav__item"><a class="side-nav__link" href="#documents">Documents</a></li>
+          <li class="side-nav__item"><a class="side-nav__link" href="#participants">Participants</a></li>
+        </ul>
+      </nav>
+  </div>
+  <div class="main__content--right">
+    <section id="summary" class="content__section">
       <div class="main__content">
         {% if mur.mur_type == 'archived' %}
         <div class="legal-mur__archive"><span class="legal-mur__archive-icon"><span class="u-visually-hidden">Icon representing an archived case</span></span>Archived case</div>
@@ -58,14 +68,14 @@
         </aside>
       </div>
     </section>
-    <section class="content__section">
+    <section id="documents" class="content__section">
       <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
       <div class="content__section">
         <a class="button button--cta button--document button--lg" href="{{ mur.url }}">View case</a>
         (<a href="{{ mur.url }}">{{ mur.pdf_size | filesize}}</a>)
       </div>
     </section>
-    <section class="content__section">
+    <section id="participants" class="content__section">
       <h2 class="t-ruled--bold t-ruled--bottom">Participants</h2>
       <table class="data-table data-table--text">
         <thead>
@@ -83,6 +93,5 @@
       </table>
     </section>
   </div>
-</div>
 </div>
 {% endblock %}

--- a/openfecwebapp/templates/legal-mur.html
+++ b/openfecwebapp/templates/legal-mur.html
@@ -86,9 +86,19 @@
           </tr>
         </thead>
         <tbody>
+          {% if 'complainants' in mur and mur.complainants %}
+            {% for complaintant in mur.complainants %}
+            <tr class="row-color-normal">
+              {% if loop.first %}
+              <td rowspan="{{ mur.complainants | length }}">Complaintant</td>
+              {% endif %}
+              <td>{{ complaintant }}</td>
+            </tr>
+            {% endfor %}
+          {% endif %}
           {% if 'respondents' in mur and mur.respondents %}
             {% for respondent in mur.respondents %}
-            <tr>
+            <tr class="row-color-contrast">
               {% if loop.first %}
               <td rowspan="{{ mur.respondents | length }}">Respondent(s)</td>
               {% endif %}

--- a/openfecwebapp/templates/legal-mur.html
+++ b/openfecwebapp/templates/legal-mur.html
@@ -29,18 +29,19 @@
   </div>
   <div class="main__content--right">
     <section id="summary" class="content__section">
-      <div class="main__content">
+      <div class="main__content legal-mur">
+        <h2>Summary</h2>
         {% if mur.mur_type == 'archived' %}
         <div class="legal-mur__archive"><span class="legal-mur__archive-icon"><span class="u-visually-hidden">Icon representing an archived case</span></span>Archived case</div>
         {% endif %}
-        <div>
-        OPEN DATE: {{ mur.open_date }}
+        <div class="legal-mur__property">
+          <strong>OPEN DATE:</strong> {{ mur.open_date | date('%Y-%m-%d') }}
         </div>
-        <div>
-        CLOSE DATE: {{ mur.close_date }}
+        <div class="legal-mur__property">
+        <strong>CLOSE DATE:</strong> {{ mur.close_date | date('%Y-%m-%d') }}
         </div>
-        <div>
-        SUBJECT:
+        <div class="legal-mur__property">
+        <strong>SUBJECT:</strong>
         {% for node in mur.subject %}
         <div>
           {{ legal.mur_subject(node) }}

--- a/openfecwebapp/templates/legal-mur.html
+++ b/openfecwebapp/templates/legal-mur.html
@@ -87,12 +87,12 @@
         </thead>
         <tbody>
           {% if 'complainants' in mur and mur.complainants %}
-            {% for complaintant in mur.complainants %}
+            {% for complainant in mur.complainants %}
             <tr class="row-color-normal">
               {% if loop.first %}
-              <td rowspan="{{ mur.complainants | length }}">Complaintant</td>
+              <td rowspan="{{ mur.complainants | length }}">Complainant</td>
               {% endif %}
-              <td>{{ complaintant }}</td>
+              <td>{{ complainant }}</td>
             </tr>
             {% endfor %}
           {% endif %}

--- a/openfecwebapp/templates/macros/legal.html
+++ b/openfecwebapp/templates/macros/legal.html
@@ -66,3 +66,12 @@
   </div>
 </div>
 {% endmacro %}
+
+{% macro mur_subject(node) %}
+{{ node.text }}
+<ul>
+  {% for child in node.children %}
+  <li>{{ mur_subject(child) }}</li>
+  {% endfor %}
+</ul>
+{% endmacro %}

--- a/openfecwebapp/templates/macros/legal.html
+++ b/openfecwebapp/templates/macros/legal.html
@@ -69,9 +69,9 @@
 
 {% macro mur_subject(node) %}
 {{ node.text }}
-<ul>
+<ul class="legal-mur__subject-list">
   {% for child in node.children %}
-  <li>{{ mur_subject(child) }}</li>
+  <li class="legal-mur__subject-list-item">{{ mur_subject(child) }}</li>
   {% endfor %}
 </ul>
 {% endmacro %}

--- a/openfecwebapp/templates/partials/legal-search-results-mur.html
+++ b/openfecwebapp/templates/partials/legal-search-results-mur.html
@@ -1,4 +1,4 @@
-<div class="simple-table simple-table--responsive simple-table--display legal-search-results">
+<div class="simple-table simple-table--responsive simple-table--display legal-search-results legal-mur">
   <div class="simple-table__header">
     <div class="simple-table__header-cell cell--25">Name</div>
     <div class="simple-table__header-cell">Matches</div>

--- a/openfecwebapp/templates/partials/legal-search-results-mur.html
+++ b/openfecwebapp/templates/partials/legal-search-results-mur.html
@@ -9,7 +9,7 @@
       <div class="simple-table__cell">
         <div class="legal-search-result__name"><a title="{{ mur.name }}" href="{{ mur.url }}">MUR #{{ mur.no }}</a></div>
         <div><a title="{{ mur.name }}" href="{{ mur.url }}">{{ mur.name }}</a></div>
-        {% if mur.archived or 1 %}
+        {% if mur.mur_type == 'archived' %}
         <div class="legal-mur__archive"><span class="legal-mur__archive-icon"><span class="u-visually-hidden">Icon representing an archived case</span></span>Archived case</div>
         {% endif %}
       </div>

--- a/openfecwebapp/templates/partials/legal-search-results-mur.html
+++ b/openfecwebapp/templates/partials/legal-search-results-mur.html
@@ -7,8 +7,8 @@
   {% for mur in murs %}
     <div class="simple-table__row legal-search-result">
       <div class="simple-table__cell">
-        <div class="legal-search-result__name"><a title="{{ mur.name }}" href="{{ mur.url }}">MUR #{{ mur.no }}</a></div>
-        <div><a title="{{ mur.name }}" href="{{ mur.url }}">{{ mur.name }}</a></div>
+        <div class="legal-search-result__name"><a title="{{ mur.name }}" href="{{ url_for('mur_page', mur_no=mur.no) }}">MUR #{{ mur.no }}</a></div>
+        <div><a title="{{ mur.name }}" href="{{  url_for('mur_page', mur_no=mur.no) }}">{{ mur.name }}</a></div>
         {% if mur.mur_type == 'archived' %}
         <div class="legal-mur__archive"><span class="legal-mur__archive-icon"><span class="u-visually-hidden">Icon representing an archived case</span></span>Archived case</div>
         {% endif %}

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -51,6 +51,13 @@ def render_legal_advisory_opinion(advisory_opinion):
     )
 
 
+def render_legal_mur(mur):
+    return render_template(
+        'legal-mur.html',
+        mur=mur,
+    )
+
+
 def to_date(committee, cycle):
     if committee['committee_type'] in ['H', 'S', 'P']:
         return None


### PR DESCRIPTION
Adds view for the canonical MUR page (for archived MURs). Resolves https://github.com/18F/fec-eregs/issues/227
- [ ] https://github.com/18F/fec-style/pull/510

@jenniferthibault since both archived and current MURs will have a name field, I moved the archive case indicator under the summary, but not really sure where it should go.

![screenshot from 2016-09-15 14-37-23](https://cloud.githubusercontent.com/assets/509703/18568527/a60eaacc-7b52-11e6-9009-46643ff7867b.png)
