### PR TITLE
Adding link to itemized receipts and disbursements from totals table

### DIFF
--- a/openfecwebapp/templates/macros/tables.html
+++ b/openfecwebapp/templates/macros/tables.html
@@ -1,7 +1,7 @@
 {% import 'macros/null.html' as null %}
 {% import 'macros/charts.html' as charts %}
 
-{% macro totals(header_name, header_value, data, report_year, header_description='') %}
+{% macro totals(header_name, header_value, data, report_year, transaction_type, id, year) %}
   <figure class="totals-table totals-table--charts js-chart-series chart-series--horizontal">
       {% if data|length %}
       <button tabindex="0" class="accordion__button accordion__button--spacious js-accordion-trigger">
@@ -9,6 +9,9 @@
         <span class="t-normal">{{ null.null(header_value | currency) }}</span>
       </button>
       <div class="accordion__content">
+        <div class="row">
+          <a class="button button--alt button--table u-float-right" href="{{ url_for(transaction_type, committee_id=id, two_year_transaction_period=year) }}">All {{ transaction_type }}</a>
+        </div>
         {% for item in data %}
           <div class="totals-table__row totals-table__row--nested">
             <div class="row">

--- a/openfecwebapp/templates/partials/committee-totals-house-senate.html
+++ b/openfecwebapp/templates/partials/committee-totals-house-senate.html
@@ -19,7 +19,7 @@
    ]
 %}
 {{ tables.totals('Total receipts', totals.0.receipts, table_data,
-    committee.report_year, header_description='Money raised by the committee' ) }}
+    committee.report_year, 'receipts', committee_id, reports.0.cycle ) }}
 
 {% set table_data = [
      (totals.0.operating_expenditures, 'Operating expenditures'),
@@ -36,6 +36,6 @@
 %}
 
 {{ tables.totals('Total disbursements', totals.0.disbursements, table_data,
-    committee.report_year, header_description='Money spent by the committee' ) }}
+    committee.report_year, 'disbursements', committee_id, reports.0.cycle ) }}
 
 {% endwith %}

--- a/openfecwebapp/templates/partials/committee-totals-pac-party.html
+++ b/openfecwebapp/templates/partials/committee-totals-pac-party.html
@@ -22,7 +22,7 @@
    ]
 %}
 {{ tables.totals('Total receipts', totals.0.receipts, table_data,
-    committee.report_year, header_description='Money raised by the committee' ) }}
+    committee.report_year, 'receipts', committee_id, reports.0.cycle ) }}
 
 {% set table_data = [
      (totals.0.shared_fed_operating_expenditures, 'Federal allocated operating expenditures'),
@@ -50,6 +50,6 @@
    ]
 %}
 {{ tables.totals('Total disbursements', totals.0.disbursements, table_data,
-    committee.report_year, header_description='Money spent by the committee' ) }}
+    committee.report_year, 'disbursements', committee_id, reports.0.cycle) }}
 
 {% endwith %}

--- a/openfecwebapp/templates/partials/committee-totals-presidential.html
+++ b/openfecwebapp/templates/partials/committee-totals-presidential.html
@@ -22,7 +22,7 @@
    ]
 %}
 {{ tables.totals('Total receipts', totals.0.receipts, table_data,
-    committee.report_year, header_description='Money raised by the committee' ) }}
+    committee.report_year, 'receipts', committee_id, reports.0.cycle ) }}
 
 {% set table_data = [
      (totals.0.operating_expenditures, 'Operating expenditures'),
@@ -39,6 +39,6 @@
    ]
 %}
 {{ tables.totals('Total disbursements', totals.0.disbursements, table_data,
-    committee.report_year, header_description='Money spent by the committee' ) }}
+    committee.report_year, 'disbursements', committee_id, reports.0.cycle ) }}
 
 {% endwith %}


### PR DESCRIPTION
This adds links to itemized disbursements and receipts from the committee financial summary tables:

![image](https://cloud.githubusercontent.com/assets/1696495/18601627/cf76d5ee-7c18-11e6-85d0-cf5ffab9a167.png)

![image](https://cloud.githubusercontent.com/assets/1696495/18601629/d54b9860-7c18-11e6-9262-9f5cd30b71d4.png)

This is an intermediate fix to address the need [originally raised in FEC feedback](https://github.com/18F/openFEC-web-app/issues/1466) to have links from these summary numbers to itemized transactions. We have several other issues addressing the larger design of this pattern, so this isn't meant as the ultimate solution, but hopefully it can ease some user pain in the short term.

I chose to present it as a separate link for a couple reasons:
- We don't have the ability to filter down to transactions for each of the sub-items in these tables
- Because the transactions will never add up to what was reported, presenting it as a separate link rather than linking from the actual dollar amount hopefully makes it slightly less confusing

I chose to just take care of this in between tasks. If this turns into a thornier issue requiring more discussion or some design time, we might need to punt. But on the chance that this resolves it, wanted to submit.

Paging @jwchumley to see what you think.