### PR TITLE
Make "view xxx" content more accessible

### DIFF
--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -179,7 +179,7 @@
 
 <div class="slab slab--neutral">
   <div class="container">
-    <h2>More ways to view this data</h2>
+    <h2>More ways to explore data</h2>
     <div class="grid grid--4-wide">
       <div class="grid__item">
         <a href="{{ url_for('election_lookup') }}">
@@ -188,7 +188,7 @@
                 <span class="card__icon i-elections"><span class="u-visually-hidden">Icon representing elections</span></span>
             </div>
             <div class="card__content">
-              View elections and candidates by location
+              Find elections by location
             </div>
           </aside>
         </a>
@@ -200,7 +200,7 @@
               <span class="card__icon i-profile"><span class="u-visually-hidden">Icon representing profiles</span></span>
             </div>
             <div class="card__content">
-                Find candidate or committee profiles
+                Search candidate or committee profiles
             </div>
           </aside>
         </a>

--- a/openfecwebapp/templates/candidates-single.html
+++ b/openfecwebapp/templates/candidates-single.html
@@ -65,7 +65,7 @@
       </ul>
       <div class="entity__header__bottom">
         <div class="entity__cycle">
-          <span class="label">View data for</span>
+          <span class="label">Show data for</span>
           {{ select.cycle_select(election_years, cycle, duration=duration, id="cycle-1") }}
         </div>
         <div class="entity__election">

--- a/openfecwebapp/templates/committees-single.html
+++ b/openfecwebapp/templates/committees-single.html
@@ -57,7 +57,7 @@
       </ul>
       <div class="entity__header__bottom">
         <div class="entity__cycle">
-          <span class="label">View data for</span>
+          <span class="label">Show data for</span>
           {{ select.cycle_select(cycles, cycle, class="select--alt-primary")}}
         </div>
       </div>

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -33,7 +33,7 @@
         </div>
         <div class="card__content">
           <h2 class="card__title"><a href="{{ url_for('advanced') }}">Advanced data &raquo;</a></h2>
-          <span>Search, filter and download data.</span>
+          <span>Search, filter and download data</span>
         </div>
       </div>
       <div class="grid__item grid__item--no-margin card card--wide">
@@ -43,7 +43,7 @@
         </div>
         <div class="card__content">
           <h2 class="card__title"><a href="{{ url_for('election_lookup') }}">Elections by location &raquo;</a></h2>
-          <span>Find elections near you&mdash;search by state or ZIP code.</span>
+          <span>Find elections near you&mdash; search by state or ZIP code</span>
         </div>
       </div>
     </div>

--- a/openfecwebapp/templates/layouts/legal-doc-search-results.html
+++ b/openfecwebapp/templates/layouts/legal-doc-search-results.html
@@ -29,7 +29,7 @@
     {% if results.total_all %}
       {% block results %}{% endblock %}
       <div class="results-info">
-	<div class="dataTables_info">Showing {{ results.offset + 1 }}&ndash;{{ results.offset + results[result_type + '_returned'] }} of about {{ results.total_all }}</span></div>
+	<div class="dataTables_info">{{ results.offset + 1 }}&ndash;{{ results.offset + results[result_type + '_returned'] }} of about {{ results.total_all }}</span></div>
 	<div class="dataTables_paginate">
 	  {% if results.offset > 0 %}
 	  <a class="paginate_button previous" href="{{ url_for(result_type, search=query, offset=(results.offset - results.limit)) }}#results-{{ result_type }}">Previous</a>

--- a/openfecwebapp/templates/legal-archived-mur.html
+++ b/openfecwebapp/templates/legal-archived-mur.html
@@ -78,7 +78,7 @@
     <section id="documents" class="content__section">
       <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
       <div class="content__section">
-        <a class="legal-mur__document-button button button--cta button--document button--lg" href="{{ mur.url }}" target="_blank">View case</a>
+        <a class="legal-mur__document-button button button--cta button--document button--lg" href="{{ mur.url }}" target="_blank">Open case</a>
         (<a class="t-sans" href="{{ mur.url }}" target="_blank">{{ mur.pdf_size | filesize}}</a>)
       </div>
     </section>

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -63,7 +63,7 @@
                         {% include 'partials/legal-search-results-statute.html' %}
                         {% endwith %}
                         <div class="results-info">
