### PR TITLE
Removing feature flags from footer nav items

### DIFF
--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -80,16 +80,12 @@
         <li>
           <a href="{{ cms_url }}/contact-us/">Contact us</a>
         </li>
-        {% if features.press %}
         <li>
           <a href="{{ cms_url }}/press/">Press</a>
         </li>
-        {% endif %}
-        {% if features.latest_updates %}
           <li>
             <a href="{{ cms_url }}/updates/">Latest updates</a>
           </li>
-        {% endif %}
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This removes the feature flags on the footer nav items so that they will show up:

![image](https://cloud.githubusercontent.com/assets/1696495/20781269/6e712354-b736-11e6-83fa-9ac99cda3f40.png)

