### PR TITLE
[MERGE WITH GIT FLOW] Updating fec-style to 5.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
     "es6-weak-map": "2.0.1",
-    "fec-style": "5.7.0",
+    "fec-style": "5.7.1",
     "glossary-panel": "0.2.0",
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",


### PR DESCRIPTION
A bump for fec-style to fix the static chart image background placeholders.