### PR TITLE
Updates landing page designs

### DIFF
--- a/openfecwebapp/templates/legal-advisory-opinions-landing.html
+++ b/openfecwebapp/templates/legal-advisory-opinions-landing.html
@@ -4,7 +4,7 @@
 <header class="heading--main">
   <h1>Advisory opinions</h1>
 </header>
-<div class="content__section">
+<div class="content__section content__section--narrow">
   <p>
     Advisory opinions are official Commission responses to questions about how federal campaign finance law applies to specific, factual situations.
   </p>
@@ -14,6 +14,30 @@
   <p>
     Learn how to <a href="http://www.fec.gov/pages/brochures/ao.shtml">request an advisory opinion or submit a public comment</a> on an advisory opinion.
   </p>
+  <div class="u-no-print">
+    <div class="slab slab--neutral slab--inline">
+      <div class="container">
+        <div class="row">
+          <div class="usa-width-one-whole">
+            <form action="{{ url_for('advisory_opinions') }}" autocomplete="off" class="search__container  js-search">
+              <label for="search-input" class="label">Search or browse advisory opinions</label>
+              <div class="combo combo--search--medium combo--search--inline">
+                <input id="search-input" type="text" name="search" class="combo__input">
+                <button class="combo__button button--search button--standard" type="submit">
+                  <span class="u-visually-hidden">Search</span>
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+        <div class="row">
+          <div class="usa-width-one-whole">
+            <span class="t-note t-sans search__example">Examples: spending prohibitions; 2003-38</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 <div class="content__section is-disabled">
   <div class="heading--section">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -43,7 +43,7 @@
   </div>
   <div class="sidebar-container">
     <aside class="sidebar sidebar--primary">
-      <h4 class="sidebar__title">Legal resources</h4>
+      <h4 class="sidebar__title">Legal citations</h4>
       <div class="sidebar__content">
         <p>Read the regulations that apply to this page:</p>
         <p>

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -93,7 +93,7 @@
           <div class="row">
             <div class="usa-width-one-whole">
               <form action="{{ url_for('murs') }}" autocomplete="off" class="search__container  js-search">
-                <label for="search-input" class="label">Search or browse MURs</label>
+                <label for="search-input" class="label">Search or browse closed MURs</label>
                 <div class="combo combo--search--large combo--search--inline">
                   <input id="search-input" type="text" name="search" class="combo__input" placeholder="Search MURs">
                   <input id="search-type" type="hidden" name="search_type" value="murs">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -51,21 +51,6 @@
     </aside>
   </div>
 </section>
-
-<!--
-<div class="content__section content__section--narrow">
-  <p>
-    The FEC has exclusive jurisdiction over the civil enforcement of the federal campaign finance law.
-    The FEC learns of possible violations through a number of sources including:
-  </p>
-  <ol class="list--numbered">
-    <li>Internal referrals, which result from the FEC’s routine review of committee reports and audits of political committees.</li>
-    <li>Sworn complaints filed with the FEC by anyone alleging that a violation has occurred or is about to occur.</li>
-    <li>Referrals to the FEC from other government agencies of possible campaign finance violations.</li>
-    <li>Self reported submissions to the FEC by any person or entity that believes it may have  committed a campaign finance violation.</li>
-  </ol>
-</div>
--->
 <div class="content__section content__section--narrow">
   <div class="grid grid--3-wide">
     <div class="grid__item">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -113,16 +113,20 @@
       </div>
     </div>
   </div>
+  <div class="content__section content__section--narrow">
   <h3>Administrative Fine Program</h3>
   <p class="t-italic">
     Coming soon: The Administrative Fine Program assesses civil money penalties
     for late and non-filed reports.
   </p>
+  </div>
+  <div class="content__section content__section--narrow">
   <h3>Alternative Dispute Resolution Program</h3>
   <p class="t-italic">
     Coming soon: Alternative Dispute Resolution is a series of procedures for
     resolving enforcement disputes through the mutual consent of the parties
     involved.
   </p>
+  </div>
 </div>
 {% endblock %}

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -16,6 +16,30 @@
       <li>Referrals to the FEC from other government agencies of possible campaign finance violations.</li>
       <li>Self reported submissions to the FEC by any person or entity that believes it may have  committed a campaign finance violation.</li>
     </ol>
