### PR TITLE
Feature/adding watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,20 @@ To run the server in debug mode set:
 
     export FEC_WEB_DEBUG=true
 
+### Watch for changes
+To watch for changes to .js and .scss:
+
+    npm run watch
+
 ### Developing with fec-style (optional)
 If you're developing with a local instance of [fec-style](https://github.com/18F/fec-style) and want to pull in styles and script changes as you go, use `npm link` to create a symbolic link to your local fec-style repo:
 
-    npm link fec-style > ~/[path to fec-style]/fec-style
+    cd ~/fec-style
+    npm link
+    cd ~/openFEC-web-app
+    npm link fec-style
+
+After linking fec-style, `npm run watch` will rebuild on changes to your local copy of fec-style's .scss and .js files.
 
 ### Developing with fec-cms (optional)
 To be able to have links between this app and a local installation of [fec-cms](https://github.com/18F/fec-cms):

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 
 ## Campaign finance for everyone
 
-The Federal Election Commission (FEC) releases information to the public about money that’s raised and spent in federal elections — that’s elections for US president, Senate, and House of Representatives. 
+The Federal Election Commission (FEC) releases information to the public about money that’s raised and spent in federal elections — that’s elections for US president, Senate, and House of Representatives.
 
 Are you interested in seeing how much money a candidate raised? Or spent? How much debt they took on? Who contributed to their campaign? The FEC is the authoritative source for that information.
 
-betaFEC is a collaboration between [18F](http://18f.gsa.gov) and the FEC. It aims to make campaign finance information more accessible (and understandable) to all users. 
+betaFEC is a collaboration between [18F](http://18f.gsa.gov) and the FEC. It aims to make campaign finance information more accessible (and understandable) to all users.
 
 ## FEC repositories
-We welcome you to explore, make suggestions, and contribute to our code. 
+We welcome you to explore, make suggestions, and contribute to our code.
 
 This repository, [openFEC-web-app](https://github.com/18f/openfec-web-app), houses the betaFEC web app for exploring campaign finance data.
 
@@ -29,7 +29,7 @@ This repository, [openFEC-web-app](https://github.com/18f/openfec-web-app), hous
 - [fec-cms](https://github.com/18F/fec-cms): the content management system (CMS) for betaFEC
 
 ## Get involved
-We’re thrilled you want to get involved! 
+We’re thrilled you want to get involved!
 - Read our [contributing guidelines](https://github.com/18F/openfec/blob/master/CONTRIBUTING.md). Then, [file an issue](https://github.com/18F/fec/issues) or submit a pull request.
 - [Send us an email](mailto:betafeedback@fec.gov).
 - If you’re a developer, follow the installation instructions in the README.md page of each repository to run the apps on your computer.
@@ -77,14 +77,15 @@ To run the server in debug mode set:
 
     export FEC_WEB_DEBUG=true
 
-To use styles served from a custom location (e.g., if developing against a local `fec-style`):
+### Developing with fec-style (optional)
+If you're developing with a local instance of [fec-style](https://github.com/18F/fec-style) and want to pull in styles and script changes as you go, use `npm link` to create a symbolic link to your local fec-style repo:
 
-    export FEC_WEB_STYLE_URL=http://localhost:8080/css/styles.css
+    npm link fec-style > ~/[path to fec-style]/fec-style
 
-To be able to have links between this app and a local installation of the cms:
+### Developing with fec-cms (optional)
+To be able to have links between this app and a local installation of [fec-cms](https://github.com/18F/fec-cms):
 
     export FEC_CMS_URL=http://localhost:8000
-
 
 ### Features
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,6 @@
 
 var _ = require('underscore');
 
-var watchify = require('watchify');
 var browserify = require('browserify');
 
 var gulp = require('gulp');
@@ -27,9 +26,6 @@ var production = ['stage', 'prod'].indexOf(process.env.FEC_WEB_ENVIRONMENT) !== 
 var sentryPublicDsn = process.env.SENTRY_PUBLIC_DSN;
 var sentryPublicDsn = (appEnv.getServiceCreds(/fec-creds/) || {}).SENTRY_PUBLIC_DSN ||
   process.env.SENTRY_PUBLIC_DSN;
-
-// TODO(jmcarp) Restore `watch-js`
-// gulp.task('watch-js', bundle.bind(this, true));
 
 gulp.task('copy-vendor-images', function() {
   return gulp.src('./node_modules/datatables/media/images/**/*')

--- a/openfecwebapp/config.py
+++ b/openfecwebapp/config.py
@@ -13,7 +13,6 @@ api_key_public = env.get_credential('FEC_WEB_API_KEY_PUBLIC', '')
 cache = os.getenv('FEC_WEB_CACHE')
 cache_size = int(os.getenv('FEC_WEB_CACHE_SIZE', 1000))
 
-style_url = os.getenv('FEC_WEB_STYLE_URL')
 cms_url = os.getenv('FEC_CMS_URL', '')
 
 # you can only give a var a string using set-env with Cloud Foundry

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -8,12 +8,8 @@
   {% include 'partials/meta-tags.html' %}
 
   <link rel="stylesheet" href="{{ asset_for('dist/styles/styles.css') }}" />
-
-  {% if style_url %}
-  <link rel="stylesheet" href="{{ style_url }}" />
-  {% else %}
   <link rel="stylesheet" href="{{ asset_for('dist/styles/fec.css') }}" />
-  {% endif %}
+
   {% if api_location %}
   <script>
     ANALYTICS = {{ use_analytics|json }};

--- a/package.json
+++ b/package.json
@@ -32,23 +32,26 @@
     "karma-phantomjs-shim": "^1.2.0",
     "mocha": "^2.2.5",
     "mockdate": "^1.0.3",
+    "nswatch": "0.2.0",
     "phantomjs-prebuilt": "^2.1.4",
     "preprocessify": "0.0.3",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0",
     "stringify": "^3.1.0",
-    "vinyl-paths": "^1.0.0",
-    "watchify": "^3.2.1"
+    "vinyl-paths": "^1.0.0"
   },
   "scripts": {
     "build": "gulp build-js && gulp build-sass",
     "build-js": "gulp build-js",
     "build-sass": "gulp build-sass",
-    "watch": "gulp watch-js & gulp watch-sass",
-    "watch-js": "gulp watch-js",
-    "watch-sass": "gulp watch-sass",
     "test": "karma start",
-    "test-single": "karma start --single-run --browsers PhantomJS"
+    "test-single": "karma start --single-run --browsers PhantomJS",
+    "watch": "nswatch"
+  },
+  "watch": {
+    "./static/js/**/*.js": ["build-js"],
+    "./node_modules/fec-style/js/*.js": ["build-js"],
+    "./node_modules/fec-style/scss/**/*.scss": ["build-sass"]
   },
   "repository": {
     "type": "git",
@@ -83,8 +86,7 @@
     "topojson": "1.6.19",
     "underscore": "1.8.3",
     "underscore.string": "3.2.0",
-    "urijs": "1.16.1",
-    "watchify": "3.2.1"
+    "urijs": "1.16.1"
   },
   "engines": {
     "node": "5.5.0",


### PR DESCRIPTION
This uses [nswatch](https://github.com/egoist/nswatch) to watch for changes to js and scss files and rebuilds them automatically. 

It also includes the proper instructions for using `npm link` for including fec-style, and configures `watch` so that it watches for changes on the linked fec-style files. 

Replaces https://github.com/18F/openFEC-web-app/pull/1383