### PR TITLE
New Footer Updates

### DIFF
--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -73,7 +73,7 @@
     <div class="footer-links__column">
       <ul>
         <li>
-          <a href="https://github.com/18F/fec">GitHub Repository</a>
+          <a href="https://github.com/18F/fec">GitHub repository</a>
         </li>
       </ul>
       <ul>
@@ -96,6 +96,24 @@
     </div>
 
     <div class="address">
+      <ul class="social-media">
+        <li>
+          <div class="i icon--twitter">
+            <a href="https://twitter.com/fec"><span class="u-visually-hidden">The FEC's Twitter page</span></a>
+          </div>
+        </li>
+{#         <li>
+          <div class="i icon--facebook">
+            <a href=""><span class="u-visually-hidden">The FEC's Facebook page</span></a>
+          </div>
+        </li> #}
+        <li>
+          <div class="i icon--youtube">
+            <a href="https://www.youtube.com/user/FECTube"><span class="u-visually-hidden">The FEC's YouTube page</span></a>
+          </div>
+        </li>
+      </ul>
+
       <p>999 E Street, NW<br>
       Washington, DC 20463</p>
       <p>(800) 424-9530</p>

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -81,7 +81,7 @@
           <a href="{{ cms_url }}/contact-us/">Contact us</a>
         </li>
         <li>
-          <a href="">Press</a>
+          <a href="{{ cms_url }}/press/">Press</a>
         </li>
       </ul>
     </div>

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -54,7 +54,6 @@
       <a title="Home" href="{{ cms_url }}/" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
       <ul class="utility-nav list--flat">
         <li class="utility-nav__item is-disabled">About</li>
-        <li class="utility-nav__item"><a href="{{ cms_url }}/contact-us/">Contact</a></li>
         <li class="utility-nav__item"><a href="{{ cms_url }}/calendar/">Calendar</a></li>
         <li class="utility-nav__item"><button class="js-glossary-toggle glossary__toggle">Glossary</button></li>
       </ul>
@@ -68,18 +67,39 @@
   <main id="main" {% if section %} data-section="{{section}}"{% endif %}>
     {% block body %}{% endblock %}
   </main>
+
+<footer class="footer-links">
+  <div class="container">
+    <div class="footer-links__column">
+      <ul>
+        <li>
+          <a href="https://github.com/18F/fec">GitHub Repository</a>
+        </li>
+      </ul>
+      <ul>
+        <li>
+          <a href="{{ cms_url }}/contact-us/">Contact us</a>
+        </li>
+        <li>
+          <a href="">Press</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</footer>
+
 <footer class="footer">
   <div class="container">
+
     <div class="seal">
       <img class="seal__img" width="140" height="140" src="{{ url_for('static', filename='img/seal--white.svg') }}" alt="Seal of the Federal Election Commission | United States of America">
-    </div>
-    <div class="address">
       <p class="address__title">Federal Election Commission</p>
-      <p>999 E Street, NW, Washington, DC 20463</p>
+    </div>
+
+    <div class="address">
+      <p>999 E Street, NW<br>
+      Washington, DC 20463</p>
       <p>(800) 424-9530</p>
-      <p class="address__subtitle">betaFEC feedback</p>
-      <p><a href="mailto:{{ contact_email }}">{{ contact_email }}</a><img class="icon--inline--right" src="{{ url_for('static', filename='img/i-email--inverse.svg') }}" alt="Icon of email being sent"></p>
-      <p><a href="https://github.com/18F/fec">GitHub repository</a><img class="icon--inline--right" src="{{ url_for('static', filename='img/i-github--inverse.svg') }}" alt="Icon of GitHub logo"></p>
     </div>
   </div>
 </footer>

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -90,7 +90,6 @@
 
 <footer class="footer">
   <div class="container">
-
     <div class="seal">
       <img class="seal__img" width="140" height="140" src="{{ url_for('static', filename='img/seal--white.svg') }}" alt="Seal of the Federal Election Commission | United States of America">
       <p class="address__title">Federal Election Commission</p>

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -68,7 +68,7 @@
     {% block body %}{% endblock %}
   </main>
 
-<footer class="footer-links">
+<nav class="footer-links">
   <div class="container">
     <div class="footer-links__column">
       <ul>
@@ -86,7 +86,7 @@
       </ul>
     </div>
   </div>
-</footer>
+</nav>
 
 <footer class="footer">
   <div class="container">
@@ -102,11 +102,6 @@
             <a href="https://twitter.com/fec"><span class="u-visually-hidden">The FEC's Twitter page</span></a>
           </div>
         </li>
-{#         <li>
-          <div class="i icon--facebook">
-            <a href=""><span class="u-visually-hidden">The FEC's Facebook page</span></a>
-          </div>
-        </li> #}
         <li>
           <div class="i icon--youtube">
             <a href="https://www.youtube.com/user/FECTube"><span class="u-visually-hidden">The FEC's YouTube page</span></a>


### PR DESCRIPTION
Updates to footer section:
- Rearrange links to accommodate new Press section
- Add social media links (right now missing Facebook, can't find link)

Header:
- Remove contact link

Issue #503, relies on 18F/fec-style#524

<img width="1176" alt="screen shot 2016-09-27 at 1 34 44 pm" src="https://cloud.githubusercontent.com/assets/24054/18890790/88cfe804-84b7-11e6-858c-25c75a0025c2.png">
<img width="1167" alt="screen shot 2016-09-27 at 1 34 33 pm" src="https://cloud.githubusercontent.com/assets/24054/18890794/8afd5008-84b7-11e6-94cc-77d088350fbc.png">