+    <div class="grid grid--2-wide">
+    <div class="grid__item">
+      <h4>Audits</h4>
+      <p class="t-italic">
+        Coming soon: Generally, the Commission may audit a committee when an internal review of the committee’s reports
+        filed meet thresholds of substantial compliance with the Federal Election Campaign Act. Also, the Commission is
+        required to audit all presidential campaigns and convention committees that accept public funds.
+      </p>
+    </div>
+    <div class="grid__item">
+      <h4>Complainants and respondents</h4>
+      <p class="t-italic">
+        Coming soon: Step-by-step guide through the Commission’s enforcement
+        process and enforcement programs.
+      </p>
+    </div>
+    <div class="grid__item">
+      <h4>Report a violation</h4>
+      <p class="t-italic">
+        Coming soon: How to file a complaint with the Commission and how
+        complaints are processed.
+      </p>
+    </div>
+  </div>
   </div>
   <div class="sidebar-container">
     <aside class="sidebar sidebar--primary">
@@ -46,37 +70,11 @@
           <span>11 CFR&nbsp;</span><a href="https://www.gpo.gov/fdsys/search/pagedetails.action?st=11+CFR+111.31&granuleId=CFR-2016-title11-vol1-sec111-31&packageId=CFR-2016-title11-vol1&fromState=">111.31</a>
           <br><i>Administrative fines</i>
         </p>
-
       </div>
     </aside>
   </div>
 </section>
-<div class="content__section content__section--narrow">
-  <div class="grid grid--3-wide">
-    <div class="grid__item">
-      <h4>Audits</h4>
-      <p class="t-italic">
-        Coming soon: Generally, the Commission may audit a committee when an internal review of the committee’s reports
-        filed meet thresholds of substantial compliance with the Federal Election Campaign Act. Also, the Commission is
-        required to audit all presidential campaigns and convention committees that accept public funds.
-      </p>
-    </div>
-    <div class="grid__item">
-      <h4>Complainants and respondents</h4>
-      <p class="t-italic">
-        Coming soon: Step-by-step guide through the Commission’s enforcement
-        process and enforcement programs.
-      </p>
-    </div>
-    <div class="grid__item">
-      <h4>Report a violation</h4>
-      <p class="t-italic">
-        Coming soon: How to file a complaint with the Commission and how
-        complaints are processed.
-      </p>
-    </div>
-  </div>
-</div>
+
 <div class="content__section">
   <header class="heading--section">
     <h2>Enforcement programs</h2>

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -95,7 +95,7 @@
               <form action="{{ url_for('murs') }}" autocomplete="off" class="search__container  js-search">
                 <label for="search-input" class="label">Search or browse closed MURs</label>
                 <div class="combo combo--search--large combo--search--inline">
-                  <input id="search-input" type="text" name="search" class="combo__input" placeholder="Search MURs">
+                  <input id="search-input" type="text" name="search" class="combo__input">
                   <input id="search-type" type="hidden" name="search_type" value="murs">
                   <button class="combo__button button--search button--standard" type="submit">
                     <span class="u-visually-hidden">Search</span>

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -94,7 +94,7 @@
             <div class="usa-width-one-whole">
               <form action="{{ url_for('murs') }}" autocomplete="off" class="search__container  js-search">
                 <label for="search-input" class="label">Search or browse closed MURs</label>
-                <div class="combo combo--search--large combo--search--inline">
+                <div class="combo combo--search--medium combo--search--inline">
                   <input id="search-input" type="text" name="search" class="combo__input">
                   <input id="search-type" type="hidden" name="search_type" value="murs">
                   <button class="combo__button button--search button--standard" type="submit">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -76,7 +76,7 @@
 </section>
 
 <div class="content__section">
-  <header class="heading--section">
+  <header class="heading--main">
     <h2>Enforcement programs</h2>
   </header>
   <div class="content__section content__section--narrow">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -4,6 +4,55 @@
 <header class="heading--main">
   <h1>Enforcement matters</h1>
 </header>
