### PR TITLE
Pinning to new minor update of glossary

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
     "fec-style": "5.0.1",
-    "glossary-panel": "0.1.2",
+    "glossary-panel": "0.2.0",
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",
     "intl": "1.0.0-rc-4",


### PR DESCRIPTION
Makes use of the new version of the glossary panel that sets focus on the element that opened the glossary.

cc @xtine