-                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">View all results</a>
+                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">Show all results</a>
                         </div>
                     {% else %}
                     {{ legal.no_results("statutes", category, query, fec_resources=['fec.gov']) }}
@@ -74,7 +74,7 @@
                         {% include 'partials/legal-search-results-regulation.html' %}
                         {% endwith %}
                         <div class="results-info">
-                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">View all results</a>
+                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">Show all results</a>
                         </div>
                     {% else %}
                     {{ legal.no_results("regulations", category, query, fec_resources=['Rulemaster', 'fec.gov']) }}
@@ -85,7 +85,7 @@
                         {% include 'partials/legal-search-results-advisory-opinion.html' %}
                         {% endwith %}
                         <div class="results-info">
-                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">View all results</a>
+                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">Show all results</a>
                         </div>
                     {% else %}
                     {{ legal.no_results("advisory opinions", category, query, fec_resources=['Advisory_Opinion', 'fec.gov']) }}
@@ -96,7 +96,7 @@
                         {% include 'partials/legal-search-results-mur.html' %}
                         {% endwith %}
                         <div class="results-info">
-                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">View all results</a>
+                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">Show all results</a>
                         </div>
                     {% else %}
                     {{ legal.no_results("enforcement matters", category, query, fec_resources=['Administrative_Fine', 'Alternative_Dispute_Resolution', 'Audit_Reports', 'Matters_Under_Review', 'Matters_Under_Review_Archived', 'fec.gov']) }}

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -63,7 +63,7 @@
                         {% include 'partials/legal-search-results-statute.html' %}
                         {% endwith %}
                         <div class="results-info">
-                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">Show all results</a>
+                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">All results</a>
                         </div>
                     {% else %}
                     {{ legal.no_results("statutes", category, query, fec_resources=['fec.gov']) }}
@@ -74,7 +74,7 @@
                         {% include 'partials/legal-search-results-regulation.html' %}
                         {% endwith %}
                         <div class="results-info">
-                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">Show all results</a>
+                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">All results</a>
                         </div>
                     {% else %}
                     {{ legal.no_results("regulations", category, query, fec_resources=['Rulemaster', 'fec.gov']) }}
@@ -85,7 +85,7 @@
                         {% include 'partials/legal-search-results-advisory-opinion.html' %}
                         {% endwith %}
                         <div class="results-info">
-                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">Show all results</a>
+                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">All results</a>
                         </div>
                     {% else %}
                     {{ legal.no_results("advisory opinions", category, query, fec_resources=['Advisory_Opinion', 'fec.gov']) }}
@@ -96,7 +96,7 @@
                         {% include 'partials/legal-search-results-mur.html' %}
                         {% endwith %}
                         <div class="results-info">
-                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">Show all results</a>
+                        <a class="button button--browse button--alt" href="{{ url_for(category, search=query, search_type=category) }}">All results</a>
                         </div>
                     {% else %}
                     {{ legal.no_results("enforcement matters", category, query, fec_resources=['Administrative_Fine', 'Alternative_Dispute_Resolution', 'Audit_Reports', 'Matters_Under_Review', 'Matters_Under_Review_Archived', 'fec.gov']) }}

--- a/openfecwebapp/templates/macros/disclaimer.html
+++ b/openfecwebapp/templates/macros/disclaimer.html
@@ -1,6 +1,6 @@
 {% macro disclaimer(type, id, cycle) %}
   <div class="datatable__note">
     <p class="t-note">These totals are calculated, in part, using free-text input as reported by this committee. Variations in spelling or abbreviation can produce multiple totals for the same category. For the most complete information,
-    <a href="{{ url_for(type, committee_id=id, cycle=cycle) }}">view the list of itemized transactions.</a></p>
+    <a href="{{ url_for(type, committee_id=id, cycle=cycle) }}">access the list of itemized transactions.</a></p>
   </div>
 {% endmacro %}

--- a/openfecwebapp/templates/macros/filters/date.html
+++ b/openfecwebapp/templates/macros/filters/date.html
@@ -27,7 +27,7 @@
     <div class="tooltip__container">
       <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
       <div id="year-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
