### PR TITLE
Feature/mur current search

### DIFF
--- a/openfecwebapp/templates/partials/legal-search-results-mur.html
+++ b/openfecwebapp/templates/partials/legal-search-results-mur.html
@@ -21,6 +21,15 @@
           {% endfor %}
         </div>
         <div><strong>Date closed:</strong> {{ mur.close_date | date('%Y') | default('Unknown', True) }}</div>
+        {% if mur.mur_type == 'current' %}
+        {# Archived MUR subjects are a tree-structure so we don't render them inline #}
+          <div>
+            <strong>Subject:</strong>
+            {% for node in mur.subject -%}
+              {% if not loop.first %}; {% endif %}{{ node['text'] }}
+            {%- endfor %}
+          </div>
+        {% endif %}
       </div>
     </div>
   {% endfor %}

--- a/openfecwebapp/templates/partials/legal-search-results-mur.html
+++ b/openfecwebapp/templates/partials/legal-search-results-mur.html
@@ -24,10 +24,7 @@
         {% if mur.mur_type == 'current' %}
         {# Archived MUR subjects are a tree-structure so we don't render them inline #}
           <div>
-            <strong>Subject:</strong>
-            {% for node in mur.subject -%}
-              {% if not loop.first %}; {% endif %}{{ node['text'] }}
-            {%- endfor %}
+            <strong>Subject:</strong> {{ '; '.join(mur['subject']['text']) }}
           </div>
         {% endif %}
       </div>


### PR DESCRIPTION
Current murs should show up in search results, resolves https://github.com/18F/fec-eregs/issues/255

![screenshot from 2016-10-06 14-44-45](https://cloud.githubusercontent.com/assets/509703/19172158/37831834-8bd5-11e6-9b0d-c4fea460033c.png)
- [x] waiting for final schema from https://github.com/18F/fec-eregs/issues/49
- [ ] depends on https://github.com/18F/openFEC/pull/1959 for `close_date`
