### PR TITLE
Corrects MUR & AO summary content styling

### DIFF
--- a/openfecwebapp/templates/legal-advisory-opinion.html
+++ b/openfecwebapp/templates/legal-advisory-opinion.html
@@ -19,7 +19,9 @@
     </header>
     <section class="content__section">
       <div id="advisory-opinion-summary" class="main__content">
-        {{ advisory_opinion.summary }}
+        <p>
+          {{ advisory_opinion.summary }}
+        </p>
       </div>
       <div class="sidebar-container">
         <aside class="sidebar sidebar--primary">

--- a/openfecwebapp/templates/legal-archived-mur.html
+++ b/openfecwebapp/templates/legal-archived-mur.html
@@ -35,19 +35,25 @@
         <div class="legal-mur__archive"><span class="legal-mur__archive-icon"><span class="u-visually-hidden">Icon representing an archived case</span></span>Archived case</div>
         {% endif %}
         <div class="legal-mur__property">
-          <strong>OPEN DATE:</strong> {{ mur.open_date | date('%Y-%m-%d') }}
+          <p>
+            <strong>OPEN DATE:</strong> {{ mur.open_date | date('%Y-%m-%d') }}
+          </p>
         </div>
         <div class="legal-mur__property">
-        <strong>CLOSE DATE:</strong> {{ mur.close_date | date('%Y-%m-%d') }}
+          <p>
+            <strong>CLOSE DATE:</strong> {{ mur.close_date | date('%Y-%m-%d') }}
+          </p>
         </div>
         <div class="legal-mur__property">
-        <strong>SUBJECT:</strong>
-        {% for node in mur.subject %}
-        <div>
-          {{ legal.mur_subject(node) }}
-        </div>
-        {% endfor %}
-        </div>
+          <p>
+            <strong>SUBJECT:</strong>
+            {% for node in mur.subject %}
+            <div>
+              {{ legal.mur_subject(node) }}
+            </div>
+            {% endfor %}
+            </div>
+          </p>
       </div>
       {% if mur.citations.regulations or mur.citations.us_code %}
       <div class="sidebar-container">

--- a/openfecwebapp/templates/legal-archived-mur.html
+++ b/openfecwebapp/templates/legal-archived-mur.html
@@ -48,12 +48,14 @@
           <p>
             <strong>SUBJECT:</strong>
             {% for node in mur.subject %}
-            <div>
-              {{ legal.mur_subject(node) }}
-            </div>
-            {% endfor %}
-            </div>
           </p>
+            <div>
+              <p>
+                {{ legal.mur_subject(node) }}
+              </p>
+            </div>
+              {% endfor %}
+        </div>
       </div>
       {% if mur.citations.regulations or mur.citations.us_code %}
       <div class="sidebar-container">

--- a/openfecwebapp/templates/legal-current-mur.html
+++ b/openfecwebapp/templates/legal-current-mur.html
@@ -33,16 +33,24 @@
     <div>
       <h2 class="t-ruled--bold t-ruled--bottom">Summary</h2>
       <div class="legal-mur__property">
-        <strong>COMPLAINANT:</strong> {{ '; '.join(mur['complainants']) }}
+        <p>
+          <strong>COMPLAINANT:</strong> {{ '; '.join(mur['complainants']) }}
+        </p>
       </div>
       <div class="legal-mur__property">
-        <strong>RESPONDENT:</strong> {{ '; '.join(mur['respondents']) }}
+        <p>
+          <strong>RESPONDENT:</strong> {{ '; '.join(mur['respondents']) }}
+        </p>
       </div>
       <div class="legal-mur__property">
-        <strong>SUBJECT:</strong> {{ '; '.join(mur['subject']['text']) }}
+        <p>
+          <strong>SUBJECT:</strong> {{ '; '.join(mur['subject']['text']) }}
+        </p>
       </div>
       <div class="legal-mur__property">
-        <strong>DISPOSITION:</strong> {{ '<br>'.join(mur['disposition_text']) | safe }}
+        <p>
+          <strong>DISPOSITION:</strong> {{ '<br>'.join(mur['disposition_text']) | safe }}
+        </p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
Previously the `<p>` tags were missing from the main content section, so all the copy was rendering as 1.4rem instead of 1.6rem. Too small.

This attempts to repair that by adding those wrappers. 

### Screenshots

<img width="1001" alt="screen shot 2016-11-02 at 11 45 39 pm" src="https://cloud.githubusercontent.com/assets/11636908/19955487/3b646d84-a158-11e6-931e-b465a2f6239b.png">
<img width="736" alt="screen shot 2016-11-02 at 11 45 54 pm" src="https://cloud.githubusercontent.com/assets/11636908/19955489/3b678fc8-a158-11e6-8058-841ac6b9a621.png">
<img width="492" alt="screen shot 2016-11-02 at 11 56 35 pm" src="https://cloud.githubusercontent.com/assets/11636908/19955488/3b65118a-a158-11e6-9f12-4000a6635c65.png">

Completes fixes for #1670 

### Review
@noahmanger or @xtine 