### PR TITLE
Enforcement landing page

### DIFF
--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -287,6 +287,12 @@ def advisory_opinions_landing():
         result_type='advisory_opinions',
         display_name='advisory opinions')
 
+@app.route('/legal/enforcement-matters/')
+def enforcement_landing():
+    return render_template('legal-enforcement-landing.html',
+        result_type='murs',
+        display_name='enforcement matters')
+
 @app.route('/legal/statutes/')
 def statutes_landing():
     return render_template('legal-statutes-landing.html',

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -287,7 +287,7 @@ def advisory_opinions_landing():
         result_type='advisory_opinions',
         display_name='advisory opinions')
 
-@app.route('/legal/enforcement-matters/')
+@app.route('/legal/enforcement/')
 def enforcement_landing():
     return render_template('legal-enforcement-landing.html',
         result_type='murs',
@@ -315,7 +315,7 @@ def advisory_opinions(query, offset):
 def statutes(query, offset):
     return legal_doc_search(query, 'statutes', offset=offset)
 
-@app.route('/legal/search/enforcement-matters/')
+@app.route('/legal/search/enforcement/')
 @use_kwargs({
     'query': fields.Str(load_from='search'),
     'offset': fields.Int(missing=0),

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -19,7 +19,7 @@
 <section class="slab slab--neutral slab--spacious">
   <div class="container">
     {{ search.search('hero', button_color="button--standard", select_class="select--alt") }}
-    <span class="t-note t-sans search__example">Examples: Obama for America, C00431445; Bush, George W., P00003335</span>
+    <span class="t-note t-sans search__example search__example--with-select">Examples: Obama for America, C00431445; Bush, George W., P00003335</span>
   </div>
 </section>
 

--- a/openfecwebapp/templates/layouts/legal-doc-landing.html
+++ b/openfecwebapp/templates/layouts/legal-doc-landing.html
@@ -11,14 +11,9 @@
   {{ breadcrumb.breadcrumbs(display_name.capitalize(), breadcrumb_links) }}
 </header>
 
-<section class="main__content--full data-container__wrapper">
-  {{ legal.filter('Search %s' % display_name, result_type) }}
-  <div class="content__section data-container__body">
-    <div class="main">
-      {% block content %}{% endblock %}
-    </div>
-  </div>
-</section>
+<div class="main container">
+  {% block content %}{% endblock %}
+</div>
 
 {% include 'partials/legal-disclaimer.html' %}
 {% endblock %}

--- a/openfecwebapp/templates/legal-archived-mur.html
+++ b/openfecwebapp/templates/legal-archived-mur.html
@@ -2,7 +2,7 @@
 {% import 'macros/breadcrumbs.html' as breadcrumb %}
 {% import 'macros/legal.html' as legal %}
 
-{% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources'), (url_for('advisory_opinions_landing'), 'Enforcement')] %}
+{% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources'), (url_for('enforcement_landing'), 'Enforcement')] %}
 
 {% block title %}MUR #{{ mur.no }}{% endblock %}
 

--- a/openfecwebapp/templates/legal-current-mur.html
+++ b/openfecwebapp/templates/legal-current-mur.html
@@ -2,7 +2,7 @@
 {% import 'macros/breadcrumbs.html' as breadcrumb %}
 {% import 'macros/legal.html' as legal %}
 
-{% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources'), (url_for('advisory_opinions_landing'), 'Enforcement')] %}
+{% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources'), (url_for('enforcement_landing'), 'Enforcement')] %}
 
 {% block title %}MUR #{{ mur.no }}{% endblock %}
 

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -1,0 +1,43 @@
+{% extends "layouts/legal-doc-landing.html" %}
+{% import 'macros/document.html' as document %}
+
+{% block content %}
+<div class="section__heading">
+  <h1 class="heading__title">Enforcement matters</h1>
+</div>
+<div class="content__section">
+  <p>Enforcement.</p>
+</div>
+<div class="content__section">
+  <div class="grid grid--3-wide">
+    <div class="grid__item">
+      <h5><a href="">Administrative Fine Program</a></h5>
+      <p>Procedure and penalties for late and missed filings.</p>
+    </div>
+    <div class="grid__item">
+      <h5><a href="">Alternative Dispute Program</a></h5>
+      <p>Procedure and penalties for late and missed filings.</p>
+    </div>
+    <div class="grid__item">
+      <h5><a href="">Matters Under Review</a></h5>
+      <p>Procedure and penalties for late and missed filings.</p>
+    </div>
+    <div class="grid__item">
+      <h5><a href="">Alternative Dispute Program</a></h5>
+      <p>Procedure and penalties for late and missed filings.</p>
+    </div>
+    <div class="grid__item">
+      <h5><a href="">Matters Under Review</a></h5>
+      <p>Procedure and penalties for late and missed filings.</p>
+    </div>
+    <div class="grid__item">
+      <h5><a href="">Alternative Dispute Program</a></h5>
+      <p>Procedure and penalties for late and missed filings.</p>
+    </div>
+    <div class="grid__item">
+      <h5><a href="">Matters Under Review</a></h5>
+      <p>Procedure and penalties for late and missed filings.</p>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -1,9 +1,9 @@
 {% extends "layouts/legal-doc-landing.html" %}
 
 {% block content %}
-<div class="section__heading">
-  <h1 class="heading__title">Enforcement matters</h1>
-</div>
+<header class="heading--main">
+  <h1>Enforcement matters</h1>
+</header>
 <div class="content__section">
   <p>
     The FEC has exclusive jurisdiction over the civil enforcement the federal campaign finance law. 
@@ -43,9 +43,9 @@
   </div>
 </div>
 <div class="content__section">
-  <div class="heading--section">
-    <h2 class="t-ruled--bottom">Enforcement programs</h2>
-  </div>
+  <header class="heading--section">
+    <h2>Enforcement programs</h2>
+  </header>
   <h4>Matters Under Review (MURs)</h4>
   <p>
     FEC enforcement matters (called MURs) must, by law, remain confidential until they are closed. 

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -4,24 +4,16 @@
 <header class="heading--main">
   <h1>Enforcement matters</h1>
 </header>
-<div class="content__section">
+<div class="content__section content__section--narrow">
   <p>
-    The FEC has exclusive jurisdiction over the civil enforcement of the federal campaign finance law. 
+    The FEC has exclusive jurisdiction over the civil enforcement of the federal campaign finance law.
     The FEC learns of possible violations through a number of sources including:
   </p>
   <ol class="list--numbered">
-    <li>
-      <p>Internal referrals, which result from the FEC’s routine review of committee reports and audits of political committees.</p>
-    </li>
-    <li>
-      <p>Sworn complaints filed with the FEC by anyone alleging that a violation has occurred or is about to occur.</p>
-    </li>
-    <li>
-      <p>Referrals to the FEC from other government agencies of possible campaign finance violations.</p>
-    </li>
-    <li>
-      <p>Self reported submissions to the FEC by any person or entity that believes it may have  committed a campaign finance violation.</p>
-    </li>
+    <li>Internal referrals, which result from the FEC’s routine review of committee reports and audits of political committees.</li>
+    <li>Sworn complaints filed with the FEC by anyone alleging that a violation has occurred or is about to occur.</li>
+    <li>Referrals to the FEC from other government agencies of possible campaign finance violations.</li>
+    <li>Self reported submissions to the FEC by any person or entity that believes it may have  committed a campaign finance violation.</li>
   </ol>
 </div>
 <div class="content__section content__section--narrow">
@@ -29,8 +21,8 @@
     <div class="grid__item">
       <h4>Audits</h4>
       <p class="t-italic">
-        Coming soon: Generally, the Commission may audit a committee when an internal review of the committee’s reports 
-        filed meet thresholds of substantial compliance with the Federal Election Campaign Act. Also, the Commission is 
+        Coming soon: Generally, the Commission may audit a committee when an internal review of the committee’s reports
+        filed meet thresholds of substantial compliance with the Federal Election Campaign Act. Also, the Commission is
         required to audit all presidential campaigns and convention committees that accept public funds.
       </p>
     </div>
@@ -57,9 +49,9 @@
   <div class="content__section content__section--narrow">
     <h4>Matters Under Review (MURs)</h4>
     <p>
-      FEC enforcement matters (called MURs) must, by law, remain confidential until they are closed. 
-      Law requires the Commission to try to resolve enforcement matters through conciliation.  
-      If the Commission fails to reach a conciliation agreement with a respondent, the Commission may choose 
+      FEC enforcement matters (called MURs) must, by law, remain confidential until they are closed.
+      Law requires the Commission to try to resolve enforcement matters through conciliation.
+      If the Commission fails to reach a conciliation agreement with a respondent, the Commission may choose
       to pursue the matter in federal court.
     </p>
     <div class="u-no-print">
@@ -68,7 +60,7 @@
           <div class="row">
             <div class="usa-width-one-whole">
               <form action="{{ url_for('murs') }}" autocomplete="off" class="search__container  js-search">
-                <label class="label">Search or browse MURs</label>
+                <label for="search-input" class="label">Search or browse MURs</label>
                 <div class="combo combo--search--large combo--search--inline">
                   <input id="search-input" type="text" name="search" class="combo__input" placeholder="Search MURs">
                   <input id="search-type" type="hidden" name="search_type" value="murs">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -46,35 +46,37 @@
   <header class="heading--section">
     <h2>Enforcement programs</h2>
   </header>
-  <h4>Matters Under Review (MURs)</h4>
-  <p>
-    FEC enforcement matters (called MURs) must, by law, remain confidential until they are closed. 
-    Law requires the Commission to try to resolve enforcement matters through conciliation.  
-    If the Commission fails to reach a conciliation agreement with a respondent, the Commission may choose 
-    to pursue the matter in federal court.
-  </p>
-  <p>
-    Search or browse closed MURs.
-  </p>
-  <div class="content__section--narrow u-no-print">
-    <div class="slab slab--neutral slab--inline">
-      <div class="container">
-        <div class="row">
-          <div class="usa-width-one-whole">
-            <form action="{{ url_for('murs') }}" autocomplete="off" class="search__container  js-search">
-              <div class="combo combo--search--large combo--search--inline">
-                <input id="search-input" type="text" name="search" class="combo__input" placeholder="Search MURs">
-                <input id="search-type" type="hidden" name="search_type" value="murs">
-                <button class="combo__button button--search button--standard" type="submit">
-                  <span class="u-visually-hidden">Search</span>
-                </button>
-              </div>
-            </form>
+  <div class="content__section content__section--narrow">
+    <h4>Matters Under Review (MURs)</h4>
+    <p>
+      FEC enforcement matters (called MURs) must, by law, remain confidential until they are closed. 
+      Law requires the Commission to try to resolve enforcement matters through conciliation.  
+      If the Commission fails to reach a conciliation agreement with a respondent, the Commission may choose 
+      to pursue the matter in federal court.
+    </p>
+    <p>
+      Search or browse closed MURs.
+    </p>
+    <div class="u-no-print">
+      <div class="slab slab--neutral slab--inline">
+        <div class="container">
+          <div class="row">
+            <div class="usa-width-one-whole">
+              <form action="{{ url_for('murs') }}" autocomplete="off" class="search__container  js-search">
+                <div class="combo combo--search--large combo--search--inline">
+                  <input id="search-input" type="text" name="search" class="combo__input" placeholder="Search MURs">
+                  <input id="search-type" type="hidden" name="search_type" value="murs">
+                  <button class="combo__button button--search button--standard" type="submit">
+                    <span class="u-visually-hidden">Search</span>
+                  </button>
+                </div>
+              </form>
+            </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="usa-width-one-whole">
-            <span class="t-note t-sans search__example">Examples: filings; 2405</span>
+          <div class="row">
+            <div class="usa-width-one-whole">
+              <span class="t-note t-sans search__example">Examples: filings; 2405</span>
+            </div>
           </div>
         </div>
       </div>

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -62,15 +62,13 @@
       If the Commission fails to reach a conciliation agreement with a respondent, the Commission may choose 
       to pursue the matter in federal court.
     </p>
-    <p>
-      Search or browse closed MURs.
-    </p>
     <div class="u-no-print">
       <div class="slab slab--neutral slab--inline">
         <div class="container">
           <div class="row">
             <div class="usa-width-one-whole">
               <form action="{{ url_for('murs') }}" autocomplete="off" class="search__container  js-search">
+                <label class="label">Search or browse MURs</label>
                 <div class="combo combo--search--large combo--search--inline">
                   <input id="search-input" type="text" name="search" class="combo__input" placeholder="Search MURs">
                   <input id="search-type" type="hidden" name="search_type" value="murs">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -6,7 +6,7 @@
 </header>
 <div class="content__section">
   <p>
-    The FEC has exclusive jurisdiction over the civil enforcement the federal campaign finance law. 
+    The FEC has exclusive jurisdiction over the civil enforcement of the federal campaign finance law. 
     The FEC learns of possible violations through a number of sources including:
   </p>
   <ol class="list--numbered">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -1,43 +1,94 @@
 {% extends "layouts/legal-doc-landing.html" %}
-{% import 'macros/document.html' as document %}
 
 {% block content %}
 <div class="section__heading">
   <h1 class="heading__title">Enforcement matters</h1>
 </div>
 <div class="content__section">
-  <p>Enforcement.</p>
+  <p>
+    The FEC exclusively enforces civil federal campaign finance law. Possible
+    violations of the law are identified one of four ways:
+  </p>
+  <ol class="list--numbered">
+    <li>The FEC regularly reviews committee reports and conducts audits.</li>
+    <li>Anyone may file a sworn complaint with the FEC that a violation has occurred or is about to occur.</li>
+    <li>Other government agencies may refer possible violations to the FEC.</li>
+    <li>Any person or entity who believes it has committed a violation may self report to the Commission.</li>
+  </ol>
 </div>
-<div class="content__section">
+<div class="content__section content__section--narrow">
   <div class="grid grid--3-wide">
     <div class="grid__item">
-      <h5><a href="">Administrative Fine Program</a></h5>
-      <p>Procedure and penalties for late and missed filings.</p>
+      <h4>Audits</h4>
+      <p>
+        Coming soon: Generally, the Commission audits a committee when it
+        appears not to have complied with the Federal Election Campaign Act.
+        The Commission is also required to audit all presidential campaigns and
+        convention committees that accept public funds.
+      </p>
     </div>
     <div class="grid__item">
-      <h5><a href="">Alternative Dispute Program</a></h5>
-      <p>Procedure and penalties for late and missed filings.</p>
+      <h4>Complainants and respondents</h4>
+      <p>
+        Coming soon: Step-by-step guide through the Commission’s enforcement
+        process and enforcement programs.
+      </p>
     </div>
     <div class="grid__item">
-      <h5><a href="">Matters Under Review</a></h5>
-      <p>Procedure and penalties for late and missed filings.</p>
-    </div>
-    <div class="grid__item">
-      <h5><a href="">Alternative Dispute Program</a></h5>
-      <p>Procedure and penalties for late and missed filings.</p>
-    </div>
-    <div class="grid__item">
-      <h5><a href="">Matters Under Review</a></h5>
-      <p>Procedure and penalties for late and missed filings.</p>
-    </div>
-    <div class="grid__item">
-      <h5><a href="">Alternative Dispute Program</a></h5>
-      <p>Procedure and penalties for late and missed filings.</p>
-    </div>
-    <div class="grid__item">
-      <h5><a href="">Matters Under Review</a></h5>
-      <p>Procedure and penalties for late and missed filings.</p>
+      <h4>Report a violation</h4>
+      <p>
+        Coming soon: How to file a complaint with the Commission and how
+        complaints are processed.
+      </p>
     </div>
   </div>
+</div>
+<div class="content__section">
+  <div class="heading--section">
+    <h2 class="t-ruled--bottom">Enforcement programs</h2>
+  </div>
+  <h4>Matters Under Review (MURs)</h4>
+  <p>
+    MURs are standard enforcement cases. By law, the Commission must attempt to
+    resolve MURs through a confidential investigative process. If that process
+    fails to end with a conciliation agreement, either the Commission or the
+    respondent(s) can choose to pursue the matter to court.
+  </p>
+  <div class="content__section--narrow u-no-print">
+    <div class="slab slab--neutral slab--inline">
+      <div class="container">
+        <div class="row">
+          <div class="usa-width-one-whole">
+            <form action="{{ url_for('murs') }}" autocomplete="off" class="search__container  js-search">
+              <div class="combo combo--search--mini">
+                <input id="search-input" type="text" name="search" class="combo__input" placeholder="Search MURs">
+                <input id="search-type" type="hidden" name="search_type" value="murs">
+                <button class="combo__button button--search button--standard" type="submit">
+                  <span class="u-visually-hidden">Search</span>
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+        <div class="row">
+          <div class="usa-width-one-whole">
+            <span class="t-note t-sans">Examples: filings; 2405</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h4>Administrative Fine Program</h4>
+  <p>
+    Coming soon: The Administrative Fine Program assesses civil money penalties
+    for late and non-filed reports.
+  </p>
+  <h4>Alternative Dispute Resolution Program</h4>
+  <p>
+    Coming soon: Alternative Dispute Resolution is a series of procedures for
+    resolving enforcement disputes through the mutual consent of the parties
+    involved.
+  </p>
 </div>
 {% endblock %}

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -72,13 +72,12 @@
         </div>
         <div class="row">
           <div class="usa-width-one-whole">
-            <span class="t-note t-sans">Examples: filings; 2405</span>
+            <span class="t-note t-sans search__example">Examples: filings; 2405</span>
           </div>
         </div>
       </div>
     </div>
   </div>
-
   <h4>Administrative Fine Program</h4>
   <p>
     Coming soon: The Administrative Fine Program assesses civil money penalties

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -10,10 +10,18 @@
     The FEC learns of possible violations through a number of sources including:
   </p>
   <ol class="list--numbered">
-    <li>Internal referrals, which result from the FEC’s routine review of committee reports and audits of political committees.</li>
-    <li>Sworn complaints filed with the FEC by anyone alleging that a violation has occurred or is about to occur.</li>
-    <li>Referrals to the FEC from other government agencies of possible campaign finance violations.</li>
-    <li>Self reported submissions to the FEC by any person or entity that believes it may have  committed a campaign finance violation.</li>
+    <li>
+      <p>Internal referrals, which result from the FEC’s routine review of committee reports and audits of political committees.</p>
+    </li>
+    <li>
+      <p>Sworn complaints filed with the FEC by anyone alleging that a violation has occurred or is about to occur.</p>
+    </li>
+    <li>
+      <p>Referrals to the FEC from other government agencies of possible campaign finance violations.</p>
+    </li>
+    <li>
+      <p>Self reported submissions to the FEC by any person or entity that believes it may have  committed a campaign finance violation.</p>
+    </li>
   </ol>
 </div>
 <div class="content__section content__section--narrow">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -60,7 +60,7 @@
         <div class="row">
           <div class="usa-width-one-whole">
             <form action="{{ url_for('murs') }}" autocomplete="off" class="search__container  js-search">
-              <div class="combo combo--search--mini">
+              <div class="combo combo--search--large">
                 <input id="search-input" type="text" name="search" class="combo__input" placeholder="Search MURs">
                 <input id="search-type" type="hidden" name="search_type" value="murs">
                 <button class="combo__button button--search button--standard" type="submit">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -6,14 +6,14 @@
 </div>
 <div class="content__section">
   <p>
-    The FEC exclusively enforces civil federal campaign finance law. Possible
-    violations of the law are identified one of four ways:
+    The FEC has exclusive jurisdiction over the civil enforcement the federal campaign finance law. 
+    The FEC learns of possible violations through a number of sources including:
   </p>
   <ol class="list--numbered">
-    <li>The FEC regularly reviews committee reports and conducts audits.</li>
-    <li>Anyone may file a sworn complaint with the FEC that a violation has occurred or is about to occur.</li>
-    <li>Other government agencies may refer possible violations to the FEC.</li>
-    <li>Any person or entity who believes it has committed a violation may self report to the Commission.</li>
+    <li>Internal referrals, which result from the FEC’s routine review of committee reports and audits of political committees.</li>
+    <li>Sworn complaints filed with the FEC by anyone alleging that a violation has occurred or is about to occur.</li>
+    <li>Referrals to the FEC from other government agencies of possible campaign finance violations.</li>
+    <li>Self reported submissions to the FEC by any person or entity that believes it may have  committed a campaign finance violation.</li>
   </ol>
 </div>
 <div class="content__section content__section--narrow">
@@ -21,10 +21,9 @@
     <div class="grid__item">
       <h4>Audits</h4>
       <p>
-        Coming soon: Generally, the Commission audits a committee when it
-        appears not to have complied with the Federal Election Campaign Act.
-        The Commission is also required to audit all presidential campaigns and
-        convention committees that accept public funds.
+        Coming soon: Generally, the Commission may audit a committee when an internal review of the committee’s reports 
+        filed meet thresholds of substantial compliance with the Federal Election Campaign Act. Also, the Commission is 
+        required to audit all presidential campaigns and convention committees that accept public funds.
       </p>
     </div>
     <div class="grid__item">
@@ -49,10 +48,13 @@
   </div>
   <h4>Matters Under Review (MURs)</h4>
   <p>
-    MURs are standard enforcement cases. By law, the Commission must attempt to
-    resolve MURs through a confidential investigative process. If that process
-    fails to end with a conciliation agreement, either the Commission or the
-    respondent(s) can choose to pursue the matter to court.
+    FEC enforcement matters (called MURs) must, by law, remain confidential until they are closed. 
+    Law requires the Commission to try to resolve enforcement matters through conciliation.  
+    If the Commission fails to reach a conciliation agreement with a respondent, the Commission may choose 
+    to pursue the matter in federal court.
+  </p>
+  <p>
+    Search or browse closed MURs.
   </p>
   <div class="content__section--narrow u-no-print">
     <div class="slab slab--neutral slab--inline">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -60,7 +60,7 @@
         <div class="row">
           <div class="usa-width-one-whole">
             <form action="{{ url_for('murs') }}" autocomplete="off" class="search__container  js-search">
-              <div class="combo combo--search--large">
+              <div class="combo combo--search--large combo--search--inline">
                 <input id="search-input" type="text" name="search" class="combo__input" placeholder="Search MURs">
                 <input id="search-type" type="hidden" name="search_type" value="murs">
                 <button class="combo__button button--search button--standard" type="submit">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -28,7 +28,7 @@
   <div class="grid grid--3-wide">
     <div class="grid__item">
       <h4>Audits</h4>
-      <p>
+      <p class="t-italic">
         Coming soon: Generally, the Commission may audit a committee when an internal review of the committee’s reports 
         filed meet thresholds of substantial compliance with the Federal Election Campaign Act. Also, the Commission is 
         required to audit all presidential campaigns and convention committees that accept public funds.
@@ -36,14 +36,14 @@
     </div>
     <div class="grid__item">
       <h4>Complainants and respondents</h4>
-      <p>
+      <p class="t-italic">
         Coming soon: Step-by-step guide through the Commission’s enforcement
         process and enforcement programs.
       </p>
     </div>
     <div class="grid__item">
       <h4>Report a violation</h4>
-      <p>
+      <p class="t-italic">
         Coming soon: How to file a complaint with the Commission and how
         complaints are processed.
       </p>
@@ -91,12 +91,12 @@
     </div>
   </div>
   <h4>Administrative Fine Program</h4>
-  <p>
+  <p class="t-italic">
     Coming soon: The Administrative Fine Program assesses civil money penalties
     for late and non-filed reports.
   </p>
   <h4>Alternative Dispute Resolution Program</h4>
-  <p>
+  <p class="t-italic">
     Coming soon: Alternative Dispute Resolution is a series of procedures for
     resolving enforcement disputes through the mutual consent of the parties
     involved.


### PR DESCRIPTION
Part of https://github.com/18F/fec-eregs/issues/224

Contains draft content from https://github.com/18F/fec-eregs/issues/233

Removes the filter panel on legal landing pages from https://github.com/18F/fec-eregs/issues/242
- [x] Depends on https://github.com/18F/fec-style/pull/523