-        <p class="tooltip__content">The two-year period in which the transaction was made. Due to the large number of itemized transactions, you can only view one period at a time.</p>
+        <p class="tooltip__content">The two-year period in which the transaction was made. Due to the large number of itemized transactions, you can only access one period at a time.</p>
       </div>
     </div>
     <select id="two-year-transaction-period" name="two_year_transaction_period" aria-describedby="unique-tooltip">

--- a/openfecwebapp/templates/partials/candidate/financial-summary.html
+++ b/openfecwebapp/templates/partials/candidate/financial-summary.html
@@ -34,7 +34,7 @@
          %}
            <span class="t-sans">Coverage period: {{ aggregate.coverage_start_date|date}}&ndash;{{ aggregate.coverage_end_date|date }}</span>  | 
            <a class="t-sans" href="{{ url_for('reports', form_type=report_type, committee_id=committee_ids, cycle=aggregate_cycles, is_amended='false' ) }}">
-             View source reports
+             Open source reports
            </a>
          {% endif %}
       </p>

--- a/openfecwebapp/templates/partials/committee/financial-summary.html
+++ b/openfecwebapp/templates/partials/committee/financial-summary.html
@@ -12,7 +12,7 @@
            committee_id=committee_id,
            cycle=cycle,
            ) }}">
-           View source reports
+           Open source reports
          </a>
       </div>
       <p>Get the full picture of all of the money received and spent by this <span class="term" data-term="Committee">committee</span>.</p>

--- a/openfecwebapp/templates/partials/datatable-modal.html
+++ b/openfecwebapp/templates/partials/datatable-modal.html
@@ -2,11 +2,11 @@
   <div class="panel">
     <div class="panel__row panel__navigation">
       <a class="panel__link button--small button--standard js-pdf_url" target="_blank">
-        View original image
+        Show original image
       </a>
       <button class="js-hide js-panel-close panel__close button--small button"
           data-hides="datatable-modal">
-        <span class="u-visually-hidden">View all</span>
+        <span class="u-visually-hidden">Show all</span>
       </button>
     </div>
     <div class="js-panel-content panel__content">

--- a/openfecwebapp/templates/partials/datatable-modal.html
+++ b/openfecwebapp/templates/partials/datatable-modal.html
@@ -2,7 +2,7 @@
   <div class="panel">
     <div class="panel__row panel__navigation">
       <a class="panel__link button--small button--standard js-pdf_url" target="_blank">
-        Show original image
+        Open original image
       </a>
       <button class="js-hide js-panel-close panel__close button--small button"
           data-hides="datatable-modal">

--- a/openfecwebapp/templates/partials/search-results-alternatives.html
+++ b/openfecwebapp/templates/partials/search-results-alternatives.html
@@ -5,7 +5,7 @@
   {% else %}
   <h2 class="message__title">Not finding what you're looking for?</h2>
   {% endif %}
-  <p>Show <a class="t-bold" href="{{ url_for('search', search_type=alt_type, search=query )}}">{{alt_type}} results</a> matching <span class="t-bold">"{{ query }}."</span></p>
+  <p>Check out <a class="t-bold" href="{{ url_for('search', search_type=alt_type, search=query )}}">{{alt_type}} results</a> matching <span class="t-bold">"{{ query }}."</span></p>
   <div class="message--alert__bottom">
     <p>Or browse a different data set:</p>
     <ul class="list--buttons">

--- a/openfecwebapp/templates/partials/search-results-alternatives.html
+++ b/openfecwebapp/templates/partials/search-results-alternatives.html
@@ -5,7 +5,7 @@
   {% else %}
   <h2 class="message__title">Not finding what you're looking for?</h2>
   {% endif %}
-  <p>View <a class="t-bold" href="{{ url_for('search', search_type=alt_type, search=query )}}">{{alt_type}} results</a> matching <span class="t-bold">"{{ query }}."</span></p>
+  <p>Show <a class="t-bold" href="{{ url_for('search', search_type=alt_type, search=query )}}">{{alt_type}} results</a> matching <span class="t-bold">"{{ query }}."</span></p>
   <div class="message--alert__bottom">
     <p>Or browse a different data set:</p>
     <ul class="list--buttons">