+<section class="content__section"> 
+  <div class="main__content">
+    <p>
+      The FEC has exclusive jurisdiction over the civil enforcement of the federal campaign finance law.
+      The FEC learns of possible violations through a number of sources including:
+    </p>
+    <ol class="list--numbered">
+      <li>Internal referrals, which result from the FEC’s routine review of committee reports and audits of political committees.</li>
+      <li>Sworn complaints filed with the FEC by anyone alleging that a violation has occurred or is about to occur.</li>
+      <li>Referrals to the FEC from other government agencies of possible campaign finance violations.</li>
+      <li>Self reported submissions to the FEC by any person or entity that believes it may have  committed a campaign finance violation.</li>
+    </ol>
+  </div>
+  <div class="sidebar-container">
+    <aside class="sidebar sidebar--primary">
+      <h4 class="sidebar__title">Legal resources</h4>
+      <div class="sidebar__content">
+        <p>Read the regulations that apply to this page:</p>
+        <p>
+          <span>11 CFR&nbsp;</span><a href="https://www.gpo.gov/fdsys/search/pagedetails.action?na=&se=&sm=&flr=&ercode=&dateBrowse=&govAuthBrowse=&collection=&historical=false&st=11+CFR+111.20&psh=&sbh=&tfh=&originalSearch=&fromState=&sb=re&sb=re&ps=10&ps=10&granuleId=CFR-2016-title11-vol1-sec111-20&packageId=CFR-2016-title11-vol1">111.20</a>
+          <br><i>Public disclosure of Commission action</i>
+        </p>
+        <p>
+          <span>11 CFR&nbsp;</span><a href="https://www.gpo.gov/fdsys/search/pagedetails.action?st=11+CFR+111.21&granuleId=CFR-2016-title11-vol1-sec111-21&packageId=CFR-2016-title11-vol1&fromState=">111.21</a>
+          <br><i>Confidentiality</i>
+        </p>
+        <p>
+          <span>11 CFR&nbsp;</span><a href="https://www.gpo.gov/fdsys/search/pagedetails.action?st=11+CFR+111.22&granuleId=CFR-2016-title11-vol1-sec111-22&packageId=CFR-2016-title11-vol1&fromState=">111.22</a>
+          <br><i>Ex parte communications</i>
+        </p>
+        <p>
+          <span>11 CFR&nbsp;</span><a href="https://www.gpo.gov/fdsys/search/pagedetails.action?st=11+CFR+111.23&granuleId=CFR-2016-title11-vol1-sec111-23&packageId=CFR-2016-title11-vol1&fromState=">111.23</a>
+          <br><i>Representation by counsel; notification</i>
+        </p>
+        <p>
+          <span>11 CFR&nbsp;</span><a href="https://www.gpo.gov/fdsys/search/pagedetails.action?st=11+CFR+111.24&granuleId=CFR-2016-title11-vol1-sec111-24&packageId=CFR-2016-title11-vol1&fromState=">111.24</a>
+          <br><i>Civil penalties</i>
+        </p>
+        <p>
+          <span>11 CFR&nbsp;</span><a href="https://www.gpo.gov/fdsys/search/pagedetails.action?st=11+CFR+111.31&granuleId=CFR-2016-title11-vol1-sec111-31&packageId=CFR-2016-title11-vol1&fromState=">111.31</a>
+          <br><i>Administrative fines</i>
+        </p>
+
+      </div>
+    </aside>
+  </div>
+</section>
+
+<!--
 <div class="content__section content__section--narrow">
   <p>
     The FEC has exclusive jurisdiction over the civil enforcement of the federal campaign finance law.
@@ -16,6 +65,7 @@
     <li>Self reported submissions to the FEC by any person or entity that believes it may have  committed a campaign finance violation.</li>
   </ol>
 </div>
+-->
 <div class="content__section content__section--narrow">
   <div class="grid grid--3-wide">
     <div class="grid__item">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -18,7 +18,7 @@
     </ol>
     <div class="grid grid--2-wide">
     <div class="grid__item">
-      <h4>Audits</h4>
+      <h3>Audits</h3>
       <p class="t-italic">
         Coming soon: Generally, the Commission may audit a committee when an internal review of the committee’s reports
         filed meet thresholds of substantial compliance with the Federal Election Campaign Act. Also, the Commission is
