### PR TITLE
Feature/ao-filters

### DIFF
--- a/openfecwebapp/templates/layouts/legal-doc-search-results.html
+++ b/openfecwebapp/templates/layouts/legal-doc-search-results.html
@@ -19,7 +19,21 @@
 </header>
 
 <section class="main__content--full data-container__wrapper">
-  {{ legal.filter('Search %s' % (document_type_display_name), result_type, query) }}
+  <div id="filters" class="filters is-open">
+    <button class="filters__header js-filter-toggle" type="button">
+      <span class="filters__title">Search {{ document_type_display_name }}</span>
+    </button>
+    <div class="filters__content">
+      <form id="category-filters" action="{{ url_for(result_type) }}">
+        <div class="filters__inner">
+          <div class="filter" id="search-field">
+            {% block filters %}
+            {% endblock %}
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
   <div id="results-{{ result_type }}" class="content__section data-container__body">
     <div class="results-info results-info--simple">
       <div class="results-info__left">

--- a/openfecwebapp/templates/layouts/legal-doc-search-results.html
+++ b/openfecwebapp/templates/layouts/legal-doc-search-results.html
@@ -26,10 +26,9 @@
     <div class="filters__content">
       <form id="category-filters" action="{{ url_for(result_type) }}">
         <div class="filters__inner">
-          <div class="filter" id="search-field">
-            {% block filters %}
-            {% endblock %}
-          </div>
+          <input id="search-type" type="hidden" name="search_type" value="{{ result_type }}">
+          {% block filters %}
+          {% endblock %}
         </div>
       </form>
     </div>

--- a/openfecwebapp/templates/legal-search-results-advisory_opinions.html
+++ b/openfecwebapp/templates/legal-search-results-advisory_opinions.html
@@ -3,10 +3,10 @@
 {% set document_type_display_name = 'advisory opinions' %}
 
 {% block filters %}
-  {{ legal.text_filter('search', 'Search keywords', query) }}
+  {{ legal.text_filter('search', 'Keywords', query) }}
   {{ legal.text_filter('ao_name', 'AO name')}}
   {{ legal.text_filter('ao_no', 'AO number')}}
-  {{ legal.date_filter('ao_min_date', 'ao_max_date', 'Issued date')}}
+  {{ legal.date_filter('ao_min_date', 'ao_max_date', 'Date issued')}}
   <div class="filter">
     <button class="button button--standard" type="submit">Search</button>
   </div>

--- a/openfecwebapp/templates/legal-search-results-advisory_opinions.html
+++ b/openfecwebapp/templates/legal-search-results-advisory_opinions.html
@@ -3,7 +3,13 @@
 {% set document_type_display_name = 'advisory opinions' %}
 
 {% block filters %}
-  {{ legal.keyword_search(result_type, query) }}
+  {{ legal.text_filter('search', 'Search keywords', query) }}
+  {{ legal.text_filter('ao_name', 'AO name')}}
+  {{ legal.text_filter('ao_no', 'AO number')}}
+  {{ legal.date_filter('ao_min_date', 'ao_max_date', 'Issued date')}}
+  <div class="filter">
+    <button class="button button--standard" type="submit">Search</button>
+  </div>
 {% endblock %}
 
 {% block results %}

--- a/openfecwebapp/templates/legal-search-results-advisory_opinions.html
+++ b/openfecwebapp/templates/legal-search-results-advisory_opinions.html
@@ -1,5 +1,10 @@
 {% extends "layouts/legal-doc-search-results.html" %}
+{% import 'macros/legal.html' as legal %}
 {% set document_type_display_name = 'advisory opinions' %}
+
+{% block filters %}
+  {{ legal.keyword_search(result_type, query) }}
+{% endblock %}
 
 {% block results %}
 {% with advisory_opinions = results.advisory_opinions %}

--- a/openfecwebapp/templates/legal-search-results-murs.html
+++ b/openfecwebapp/templates/legal-search-results-murs.html
@@ -1,5 +1,10 @@
 {% extends "layouts/legal-doc-search-results.html" %}
