### PR TITLE
Adding link to other groups definition

### DIFF
--- a/openfecwebapp/templates/macros/overviews.html
+++ b/openfecwebapp/templates/macros/overviews.html
@@ -51,7 +51,7 @@
       </div>
       <div class="snapshot__item">
         <div class="snapshot__item-title">
-          <span class="swatch other"></span>Other
+          <span class="term" data-term="Other groups"><span class="swatch other"></span>Other groups</span>
         </div>
         <span class="snapshot__item-number">
           <span class="figure__decimals" aria-hidden="true"></span>


### PR DESCRIPTION
Adds a link to the glossary definition for "Other groups":

![image](https://cloud.githubusercontent.com/assets/1696495/19541683/f6b24364-961c-11e6-8faa-caf9d75a25bb.png)

Resolves https://github.com/18F/fec-cms/issues/523
Requires https://github.com/18F/fec-style/pull/551

cc @emileighoutlaw 