### PR TITLE
[WIP] Disable sticky on small screens

### DIFF
--- a/static/js/init.js
+++ b/static/js/init.js
@@ -52,13 +52,46 @@ $(document).ready(function() {
   new skipNav.Skipnav('.skip-nav', 'main');
 
   // Initialize stick side elements
-  $('.js-sticky-side').each(function() {
-    var container = $(this).data('sticky-container');
-    var opts = {
-      within: document.getElementById(container)
-    };
-    new Sticky(this, opts);
-  });
+  (function () {
+    var stickies = [];
+    var enabled = helpers.isMediumScreen();
+
+    $('.js-sticky-side').each(function() {
+      var container = $(this).data('sticky-container');
+      var opts = {
+        within: document.getElementById(container)
+      };
+
+      var sticky = new Sticky(this, opts);
+      stickies.push(sticky);
+
+      // Initialize sticky as disabled
+      if (!enabled) {
+        sticky.disable();
+      }
+    });
+
+    $(window).on('resize', function onResize () {
+      // If enabled already and on a medium+ screen, noop
+      if (enabled && helpers.isMediumScreen()) {
+        return;
+      }
+
+      // If disabled already and on a small screen, noop
+      if (!enabled && !helpers.isMediumScreen()) {
+        return;
+      }
+
+      enabled = helpers.isMediumScreen();
+      stickies.forEach(function (sticky) {
+        if (enabled) {
+          sticky.enable();
+        } else {
+          sticky.disable();
+        }
+      });
+    });
+  })();
 
   // Initialize sticky bar elements
   $('.js-sticky-bar').each(function() {


### PR DESCRIPTION
This change is paired with https://github.com/18F/fec-style/pull/516. This is an experiment to see how much effort is involved in making the `side-nav` on mobile behave as a static top nav.

Right now, this change would also have to be made in all the repos that use the side-nav. If we're interested in taking this forward, we can move `component-sticky` into `fec-style` and handle the resizing internally.

... the gif I made to demo the behavior is too big for github, I'll make a new one on Monday.
