### PR TITLE
Adding limited MUR search message 

### DIFF
--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -92,7 +92,7 @@
             <div class="usa-width-one-whole">
               <form action="{{ url_for('murs') }}" autocomplete="off" class="search__container  js-search">
                 <label for="search-input" class="label">Search closed MURs</label>
-                <div class="message message--info"><p>Results don't include microfilm cases closed between 1975 and 1998. Search those cases on <a href="http://www.fec.gov/MUR/">FEC.gov.</a></p></div>
+                <div class="message message--info"><p>Results don't include most of the cases closed between 1975 and 1998. Search those cases on <a href="http://www.fec.gov/MUR/">FEC.gov.</a></p></div>
                 <div class="combo combo--search--medium combo--search--inline">
                   <input id="search-input" type="text" name="search" class="combo__input">
                   <input id="search-type" type="hidden" name="search_type" value="murs">

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -4,7 +4,7 @@
 <header class="heading--main">
   <h1>Enforcement matters</h1>
 </header>
-<section class="content__section"> 
+<section class="content__section">
   <div class="main__content">
     <p>
       The FEC has exclusive jurisdiction over the civil enforcement of the federal campaign finance law.
@@ -92,7 +92,6 @@
             <div class="usa-width-one-whole">
               <form action="{{ url_for('murs') }}" autocomplete="off" class="search__container  js-search">
                 <label for="search-input" class="label">Search closed MURs</label>
-                <div class="message message--info"><p>Results don't include most of the cases closed between 1975 and 1998. Search those cases on <a href="http://www.fec.gov/MUR/">FEC.gov.</a></p></div>
                 <div class="combo combo--search--medium combo--search--inline">
                   <input id="search-input" type="text" name="search" class="combo__input">
                   <input id="search-type" type="hidden" name="search_type" value="murs">
@@ -105,9 +104,10 @@
           </div>
           <div class="row">
             <div class="usa-width-one-whole">
-              <span class="t-note t-sans search__example">Examples: filings; 2405</span>
+              <p class="t-note t-sans search__example">Examples: filings; 2405</p>
             </div>
           </div>
+          <p><i class="icon icon--inline--left i-bang-circle"></i>Results don't include most of the cases closed between 1975 and 1998. Search those cases on <a href="http://www.fec.gov/MUR/">FEC.gov.</a></p>
         </div>
       </div>
     </div>

--- a/openfecwebapp/templates/legal-enforcement-landing.html
+++ b/openfecwebapp/templates/legal-enforcement-landing.html
@@ -92,6 +92,7 @@
             <div class="usa-width-one-whole">
               <form action="{{ url_for('murs') }}" autocomplete="off" class="search__container  js-search">
                 <label for="search-input" class="label">Search closed MURs</label>
+                <div class="message message--info"><p>Results don't include microfilm cases closed between 1975 and 1998. Search those cases on <a href="http://www.fec.gov/MUR/">FEC.gov.</a></p></div>
                 <div class="combo combo--search--medium combo--search--inline">
                   <input id="search-input" type="text" name="search" class="combo__input">
                   <input id="search-type" type="hidden" name="search_type" value="murs">

--- a/openfecwebapp/templates/legal-search-results-murs.html
+++ b/openfecwebapp/templates/legal-search-results-murs.html
@@ -3,6 +3,7 @@
 
 {% block results %}
 {% with murs = results.murs %}
+<div class="message message--info"><p>Results don't include microfilm cases closed between 1975 and 1998. Search those cases on <a href="http://www.fec.gov/MUR/">FEC.gov.</a></p></div>
 {% include 'partials/legal-search-results-mur.html' %}
 {% endwith %}
 {% endblock %}

--- a/openfecwebapp/templates/legal-search-results-murs.html
+++ b/openfecwebapp/templates/legal-search-results-murs.html
@@ -3,7 +3,7 @@
 
 {% block results %}
 {% with murs = results.murs %}
-<div class="message message--info"><p>Results don't include microfilm cases closed between 1975 and 1998. Search those cases on <a href="http://www.fec.gov/MUR/">FEC.gov.</a></p></div>
+<div class="message message--info"><p>Results don't include most of the cases closed between 1975 and 1998. Search those cases on <a href="http://www.fec.gov/MUR/">FEC.gov.</a></p></div>
 {% include 'partials/legal-search-results-mur.html' %}
 {% endwith %}
 {% endblock %}

