### PR TITLE
Adding polyfill for WeakMap

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "d3": "3.5.5",
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
+    "es6-weak-map": "2.0.1",
     "fec-style": "5.2.1",
     "glossary-panel": "0.2.0",
     "handlebars": "^4.0.5",

--- a/static/js/init.js
+++ b/static/js/init.js
@@ -2,6 +2,10 @@
 
 /* global window, document, ANALYTICS, BASE_PATH, CMS_URL */
 
+// Implementing a polyfill for js native WeakMap
+// in order to patch functionality in an included library
+require('es6-weak-map/implement');
+
 var $ = require('jquery');
 var Sticky = require('component-sticky');
 var Accordion = require('aria-accordion').Accordion;


### PR DESCRIPTION
Adds a polyfill for `WeakMap` to patch a bug in IE 10 caused by an included library that used `WeakMap`. 

Resolves https://github.com/18F/openFEC-web-app/issues/1194
