### PR TITLE
Adding tooltip--right to export tooltip

### DIFF
--- a/static/templates/tables/exportWidget.hbs
+++ b/static/templates/tables/exportWidget.hbs
@@ -7,7 +7,7 @@
         class="js-export button button--cta button--export">
           Export
       </button>
-      <div id="export-tooltip" role="tooltip" class="tooltip tooltip--under tooltip__content" aria-hidden="true">
+      <div id="export-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--right tooltip__content" aria-hidden="true">
       </div>
     </div>
   </div>


### PR DESCRIPTION
Uses the new `.tooltip--right` style to ensure that the tooltip is visible and right aligned. 

Requires https://github.com/18F/fec-style/pull/546

Resolves https://github.com/18F/openFEC-web-app/issues/1632