### PR TITLE
Adding means filed to filings panels

### DIFF
--- a/static/js/modules/decoders.js
+++ b/static/js/modules/decoders.js
@@ -185,6 +185,7 @@ module.exports = {
   amendments: {A: 'Amendment', N: 'New'},
   office: {P: 'President', S: 'Senate', H: 'House of Representatives'},
   supportOppose: {S: 'Support', O: 'Oppose'},
+  means: {'e-file': 'eFiling', 'paper': 'Paper filing'},
   forms: forms,
   parties: parties,
   states: states,

--- a/static/js/modules/decoders.js
+++ b/static/js/modules/decoders.js
@@ -185,7 +185,7 @@ module.exports = {
   amendments: {A: 'Amendment', N: 'New'},
   office: {P: 'President', S: 'Senate', H: 'House of Representatives'},
   supportOppose: {S: 'Support', O: 'Oppose'},
-  means: {'e-file': 'eFiling', 'paper': 'Paper filing'},
+  means: {'e-file': 'Electronic filing', 'paper': 'Paper filing'},
   forms: forms,
   parties: parties,
   states: states,

--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -75,6 +75,10 @@ Handlebars.registerHelper('decodeParty', function(value) {
   return decoders.parties[value] || value;
 });
 
+Handlebars.registerHelper('decodeMeans', function(value) {
+  return decoders.means[value] || value;
+});
+
 Handlebars.registerHelper('basePath', BASE_PATH);
 
 Handlebars.registerHelper('panelRow', function(label, options) {

--- a/static/templates/reports/candidate.hbs
+++ b/static/templates/reports/candidate.hbs
@@ -14,6 +14,9 @@
     {{#panelRow "Receipt date"}}
       {{datetime receipt_date format="pretty"}}
     {{/panelRow}}
+    {{#panelRow "Means filed"}}
+      {{ decodeMeans means_filed}}
+    {{/panelRow}}
   </table>
 </div>
 <div class="panel__row">

--- a/static/templates/reports/ie-only.hbs
+++ b/static/templates/reports/ie-only.hbs
@@ -14,6 +14,9 @@
     {{#panelRow "Receipt date"}}
       {{datetime receipt_date format="pretty"}}
     {{/panelRow}}
+    {{#panelRow "Means filed"}}
+      {{ decodeMeans means_filed}}
+    {{/panelRow}}
   </table>
 </div>
 <div class="panel__row">

--- a/static/templates/reports/pac.hbs
+++ b/static/templates/reports/pac.hbs
@@ -14,6 +14,9 @@
     {{#panelRow "Receipt date"}}
       {{datetime receipt_date format="pretty"}}
     {{/panelRow}}
+    {{#panelRow "Means filed"}}
+      {{ decodeMeans means_filed}}
+    {{/panelRow}}
   </table>
 </div>
 <div class="panel__row">


### PR DESCRIPTION
This adds the means filed field to the report panels:

![image](https://cloud.githubusercontent.com/assets/1696495/20120291/25b0248e-a5c1-11e6-9441-26f77732b37c.png)

It will show "eFiling" and "Paper filing".

@emileighoutlaw is that the right labelling?