### PR TITLE
Format citations according to type

### DIFF
--- a/openfecwebapp/templates/legal-current-mur.html
+++ b/openfecwebapp/templates/legal-current-mur.html
@@ -92,8 +92,14 @@
                 <td> {{ entry.respondent }}</td>
                 <td>
                 {% for citation in entry.citations %}
-                <a href="{{ citation.url }}">{{ citation.text }}{% if not loop.last %}<br>{% endif %}
-                  </a>
+                    {{ citation.title }}
+                    {% if citation.type == 'statute' %}
+                    U.S.C. &sect;
+                    {% else %}
+                    CFR
+                    {% endif %}
+                    <a href="{{ citation.url }}">{{ citation.text }}{% if not loop.last %}<br>{% endif %}
+                    </a>
                 {% endfor %}
                 </td>
               </tr>


### PR DESCRIPTION
Use the following conventions:
- 11 CFR 112.1(a)
- 52 U.S.C. §30123
- Periods and section symbol for U.S.C.
- No period or section symbol for CFR
- Linking only the part of the citation that follows CFR or U.S.C.

Fixes 18F/openFEC#2069

https://github.com/18F/openFEC/issues/2069