### PR TITLE
Remove spaces around n-dash and use real n-dash

### DIFF
--- a/openfecwebapp/templates/macros/overviews.html
+++ b/openfecwebapp/templates/macros/overviews.html
@@ -8,7 +8,7 @@
     <div class="snapshot js-snapshot">
       <div class="snapshot__controls">
         <button class="button button--standard button--previous js-snapshot-prev"><span class="u-visually-hidden">Previous month</span></button>
-        <h5>Jan 1, 2015 - <span class="js-date">Jul 31, 2016</span></h5>
+        <h5>Jan 1, 2015&ndash;<span class="js-date">Jul 31, 2016</span></h5>
         <button class="button button--standard button--next js-snapshot-next"><span class="u-visually-hidden">next month</span></button>
       </div>
       <div class="snapshot__item">


### PR DESCRIPTION
This removes the spaces around the n-dash in the controls for the landing charts so they now look like:

![image](https://cloud.githubusercontent.com/assets/1696495/18923094/f302f6b4-855f-11e6-9cdd-da22ef8bde29.png)

There's still some window-widths where the length of the title forces the next button to break on a new line, but with this change it's less common. I think we need a better solution ultimately but this should hopefully help in the mean time. 
 
cc @jenniferthibault @PaulClark2 