--- a/openfecwebapp/templates/legal-search-results-murs.html
+++ b/openfecwebapp/templates/legal-search-results-murs.html
@@ -1,5 +1,5 @@
 {% extends "layouts/legal-doc-search-results.html" %}
-{% set document_type_display_name = 'enforcement matters' %}
+{% set document_type_display_name = 'Matters Under Review' %}
 
 {% block results %}
 {% with murs = results.murs %}

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -93,7 +93,7 @@
                 {% else %}
                     {% if results["total_" + category] %}
                         {% with murs = results[category] %}
-                        <div class="message message--info"><p>Results don't include microfilm cases closed between 1975 and 1998. Search those cases on <a href="http://www.fec.gov/MUR/">FEC.gov.</a></p></div>
+                        <div class="message message--info"><p>Results don't include most of the cases closed between 1975 and 1998. Search those cases on <a href="http://www.fec.gov/MUR/">FEC.gov.</a></p></div>
                         {% include 'partials/legal-search-results-mur.html' %}
                         {% endwith %}
                         <div class="results-info">

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -93,6 +93,7 @@
                 {% else %}
                     {% if results["total_" + category] %}
                         {% with murs = results[category] %}
+                        <div class="message message--info"><p>Results don't include microfilm cases closed between 1975 and 1998. Search those cases on <a href="http://www.fec.gov/MUR/">FEC.gov.</a></p></div>
                         {% include 'partials/legal-search-results-mur.html' %}
                         {% endwith %}
                         <div class="results-info">

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -25,7 +25,7 @@
         <nav class="sidebar sidebar--neutral side-nav js-sticky-side" data-sticky-container="main">
           <ul class="sidebar__content">
             {% for category in category_order %}
-                {% set category_title = "Enforcement matters" if category == "murs" else category.replace('_', ' ').capitalize() %}
+                {% set category_title = "Matters Under Review" if category == "murs" else category.replace('_', ' ').capitalize() %}
                 {% if features.legal_murs or category != 'murs' %}
                     <li class="side-nav__item">
                         <a class="side-nav__link" href="#results-{{ category|replace('_', '-') }}">
@@ -44,7 +44,7 @@
         <h1 class="main__title">Results for &ldquo;{{ query }}&rdquo;</h1>
         {% endif %}
         {% for category in category_order %}
-            {% set category_title = "Enforcement matters" if category == "murs" else category.replace('_', ' ').capitalize() %}
+            {% set category_title = "Matters Under Review" if category == "murs" else category.replace('_', ' ').capitalize() %}
             {% if features.legal_murs or category != 'murs' %}
             <div id="results-{{ category|replace('_', '-') }}" class="content__section">
                 <div class="results-info results-info--simple">


### PR DESCRIPTION
## Summary:

I wanted to see if I could skip the mockups and design @emileighoutlaw's solutions from https://github.com/18F/openFEC-web-app/issues/1704 in the browser with our existing patterns. I was able to successfully change the name of pages & search fields from "Enforcement" > "Matters Under Review" and add the alert message to both the legal integrates search results and to the MUR search results list.

![screen shot 2016-11-22 at 10 41 21 pm](https://cloud.githubusercontent.com/assets/11636908/20550730/be00f538-b106-11e6-9a13-61e4e4f9d2b1.png)

![screen shot 2016-11-22 at 10 51 21 pm](https://cloud.githubusercontent.com/assets/11636908/20550731/be01d520-b106-11e6-808c-2493800ec576.png)


## Remaining
I couldn't get the enforcement landing page to load locally (I probably have a wrong url or variable somewhere) so [that commit](https://github.com/18F/openFEC-web-app/commit/fa2072bda790091ff82ab45bf5f4840c8c965362) is kind of a shot in the dark, and I've tagged in @xtine to ask for help seeing if it looks 12 types of crazy, or if it looks like it fits there. 



Since I'll be out Weds-Fri this week, I wanted to get this started and welcome others to chip in with commits to this branch: @emileighoutlaw with content edits & @xtine with implementation/front end corrections from here on out. 
