### PR TITLE
Adding the correct class to headings with action

### DIFF
--- a/openfecwebapp/templates/partials/committee/disbursements-tab.html
+++ b/openfecwebapp/templates/partials/committee/disbursements-tab.html
@@ -2,7 +2,7 @@
 
 <section class="main" id="section-3" role="tabpanel" aria-hidden="true" aria-labelledby="section-3-heading">
   <div class="container">
-    <div class="heading--section">
+    <div class="heading--section heading--with-action">
       <h2 class="heading__left" id="section-2-heading">
         Money spent by this committee: {{ cycle|fmt_year_range }}
       </h2>

--- a/openfecwebapp/templates/partials/committee/filings-tab.html
+++ b/openfecwebapp/templates/partials/committee/filings-tab.html
@@ -1,6 +1,6 @@
 <section class="main" id="section-5" role="tabpanel" aria-hidden="true" aria-labelledby="section-5-heading">
   <div class="container">
-    <div class="heading--section">
+    <div class="heading--section heading--with-action">
       <h2 class="heading__left" id="section-5-heading">
         Committee filings: {{ cycle|fmt_year_range }}
       </h2>

--- a/openfecwebapp/templates/partials/committee/financial-summary.html
+++ b/openfecwebapp/templates/partials/committee/financial-summary.html
@@ -3,7 +3,7 @@
 <section class="main" id="section-1" role="tabpanel" aria-hidden="true" aria-labelledby="section-1-heading">
   <div class="container">
     <div class="content__section">
-      <div class="heading--section">
+      <div class="heading--section heading--with-action">
         <h2 class="heading__left" id="section-1-heading">
           Financial summary: {{ cycle|fmt_year_range }}
         </h2>

--- a/openfecwebapp/templates/partials/committee/receipts-tab.html
+++ b/openfecwebapp/templates/partials/committee/receipts-tab.html
@@ -4,7 +4,7 @@
 
 <section class="main" id="section-2" role="tabpanel" aria-hidden="true" aria-labelledby="section-2-heading">
   <div class="container">
-    <div class="heading--section">
+    <div class="heading--section heading--with-action">
       <h2 class="heading__left" id="section-2-heading">
         Money raised by the committee: {{ cycle|fmt_year_range }}
       </h2>


### PR DESCRIPTION
Fixes an issue where the buttons in headings were breaking onto new lines instead of being floated to the right like: 
![image](https://cloud.githubusercontent.com/assets/1696495/19207211/94a6049e-8ca3-11e6-9849-43bd088e2af7.png)

cc @jenniferthibault 
