### PR TITLE
Chart fixes

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -235,24 +235,6 @@ def result_or_404(data):
         abort(404)
     return data['results'][0]
 
-def landing_mock_data():
-    return {
-        'raising': {
-            'total': 5409774242.62,
-            'candidates': 1883399322.78,
-            'pacs': 2525845906.85,
-            'parties': 997221077.99,
-            'other': 3307935.00
-        },
-        'spending': {
-            'total': 3571287377.71,
-            'candidates': 1669086332.88,
-            'pacs': 1014344445.93,
-            'parties': 734898386.06,
-            'other': 152958212.84
-        }
-    }
-
 def load_top_candidates(sort, office=None, cycle=2016, per_page=5):
         response = _call_api(
             'candidates', 'totals',

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -27,7 +27,6 @@ def search():
         return render_template('landing.html',
             page='home',
             dates=utils.date_ranges(),
-            totals= api_caller.landing_mock_data(),
             top_candidates_raising = api_caller.load_top_candidates('-receipts')['results'],
             top_candidates_spending = api_caller.load_top_candidates('-disbursements')['results'],
             top_pacs_raising = api_caller.load_top_pacs('-receipts')['results'],

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -65,7 +65,7 @@
             </ul>
           </div>
         </div>
-        {{ overviews.overview(totals['raising'], 'raised', 'landing')}}
+        {{ overviews.overview('raised', 'landing')}}
         <a class="breakdown-link" href="{{ url_for('raising_breakdown') }}">Raising breakdown &raquo;</a>
       </div>
     </section>
@@ -83,7 +83,7 @@
             </ul>
           </div>
         </div>
-        {{ overviews.overview(totals['spending'], 'spent', 'landing')}}
+        {{ overviews.overview('spent', 'landing')}}
         <a class="breakdown-link" href="{{ url_for('spending_breakdown') }}">Spending breakdown &raquo;</a>
       </div>
     </section>

--- a/openfecwebapp/templates/macros/overviews.html
+++ b/openfecwebapp/templates/macros/overviews.html
@@ -1,6 +1,6 @@
 {% import 'macros/reaction-box.html' as reaction_box %}
 
-{% macro overview(data, verb, location) %}
+{% macro overview(verb, location) %}
   <div class="overview js-{{verb}}-overview">
     <div class="overview__chart js-chart">
 
@@ -18,7 +18,7 @@
         <div class="snapshot__item-number">
           <span class="snapshot__item-number">
             <span class="figure__decimals" aria-hidden="true"></span>
-            <span data-total-for="all">{{ data['total'] | currency }}</span>
+            <span data-total-for="all"></span>
           </span>
         </div>
       </div>
@@ -28,7 +28,7 @@
         </div>
         <span class="snapshot__item-number">
           <span class="figure__decimals" aria-hidden="true"></span>
-          <span data-total-for="candidate">{{ data['candidates'] | currency }}</span>
+          <span data-total-for="candidate"></span>
         </span>
       </div>
       <div class="snapshot__item">
@@ -37,7 +37,7 @@
         </div>
         <span class="snapshot__item-number">
           <span class="figure__decimals" aria-hidden="true"></span>
-          <span data-total-for="pac">{{ data['pacs'] | currency }}</span>
+          <span data-total-for="pac"></span>
         </span>
       </div>
       <div class="snapshot__item">
@@ -46,7 +46,7 @@
         </div>
         <span class="snapshot__item-number">
           <span class="figure__decimals" aria-hidden="true"></span>
-          <span data-total-for="party">{{ data['parties'] | currency }}</span>
+          <span data-total-for="party"></span>
         </span>
       </div>
       <div class="snapshot__item">
@@ -55,7 +55,7 @@
         </div>
         <span class="snapshot__item-number">
           <span class="figure__decimals" aria-hidden="true"></span>
-          <span data-total-for="other">{{ data['other'] | currency }}</span>
+          <span data-total-for="other"></span>
         </span>
       </div>
     </div>

--- a/static/js/modules/line-chart.js
+++ b/static/js/modules/line-chart.js
@@ -34,6 +34,8 @@ function LineChart(selector, snapshot, data, index) {
     this.$snapshot.height(this.baseHeight - this.margin.bottom);
   }
 
+  this.moveCursor(this.data[this.data.length - 1]);
+
   this.element.on('mousemove', this.handleMouseMove.bind(this));
   this.$prev.on('click', this.goToPreviousMonth.bind(this));
   this.$next.on('click', this.goToNextMonth.bind(this));

--- a/static/js/modules/line-chart.js
+++ b/static/js/modules/line-chart.js
@@ -50,18 +50,14 @@ LineChart.prototype.buildChart = function() {
     d.date = new Date(d.date);
   });
 
-  // Transform the data
-  var entityNames = d3.keys(data[0])
-    .filter(function(key) {
-      return key !== 'date';
-    });
+  var entityNames = ['candidate', 'party', 'pac', 'other'];
 
   // Create different objects for each entity type
   entityNames.forEach(function(type) {
     var totals = data.map(function(d) {
       return {
         date: d.date,
-        amount: d[type]
+        amount: d[type] || 0
       };
     });
 


### PR DESCRIPTION
This fixes a couple bugs that need fixing before releasing the live data charts.
1. It removes the mock server-side data that was populating the chart on initial page load and instead just moves the dotted line cursor to the last data point.
2. It restores the line for communication spenders by hard-coding the entity types rather than deriving them from the data. This is because the first data point didn't include an entry for `other` which was preventing the line from getting drawn.

cc @LindsayYoung @ccostino 

Resolves https://github.com/18F/openFEC-web-app/issues/1650
Resolves https://github.com/18F/openFEC-web-app/issues/1643