@@ -26,14 +26,14 @@
       </p>
     </div>
     <div class="grid__item">
-      <h4>Complainants and respondents</h4>
+      <h3>Complainants and respondents</h3>
       <p class="t-italic">
         Coming soon: Step-by-step guide through the Commission’s enforcement
         process and enforcement programs.
       </p>
     </div>
     <div class="grid__item">
-      <h4>Report a violation</h4>
+      <h3>Report a violation</h3>
       <p class="t-italic">
         Coming soon: How to file a complaint with the Commission and how
         complaints are processed.
@@ -80,7 +80,7 @@
     <h2>Enforcement programs</h2>
   </header>
   <div class="content__section content__section--narrow">
-    <h4>Matters Under Review (MURs)</h4>
+    <h3>Matters Under Review (MURs)</h3>
     <p>
       FEC enforcement matters (called MURs) must, by law, remain confidential until they are closed.
       Law requires the Commission to try to resolve enforcement matters through conciliation.
@@ -113,12 +113,12 @@
       </div>
     </div>
   </div>
-  <h4>Administrative Fine Program</h4>
+  <h3>Administrative Fine Program</h3>
   <p class="t-italic">
     Coming soon: The Administrative Fine Program assesses civil money penalties
     for late and non-filed reports.
   </p>
-  <h4>Alternative Dispute Resolution Program</h4>
+  <h3>Alternative Dispute Resolution Program</h3>
   <p class="t-italic">
     Coming soon: Alternative Dispute Resolution is a series of procedures for
     resolving enforcement disputes through the mutual consent of the parties

--- a/openfecwebapp/templates/legal-statutes-landing.html
+++ b/openfecwebapp/templates/legal-statutes-landing.html
@@ -5,7 +5,7 @@
 <header class="heading--main">
   <h1>Statutes</h1>
 </header>
-<div class="content__section">
+<div class="content__section content__section--narrow">
   <p>
     The FEC administers and enforces the Federal Election Campaign Act, the
     Presidential Election Campaign Fund Act and the Presidential Primary
@@ -13,6 +13,30 @@
     by Congress and signed by the President, are collected and restated as law
     in Title 52 and Title 26 of the U.S. Code.
   </p>
+  <div class="u-no-print">
+    <div class="slab slab--neutral slab--inline">
+      <div class="container">
+        <div class="row">
+          <div class="usa-width-one-whole">
+            <form action="{{ url_for('statutes') }}" autocomplete="off" class="search__container  js-search">
+              <label for="search-input" class="label">Search or browse statutes</label>
+              <div class="combo combo--search--medium combo--search--inline">
+                <input id="search-input" type="text" name="search" class="combo__input">
+                <button class="combo__button button--search button--standard" type="submit">
+                  <span class="u-visually-hidden">Search</span>
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+        <div class="row">
+          <div class="usa-width-one-whole">
+            <span class="t-note t-sans search__example">Examples: spending; 52 USC 30123</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 <div class="content__section">
   <div class="heading--section">


### PR DESCRIPTION
## Summary
This updates the enforcement landing page design to include the required legal citations from OGC in https://github.com/18F/fec-eregs/issues/282

## Things that need to happen before review/merge
- There are a few open content questions for @emileighoutlaw to answer in that issue before this gets merged in
- I'd also like to pair with @noahmanger or @adborden to finesse a few lingering spacing issues within this layout. That will probably require a PR to `fec-style` which I haven't started.
- It would be really really nice to include the search bar patterns in the style guide while we're looking at them, but that's not a deal-breaker :bowing_woman: 

## Screenshots

**Desktop**

![screencapture-127-0-0-1-3000-legal-enforcement-1475806583662](https://cloud.githubusercontent.com/assets/11636908/19177653/ffaa175c-8c18-11e6-925a-71e0f9b9e6c0.png)

**Small screens**

![screencapture-127-0-0-1-3000-legal-enforcement-1475809456877](https://cloud.githubusercontent.com/assets/11636908/19177679/2daf47e4-8c19-11e6-91e1-635879a02aa6.png)

