### PR TITLE
Changes message patterns for no data instances

### DIFF
--- a/openfecwebapp/templates/layouts/legal-doc-search-results.html
+++ b/openfecwebapp/templates/layouts/legal-doc-search-results.html
@@ -47,7 +47,7 @@
     <div class="message message--no-icon">
       <h2 class="message__title">No results</h2>
       <p>Sorry, we didn&rsquo;t find any documents matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your search{% endif %}.</p>
-      <div class="message--no-icon__bottom">
+      <div class="message--alert__bottom">
         <p>Think this was a mistake?</p>
         <ul class="list--buttons">
           {% if query %}

--- a/openfecwebapp/templates/layouts/legal-doc-search-results.html
+++ b/openfecwebapp/templates/layouts/legal-doc-search-results.html
@@ -44,10 +44,10 @@
 	</div>
       </div>
     {% else %}
-    <div class="message message--alert">
+    <div class="message message--no-icon">
       <h2 class="message__title">No results</h2>
       <p>Sorry, we didn&rsquo;t find any documents matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your search{% endif %}.</p>
-      <div class="message--alert__bottom">
+      <div class="message--no-icon__bottom">
         <p>Think this was a mistake?</p>
         <ul class="list--buttons">
           {% if query %}

--- a/openfecwebapp/templates/macros/legal.html
+++ b/openfecwebapp/templates/macros/legal.html
@@ -51,10 +51,10 @@
 {% endmacro %}
 
 {% macro no_results(display_name, result_type, query, fec_resources=None) %}
-<div class="message message--alert">
+<div class="message message--no-icon">
   <h2 class="message__title">No results</h2>
   <p>Sorry, we didn&rsquo;t find any {{ display_name }} matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your query{% endif %}.</p>
-  <div class="message--alert__bottom">
+  <div class="message--no-icon__bottom">
     <p>Think this was a mistake?</p>
     <ul class="list--buttons">
       {% if query %}

--- a/openfecwebapp/templates/macros/legal.html
+++ b/openfecwebapp/templates/macros/legal.html
@@ -54,7 +54,7 @@
 <div class="message message--no-icon">
   <h2 class="message__title">No results</h2>
   <p>Sorry, we didn&rsquo;t find any {{ display_name }} matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your query{% endif %}.</p>
-  <div class="message--no-icon__bottom">
+  <div class="message--alert__bottom">
     <p>Think this was a mistake?</p>
     <ul class="list--buttons">
       {% if query %}

--- a/openfecwebapp/templates/macros/missing.html
+++ b/openfecwebapp/templates/macros/missing.html
@@ -1,8 +1,8 @@
 {% macro missing_financials(entity, cycle) %}
-<div class="message message--alert">
+<div class="message message--no-icon">
   <h2 class="message__title" id="section-1-header" tabindex="0">No results</h2>
   <p>Sorry, we didn't find any financial data for <span class="t-bold">{{ entity }}</span> in the <span class="t-bold">{{ cycle | fmt_year_range }}</span> election cycle.</p>
-  <div class="message--alert__bottom">
+  <div class="message--no-icon__bottom">
     <p>Think this was a mistake?</p>
     <ul class="list--buttons">
       <li><a class="button button--standard" href="http://www.fec.gov/finance/disclosure/candcmte_info.shtml">Try FEC.gov</a></li>

--- a/openfecwebapp/templates/macros/missing.html
+++ b/openfecwebapp/templates/macros/missing.html
@@ -2,7 +2,7 @@
 <div class="message message--no-icon">
   <h2 class="message__title" id="section-1-header" tabindex="0">No results</h2>
   <p>Sorry, we didn't find any financial data for <span class="t-bold">{{ entity }}</span> in the <span class="t-bold">{{ cycle | fmt_year_range }}</span> election cycle.</p>
-  <div class="message--no-icon__bottom">
+  <div class="message--alert__bottom">
     <p>Think this was a mistake?</p>
     <ul class="list--buttons">
       <li><a class="button button--standard" href="http://www.fec.gov/finance/disclosure/candcmte_info.shtml">Try FEC.gov</a></li>

--- a/openfecwebapp/templates/partials/search-results-alternatives.html
+++ b/openfecwebapp/templates/partials/search-results-alternatives.html
@@ -6,7 +6,7 @@
   <h2 class="message__title">Not finding what you're looking for?</h2>
   {% endif %}
   <p>View <a class="t-bold" href="{{ url_for('search', search_type=alt_type, search=query )}}">{{alt_type}} results</a> matching <span class="t-bold">"{{ query }}."</span></p>
