### PR TITLE
Add title to 404 page

### DIFF
--- a/openfecwebapp/templates/404.html
+++ b/openfecwebapp/templates/404.html
@@ -1,5 +1,6 @@
 {% extends "layouts/main.html" %}
 {% import 'macros/search.html' as search %}
+{% block title %}Not found{% endblock %}
 {% block body %}
 
 <section class="content--blank">


### PR DESCRIPTION
404 page always shows up with the title "| FEC". This changes it to "Not found | FEC"