### PR TITLE
[MERGE WITH GITFLOW] Hotfix/fix committee tables

### DIFF
--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -255,6 +255,13 @@ var filings = {
       }
     },
   },
+  pdf_url: columnHelpers.urlColumn('pdf_url', {
+    // This is just used by the committee pages because those tables
+    // are too narrow to support the combo button
+    data: 'document_description',
+    className: 'all column--medium',
+    orderable: false
+  }),
   document_type: {
     data: 'document_description',
     className: 'all column--doc-download column--large',


### PR DESCRIPTION
This adds back the `pdf_url` column which was replaced by `document_type` which includes the button to download different versions of a report. This is needed by the committee page filings table, which is currently too narrow to support the button. This fixes an error in production, but we’ll want to come up with a better solution later.

![image](https://cloud.githubusercontent.com/assets/1696495/19907179/faedae8c-a03a-11e6-8441-043a3c7d4882.png)

cc @LindsayYoung 