+{% import 'macros/legal.html' as legal %}
 {% set document_type_display_name = 'Matters Under Review' %}
+
+{% block filters %}
+  {{ legal.keyword_search(result_type, query) }}
+{% endblock %}
 
 {% block results %}
 {% with murs = results.murs %}

--- a/openfecwebapp/templates/legal-search-results-regulations.html
+++ b/openfecwebapp/templates/legal-search-results-regulations.html
@@ -1,5 +1,10 @@
 {% extends "layouts/legal-doc-search-results.html" %}
+{% import 'macros/legal.html' as legal %}
 {% set document_type_display_name = 'regulations' %}
+
+{% block filters %}
+  {{ legal.keyword_search(result_type, query) }}
+{% endblock %}
 
 {% block results %}
 {% with regulations = results.regulations %}

--- a/openfecwebapp/templates/legal-search-results-statutes.html
+++ b/openfecwebapp/templates/legal-search-results-statutes.html
@@ -1,5 +1,10 @@
 {% extends "layouts/legal-doc-search-results.html" %}
+{% import 'macros/legal.html' as legal %}
 {% set document_type_display_name = 'statutes' %}
+
+{% block filters %}
+  {{ legal.keyword_search(result_type, query) }}
+{% endblock %}
 
 {% block results %}
 {% with statutes = results.statutes %}

--- a/openfecwebapp/templates/macros/legal.html
+++ b/openfecwebapp/templates/macros/legal.html
@@ -1,6 +1,6 @@
 {% macro keyword_search(result_type, query) %}
 <div class="filter">
-  <label class="label" for="search-input">Search keywords</label>
+  <label class="label" for="search-input">Keywords</label>
   <div class="combo combo--search--mini">
     <input id="search-input" type="text" name="search" class="combo__input"{% if query %} value="{{ query }}"{% endif %}>
     <button class="combo__button button--search button--standard" type="submit">

--- a/openfecwebapp/templates/macros/legal.html
+++ b/openfecwebapp/templates/macros/legal.html
@@ -3,12 +3,35 @@
   <label class="label" for="search-input">Search keywords</label>
   <div class="combo combo--search--mini">
     <input id="search-input" type="text" name="search" class="combo__input"{% if query %} value="{{ query }}"{% endif %}>
-    <input id="search-type" type="hidden" name="search_type" value="{{ result_type }}">
     <button class="combo__button button--search button--standard" type="submit">
       <span class="u-visually-hidden">Search</span>
     </button>
   </div>
 </div>
+{% endmacro %}
+
+{% macro text_filter(name, label, value) %}
+  <div class="filter">
+    <label class="label" for="{{name}}-filter">{{ label }}</label>
+    <input type="text" name="{{name}}" id="{{name}}-filter"{% if value%} value="{{ value }}"{% endif %}>
+  </div>
+{% endmacro %}
+
+{% macro date_filter(min_name, max_name, label, value) %}
+  <fieldset class="filter">
+    <legend class="label">{{ label }}</legend>
+    <div class="range range--date js-date-range">
+      <div class="range__input range__input--min" data-filter="range">
+        <label for="{{ min_name }}">Beginning</label>
+        <input type="text" id="{{ min_name }}" name="{{ min_name }}">
+      </div>
+      <div class="range__hyphen">-</div>
+      <div class="range__input range__input--max" data-filter="range">
+        <label for="{{ max_name }}">Ending</label>
+        <input type="text" id="{{ max_name }}" name="{{ max_name }}">
+      </div>
+    </div>
+  </fieldset>
 {% endmacro %}
 
 {% macro search(location, result_type, query, button_color="button--standard", select_class="select--alt-primary") %}

--- a/openfecwebapp/templates/macros/legal.html
+++ b/openfecwebapp/templates/macros/legal.html
@@ -23,12 +23,12 @@
     <div class="range range--date js-date-range">
       <div class="range__input range__input--min" data-filter="range">
         <label for="{{ min_name }}">Beginning</label>
