### PR TITLE
Simplify DateFilter for non two-year transaction periods

### DIFF
--- a/openfecwebapp/templates/macros/filters/date.html
+++ b/openfecwebapp/templates/macros/filters/date.html
@@ -5,12 +5,12 @@
     <div class="range range--date js-date-range">
       <div class="range__input range__input--min" data-filter="range">
         <label for="min_{{ name }}">Beginning</label>
-        <input type="text" id="min_{{ name }}" name="min_{{ name }}" data-range="min" class="js-min-date" data-prefix="Beginning" data-min-date={{ dates['year'][0] | date(fmt='%m/%d/%Y') }}>
+        <input type="text" id="min_{{ name }}" name="min_{{ name }}" data-range="min" class="js-min-date" data-prefix="Beginning">
       </div>
       <div class="range__hyphen">-</div>
       <div class="range__input range__input--max" data-filter="range">
         <label for="max_{{ name }}">Ending</label>
-        <input type="text" id="max_{{ name }}" name="max_{{ name }}" data-range="max" class="js-max-date" data-prefix="Ending" data-max-date={{ dates['year'][1] | date(fmt='%m/%d/%Y') }}>
+        <input type="text" id="max_{{ name }}" name="max_{{ name }}" data-range="max" class="js-max-date" data-prefix="Ending">
       </div>
       <button class="button--go button--standard" type="button">
         <span class="u-visually-hidden">Search</span>

--- a/openfecwebapp/templates/macros/filters/date.html
+++ b/openfecwebapp/templates/macros/filters/date.html
@@ -5,12 +5,12 @@
     <div class="range range--date js-date-range">
       <div class="range__input range__input--min" data-filter="range">
         <label for="min_{{ name }}">Beginning</label>
-        <input type="text" id="min_{{ name }}" name="min_{{ name }}" data-range="min" class="js-min-date" data-prefix="Beginning">
+        <input type="text" id="min_{{ name }}" name="min_{{ name }}" data-range="min" data-removable="true" class="js-min-date" data-prefix="Beginning">
       </div>
       <div class="range__hyphen">-</div>
       <div class="range__input range__input--max" data-filter="range">
         <label for="max_{{ name }}">Ending</label>
-        <input type="text" id="max_{{ name }}" name="max_{{ name }}" data-range="max" class="js-max-date" data-prefix="Ending">
+        <input type="text" id="max_{{ name }}" name="max_{{ name }}" data-range="max" data-removable="true" class="js-max-date" data-prefix="Ending">
       </div>
       <button class="button--go button--standard" type="button">
         <span class="u-visually-hidden">Search</span>

--- a/openfecwebapp/templates/macros/filters/date.html
+++ b/openfecwebapp/templates/macros/filters/date.html
@@ -1,31 +1,23 @@
 {% macro field(name, label, dates) %}
-
   <div class="filter js-filter" id="{{ name }}" data-name="{{ name }}" data-filter="date">
   <fieldset>
     <legend for="{{ name }}" class="label">{{ label }}</legend>
-    <ul>
-      <li>
-        <input id="radio-1" name="_{{ name }}" type="radio" data-min-date={{ dates['year'][0] | date(fmt='%m-%d-%Y') }} data-max-date={{ dates['year'][1] | date(fmt='%m-%d-%Y') }}>
-        <label for="radio-1">This year</label>
-      </li>
-      <li>
-        <input id="radio-2" name="_{{ name }}" type="radio" data-min-date={{ dates['cycle'][0] | date(fmt='%m-%d-%Y') }} data-max-date={{ dates['cycle'][1] | date(fmt='%m-%d-%Y') }}>
-        <label for="radio-2">This cycle</label>
-      </li>
-      <li>
-        <input id="radio-3" name="_{{ name }}" type="radio">
-        <label for="radio-3">Custom</label>
-      </li>
-    </ul>
-    <div class="date-range-input">
-      <label for="min_{{ name }}">From</label>
-      <input type="text" id="min_{{ name }}" name="min_{{ name }}" class="js-min-date" data-prefix="Beginning" data-inputmask="'alias': 'mm/dd/yyyy'">
-      <label for="max_{{ name }}">To</label>
-      <input type="text" id="max_{{ name }}" name="max_{{ name }}" class="js-max-date" data-prefix="Ending" data-inputmask="'alias': 'mm/dd/yyyy'">
+    <div class="range range--date js-date-range">
+      <div class="range__input range__input--min" data-filter="range">
+        <label for="min_{{ name }}">Beginning</label>
+        <input type="text" id="min_{{ name }}" name="min_{{ name }}" data-range="min" class="js-min-date" data-prefix="Beginning" data-min-date={{ dates['year'][0] | date(fmt='%m/%d/%Y') }}>
+      </div>
+      <div class="range__hyphen">-</div>
+      <div class="range__input range__input--max" data-filter="range">
+        <label for="max_{{ name }}">Ending</label>
+        <input type="text" id="max_{{ name }}" name="max_{{ name }}" data-range="max" class="js-max-date" data-prefix="Ending" data-max-date={{ dates['year'][1] | date(fmt='%m/%d/%Y') }}>
+      </div>
+      <button class="button--go button--standard" type="button">
+        <span class="u-visually-hidden">Search</span>
+      </button>
     </div>
   </fieldset>
 </div>
-
 {% endmacro %}
 
 {% macro partition_field(name, label, dates) %}


### PR DESCRIPTION
Date filters that are not bound to two-year transaction periods will not have a radio selection but  simpler beginning/end input date fields. Relies on 18F/fec-style#517

Issue: 18F/fec-style#501

<img width="278" alt="screen shot 2016-09-19 at 3 04 38 pm" src="https://cloud.githubusercontent.com/assets/24054/18650558/88332340-7e7a-11e6-8ea0-080390790ed0.png">