-  <div class="message--no-icon__bottom">
+  <div class="message--alert__bottom">
     <p>Or browse a different data set:</p>
     <ul class="list--buttons">
       <li><a class="button--browse button--standard" href="{{ url_for('candidates', election_year=default_cycles, has_raised_funds='true') }}">Candidates</a></li>

--- a/openfecwebapp/templates/partials/search-results-alternatives.html
+++ b/openfecwebapp/templates/partials/search-results-alternatives.html
@@ -1,4 +1,4 @@
-<div class="message message--alert">
+<div class="message message--no-icon">
   {% if not results %}
   <h2 class="message__title">No results</h2>
   <p>Sorry, no results match your search, <span class="t-bold">"{{ query }}."</span></p>
@@ -6,7 +6,7 @@
   <h2 class="message__title">Not finding what you're looking for?</h2>
   {% endif %}
   <p>View <a class="t-bold" href="{{ url_for('search', search_type=alt_type, search=query )}}">{{alt_type}} results</a> matching <span class="t-bold">"{{ query }}."</span></p>
-  <div class="message--alert__bottom">
+  <div class="message--no-icon__bottom">
     <p>Or browse a different data set:</p>
     <ul class="list--buttons">
       <li><a class="button--browse button--standard" href="{{ url_for('candidates', election_year=default_cycles, has_raised_funds='true') }}">Candidates</a></li>

--- a/static/templates/electionNoResults.hbs
+++ b/static/templates/electionNoResults.hbs
@@ -1,4 +1,4 @@
-<div class="message message--alert">
+<div class="message message--no-icon">
   <h3 class="message__title">
     {{#if this.zip}}
     We can't find any results for this ZIP code

--- a/static/templates/tables/noData.hbs
+++ b/static/templates/tables/noData.hbs
@@ -1,7 +1,7 @@
 <div class="message message--no-icon">
   <h2 class="message__title" id="section-1-header" tabindex="0">No results</h2>
   <p>Sorry, we didn't find any {{dataType}} for <strong>{{name}}</strong> in <strong>{{timePeriod}}</strong>.</p>
-  <div class="message--no-icon__bottom">
+  <div class="message--alert__bottom">
     <p>Think this was a mistake?</p>
     <ul class="list--buttons">
       <li><a class="button button--standard" href="http://www.fec.gov/finance/disclosure/candcmte_info.shtml">Try FEC.gov</a>

--- a/static/templates/tables/noData.hbs
+++ b/static/templates/tables/noData.hbs
@@ -1,7 +1,7 @@
-<div class="message message--alert">
+<div class="message message--no-icon">
   <h2 class="message__title" id="section-1-header" tabindex="0">No results</h2>
   <p>Sorry, we didn't find any {{dataType}} for <strong>{{name}}</strong> in <strong>{{timePeriod}}</strong>.</p>
-  <div class="message--alert__bottom">
+  <div class="message--no-icon__bottom">
     <p>Think this was a mistake?</p>
     <ul class="list--buttons">
       <li><a class="button button--standard" href="http://www.fec.gov/finance/disclosure/candcmte_info.shtml">Try FEC.gov</a>


### PR DESCRIPTION
## Summary

While I was looking for example patterns for https://github.com/18F/openFEC-web-app/issues/1598 I looked back to our pattern design work in https://github.com/18F/fec-style/issues/266#issuecomment-214425298 and noticed that when I was reviewing the implementation in https://github.com/18F/openFEC-web-app/pull/1205 I missed something. We placed many `alert` style messages where we had intended to place `no-icon` style messages. The slightly angrier tone was picked up by Jeff in this issue: https://github.com/18F/FEC/issues/471
(cc @emileighoutlaw )

This PR replaces these instances with the `no-icon` message pattern.

## Screenshots
**New**

<img width="1158" alt="screen shot 2016-09-30 at 4 12 04 pm" src="https://cloud.githubusercontent.com/assets/11636908/19005927/293ba9c0-872b-11e6-9188-96dc9f231644.png">

**Before**

<img width="1100" alt="screen shot 2016-09-30 at 4 32 43 pm" src="https://cloud.githubusercontent.com/assets/11636908/19005991/7b1d93ca-872b-11e6-8a45-7e832b15330f.png">

 
## Review:
@noahmanger : did I do this right? 