-        <input type="text" id="{{ min_name }}" name="{{ min_name }}">
+        <input type="text" id="{{ min_name }}" name="{{ min_name }}" class="js-date-mask">
       </div>
       <div class="range__hyphen">-</div>
       <div class="range__input range__input--max" data-filter="range">
         <label for="{{ max_name }}">Ending</label>
-        <input type="text" id="{{ max_name }}" name="{{ max_name }}">
+        <input type="text" id="{{ max_name }}" name="{{ max_name }}"  class="js-date-mask">
       </div>
     </div>
   </fieldset>

--- a/openfecwebapp/templates/macros/legal.html
+++ b/openfecwebapp/templates/macros/legal.html
@@ -1,23 +1,12 @@
-{% macro filter(title, result_type, query) %}
-<div id="filters" class="filters is-open">
-  <button class="filters__header js-filter-toggle" type="button">
-    <span class="filters__title">{{ title }}</span>
-  </button>
-  <div class="filters__content">
-    <form id="category-filters" action="{{ url_for(result_type) }}">
-      <div class="filters__inner">
-        <div class="filter" id="search-field">
-          <label class="label" for="search-input">Search keywords</label>
-          <div class="combo combo--search--mini">
-            <input id="search-input" type="text" name="search" class="combo__input"{% if query %} value="{{ query }}"{% endif %}>
-            <input id="search-type" type="hidden" name="search_type" value="{{ result_type }}">
-            <button class="combo__button button--search button--standard" type="submit">
-              <span class="u-visually-hidden">Search</span>
-            </button>
-          </div>
-        </div>
-      </div>
-    </form>
+{% macro keyword_search(result_type, query) %}
+<div class="filter">
+  <label class="label" for="search-input">Search keywords</label>
+  <div class="combo combo--search--mini">
+    <input id="search-input" type="text" name="search" class="combo__input"{% if query %} value="{{ query }}"{% endif %}>
+    <input id="search-type" type="hidden" name="search_type" value="{{ result_type }}">
+    <button class="combo__button button--search button--standard" type="submit">
+      <span class="u-visually-hidden">Search</span>
+    </button>
   </div>
 </div>
 {% endmacro %}

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "hbsfy": "2.2.1",
     "intl": "1.0.0-rc-4",
     "jquery": "2.1.4",
+    "jquery.inputmask": "3.2.7",
     "keyboardjs": "0.4.2",
     "leaflet": "0.7.7",
     "leaflet-providers": "1.1.6",

--- a/static/js/pages/legal.js
+++ b/static/js/pages/legal.js
@@ -1,10 +1,15 @@
 'use strict';
 
 /* global require */
+require('jquery.inputmask');
+require('jquery.inputmask/dist/inputmask/inputmask.date.extensions.js');
+require('jquery.inputmask/dist/inputmask/inputmask.numeric.extensions.js');
 
 var $ = require('jquery');
 var FilterPanel = require('fec-style/js/filter-panel').FilterPanel;
 
 $(function () {
-  var filterPanel = new FilterPanel();
+  new FilterPanel();
+
+  $('.js-date-mask').inputmask('mm/dd/yyyy');
 });


### PR DESCRIPTION
This adds the basic makings for the AO filters. 

![image](https://cloud.githubusercontent.com/assets/1696495/21034043/b1b5f26e-bd69-11e6-8b7a-253da4b3e3b8.png)

To do this, I changed the implementation of the filter panel slightly so that the general filter panel code is a block in `legal-doc-search-results.html` that individual doc search pages can populate with the filters of their choosing.

There are now three macros for legal filters:
- `keyword_search` which creates the combo input + button (used by non-AO pages currently)
- `text_filter` which creates a basic text input
- `date_filter` which creates the min and max date range

Remaining to do:
- [x] Add input masks to the date filter in order to format dates correctly

cc @anthonygarvan 