### PR TITLE
Adding coverage period to candidate financial totals page

### DIFF
--- a/openfecwebapp/templates/partials/candidate/financial-summary.html
+++ b/openfecwebapp/templates/partials/candidate/financial-summary.html
@@ -32,7 +32,7 @@
           aggregate.cash != 0 or
           aggregate.debt != 0
          %}
-           <span class="t-sans">Coverage period: {{ aggregate.coverage_start_date|date}}&ndash;{{ aggregate.coverage_end_date|date }}</span> |
+           <span class="t-sans">Coverage period: {{ aggregate.coverage_start_date|date}}&ndash;{{ aggregate.coverage_end_date|date }}</span>  | 
            <a class="t-sans" href="{{ url_for('reports', form_type=report_type, committee_id=committee_ids, cycle=aggregate_cycles, is_amended='false' ) }}">
              View source reports
            </a>

--- a/openfecwebapp/templates/partials/candidate/financial-summary.html
+++ b/openfecwebapp/templates/partials/candidate/financial-summary.html
@@ -32,7 +32,8 @@
           aggregate.cash != 0 or
           aggregate.debt != 0
          %}
-           <a href="{{ url_for('reports', form_type=report_type, committee_id=committee_ids, cycle=aggregate_cycles, is_amended='false' ) }}">
+           <span class="t-sans">Coverage period: {{ aggregate.coverage_start_date|date}}&ndash;{{ aggregate.coverage_end_date|date }}</span> |
+           <a class="t-sans" href="{{ url_for('reports', form_type=report_type, committee_id=committee_ids, cycle=aggregate_cycles, is_amended='false' ) }}">
              View source reports
            </a>
          {% endif %}


### PR DESCRIPTION
This adds support for showing the coverage start and end date on candidate financial summary pages:

![image](https://cloud.githubusercontent.com/assets/1696495/19460357/baa6999e-948f-11e6-8e3a-7a7305ba93fb.png)

Depends on https://github.com/18F/openFEC/pull/1979/
Resolves https://github.com/18F/openFEC-web-app/issues/1584
- cc @jontours if you want to test it.
- cc @jenniferthibault for a quick eyeball test, though we'll be devoting more time to these pages in the near future, so we shouldn't put a ton of effort in.
