### PR TITLE
Fix/add feature flag

### DIFF
--- a/openfecwebapp/config.py
+++ b/openfecwebapp/config.py
@@ -28,6 +28,7 @@ environment = (
 
 features = {
     'legal_murs': bool(env.get_credential('FEC_FEATURE_LEGAL_MURS', '')),
+    'press': bool(env.get_credential('FEC_FEATURE_PRESS', ''))
 }
 
 # Whether the app should force HTTPS/HSTS.

--- a/openfecwebapp/config.py
+++ b/openfecwebapp/config.py
@@ -28,7 +28,8 @@ environment = (
 
 features = {
     'legal_murs': bool(env.get_credential('FEC_FEATURE_LEGAL_MURS', '')),
-    'press': bool(env.get_credential('FEC_FEATURE_PRESS', ''))
+    'press': bool(env.get_credential('FEC_FEATURE_PRESS', '')),
+    'latest_updates': bool(env.get_credential('FEC_FEATURE_UPDATES', ''))
 }
 
 # Whether the app should force HTTPS/HSTS.

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -80,9 +80,11 @@
         <li>
           <a href="{{ cms_url }}/contact-us/">Contact us</a>
         </li>
+        {% if features.press %}
         <li>
           <a href="{{ cms_url }}/press/">Press</a>
         </li>
+        {% endif %}
       </ul>
     </div>
   </div>

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -85,6 +85,11 @@
           <a href="{{ cms_url }}/press/">Press</a>
         </li>
         {% endif %}
+        {% if features.latest_updates %}
+          <li>
+            <a href="{{ cms_url }}/updates/">Latest updates</a>
+          </li>
+        {% endif %}
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This moves the link for the press page in the footer nav behind a feature flag, since we won't be including it in this release.

It also adds the latest updates link, also behind a feature flag.

With the flag enabled, it looks like:
![image](https://cloud.githubusercontent.com/assets/1696495/19296905/bf18a89a-900d-11e6-856b-f32f66d5bc0f.png)

This just brings parity between the web app and the CMS. We should turn this flag on on staging at some point, but it's not necessary right now.