--- a/openfecwebapp/templates/partials/warnings.html
+++ b/openfecwebapp/templates/partials/warnings.html
@@ -23,7 +23,7 @@
 <div class="banner">
   <div class="container">
     <span class="t-block t-bold t-centered">{{ 'STAGING' if environment == 'stage' else 'DEVELOPMENT' }}</span>
-    <span class="t-block t-centered">This site is for testing new ideas and code. View the most accurate data on the <a href="https://beta.fec.gov">live site</a>.</span>
+    <span class="t-block t-centered">This site is for testing new ideas and code. Access the most accurate data on the <a href="https://beta.fec.gov">live site</a>.</span>
   </div>
 </div>
 {% endif %}

--- a/openfecwebapp/templates/search-results.html
+++ b/openfecwebapp/templates/search-results.html
@@ -28,7 +28,7 @@
             {% if results|length >= 20 %}
               <div class="results__count">
                 Showing first 20 results.
-                <a href="{{ url_for(result_type, q=query) }}">View all &raquo;</a>
+                <a href="{{ url_for(result_type, q=query) }}">Show all results &raquo;</a>
               </div>
             {% endif %}
             <h2 class="results__title">Results:</h2>

--- a/openfecwebapp/templates/search-results.html
+++ b/openfecwebapp/templates/search-results.html
@@ -28,7 +28,7 @@
             {% if results|length >= 20 %}
               <div class="results__count">
                 Showing first 20 results.
-                <a href="{{ url_for(result_type, q=query) }}">Show all results &raquo;</a>
+                <a href="{{ url_for(result_type, q=query) }}">All results &raquo;</a>
               </div>
             {% endif %}
             <h2 class="results__title">Results:</h2>

--- a/static/js/modules/column-helpers.js
+++ b/static/js/modules/column-helpers.js
@@ -114,7 +114,7 @@ function buildTotalLink(path, getParams) {
     if (params) {
       var link = document.createElement('a');
       link.textContent = helpers.currency(data);
-      link.setAttribute('title', 'View individual transactions');
+      link.setAttribute('title', 'Show individual transactions');
       if (path.indexOf('receipts') > -1 || path.indexOf('disbursements') > -1) {
         includeTransactionPeriod = true;
       }

--- a/static/templates/candidateStateMap.hbs
+++ b/static/templates/candidateStateMap.hbs
@@ -6,7 +6,7 @@
     </option>
   {{/each}}
   </select>
-  <button class="js-add-map button button--standard button--two-candidates">View two candidates</button>
+  <button class="js-add-map button button--standard button--two-candidates">Show two candidates</button>
   <button class="js-remove-map button button--close button--close--primary" title="Remove map"><span class="u-visually-hidden">Hide map</span></button>
   <div class="state-map-choropleth"></div>
 </div>

--- a/static/templates/electionResult.hbs
+++ b/static/templates/electionResult.hbs
@@ -19,7 +19,7 @@
     {{/if}}
     <div class="row">
       <span class="result__term">Current candidates:</span>
-      <a class="result__definition" href="{{this.url}}">View all &raquo;</a>
+      <a class="result__definition" href="{{this.url}}">Show all &raquo;</a>
     </div>
   </div>
   {{/each}}


### PR DESCRIPTION
"View" generally isn't an ideal word for interface copy, because it can feel exclusionary to folks who use screenreaders and aren't "viewing" the text. 

Additionally, what we mean by "view" can vary depending on the context. This PR attempts to make our content more accessible and descriptive by changing the word "view" into one of the following:

- `Show` when we mean “display” information on the same page
- `Open` when we mean “opening” a document or taking users to a new page
- `Access` when we mean “making contact with” or “gaining access to" information
- `Check out` in the rare instance when we are offering alternative search pathways

 This PR also contains some edits to improve the consistency of our results ranges. Sometimes we had "Viewing XX-XX of XXX results." Sometimes we had "Showing XX to XX of XXX results." Sometimes we had "XX-XX of XXX results."

This PR moves to make all results ranges consistent with `XX-XX of XXX results`, which is the most concise and fastest to scan.

Content only. Anyone can review, but my gut is telling me that @noahmanger should take a gander


