### PR TITLE
Electronic filing

### DIFF
--- a/openfecwebapp/templates/partials/filters/efiling.html
+++ b/openfecwebapp/templates/partials/filters/efiling.html
@@ -4,10 +4,10 @@
       <button class="tooltip__trigger" type="button" aria-controls="data-type-tooltip"><span class="u-visually-hidden">Learn more</span></button>
       <div id="data-type-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
         <div class="tooltip__content">
-          <strong>eFiling data</strong>
-          <p class="tooltip__content">eFiling data is made available to the public quickly after a committee files a report electronically with the Commission. The information available in these files comes directly from the committee's report in a raw data format. Use processed data to access more comprehensive search options and all years of data.</p>
+          <strong>Electronic filing data</strong>
+          <p class="tooltip__content">Electronic filing data is made available to the public quickly after a committee files a report electronically with the Commission. The information available in these files comes directly from the committee's report in a raw data format. Use processed data to access more comprehensive search options and all years of data.</p>
           <strong>Processed data</strong>
-          <p class="tooltip__content">Processed data has been reviewed by the FEC using a multi-step process. This process can take days (for electronic filings) or weeks (for paper filings). Use processed data to comprehensively search all FEC data, which includes eFilings, once they're processed. Use eFiling data to access the most recent, raw information.</p>
+          <p class="tooltip__content">Processed data has been reviewed by the FEC using a multi-step process. This process can take days (for electronic filings) or weeks (for paper filings). Use processed data to comprehensively search all FEC data, which includes electronic filings, once they're processed. Use electronic filing data to access the most recent, raw information.</p>
         </div>
       </div>
     </div>

--- a/openfecwebapp/templates/partials/filters/efiling.html
+++ b/openfecwebapp/templates/partials/filters/efiling.html
@@ -16,7 +16,7 @@
       <span class="button--alt">Processed data</span>
     </label>
     <label for="switcher-efilings" class="toggle">
-      <input type="radio" class="toggle" value="efiling" id="switcher-efilings" name="data_type" data-prefix="Data type:" data-tag-value="efilings">
+      <input type="radio" class="toggle" value="efiling" id="switcher-efilings" name="data_type" data-prefix="Data type:" data-tag-value="electronic filings">
       <span class="button--alt">Electronic filings</span>
     </label>
   </fieldset>

--- a/openfecwebapp/templates/partials/filters/efiling.html
+++ b/openfecwebapp/templates/partials/filters/efiling.html
@@ -17,6 +17,6 @@
     </label>
     <label for="switcher-efilings" class="toggle">
       <input type="radio" class="toggle" value="efiling" id="switcher-efilings" name="data_type" data-prefix="Data type:" data-tag-value="efilings">
-      <span class="button--alt">eFilings</span>
+      <span class="button--alt">Electronic filings</span>
     </label>
   </fieldset>


### PR DESCRIPTION
One of our UI consistency decisions was to use the phrase "electronic filings" rather than the more jargon-y "e-file" or "eFile" whenever possible.

Content only.

Partially resolves: 18F/fec-cms#585