### PR TITLE
Feature/enable additional downloads

### DIFF
--- a/static/js/pages/candidates-office.js
+++ b/static/js/pages/candidates-office.js
@@ -38,7 +38,7 @@ $(document).ready(function() {
     order: [[defaultSort[context.office], 'desc']],
     useFilters: true,
     useExport: true,
-    disableExport: true,
+    disableExport: false,
     rowCallback: tables.modalRenderRow,
     callbacks: {
       afterRender: tablePanels.renderCandidatePanel(true)

--- a/static/js/pages/candidates-office.js
+++ b/static/js/pages/candidates-office.js
@@ -38,7 +38,6 @@ $(document).ready(function() {
     order: [[defaultSort[context.office], 'desc']],
     useFilters: true,
     useExport: true,
-    disableExport: false,
     rowCallback: tables.modalRenderRow,
     callbacks: {
       afterRender: tablePanels.renderCandidatePanel(true)

--- a/static/js/pages/candidates-office.js
+++ b/static/js/pages/candidates-office.js
@@ -38,6 +38,7 @@ $(document).ready(function() {
     order: [[defaultSort[context.office], 'desc']],
     useFilters: true,
     useExport: true,
+    disableExport: true,
     rowCallback: tables.modalRenderRow,
     callbacks: {
       afterRender: tablePanels.renderCandidatePanel(true)

--- a/static/js/pages/filings.js
+++ b/static/js/pages/filings.js
@@ -42,7 +42,7 @@ $(document).ready(function() {
       disableFilters: true,
       enabledFilters: ['committee_id', 'data_type', 'receipt_date'],
       hideColumns: '.hide-efiling',
-      disableExport: true
+      disableExport: false
     },
     processed: {
       path: ['filings'],

--- a/static/js/pages/filings.js
+++ b/static/js/pages/filings.js
@@ -41,13 +41,11 @@ $(document).ready(function() {
       path: ['efile', 'filings'],
       disableFilters: true,
       enabledFilters: ['committee_id', 'data_type', 'receipt_date'],
-      hideColumns: '.hide-efiling',
-      disableExport: false
+      hideColumns: '.hide-efiling'
     },
     processed: {
       path: ['filings'],
-      hideColumns: '.hide-processed',
-      disableExport: false
+      hideColumns: '.hide-processed'
     }
   }).init();
 });

--- a/static/js/pages/reports.js
+++ b/static/js/pages/reports.js
@@ -54,7 +54,6 @@ $(document).ready(function() {
     order: [[2, 'desc']],
     useFilters: true,
     useExport: true,
-    disableExport: false,
     callbacks: {
       afterRender: tables.modalRenderFactory(pageTemplate)
     }
@@ -64,12 +63,10 @@ $(document).ready(function() {
     efiling: {
       path: ['efile', 'reports', context.form_type],
       disableFilters: true,
-      enabledFilters: ['committee_id', 'data_type', 'receipt_date'],
-      disableExport: false
+      enabledFilters: ['committee_id', 'data_type', 'receipt_date']
     },
     processed: {
-      path: ['reports', context.form_type],
-      disableExport: false
+      path: ['reports', context.form_type]
     }
   }).init();
 });

--- a/static/js/pages/reports.js
+++ b/static/js/pages/reports.js
@@ -54,7 +54,7 @@ $(document).ready(function() {
     order: [[2, 'desc']],
     useFilters: true,
     useExport: true,
-    disableExport: true,
+    disableExport: false,
     callbacks: {
       afterRender: tables.modalRenderFactory(pageTemplate)
     }
@@ -65,11 +65,11 @@ $(document).ready(function() {
       path: ['efile', 'reports', context.form_type],
       disableFilters: true,
       enabledFilters: ['committee_id', 'data_type', 'receipt_date'],
-      disableExport: true
+      disableExport: false
     },
     processed: {
       path: ['reports', context.form_type],
-      disableExport: true
+      disableExport: false
     }
   }).init();
 });


### PR DESCRIPTION
Closes https://github.com/18F/openFEC/issues/1925
Depends on https://github.com/18F/openFEC/pull/1945

This changeset adds support for additional downloads/exports at other endpoints. Specifically, it adds support for Filings, E-Filings, and Reports.

/cc @LindsayYoung, @jontours, @noahmanger, @xtine
