### PR TITLE
[MERGE WITH GITFLOW] Updating chart data munging for the new endpoint

### DIFF
--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -71,7 +71,7 @@
     </section>
     <section class="content__section content__section--ruled" id="spending">
       <h3 class="u-no-margin">Spending</h3>
-      <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">parties</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported spending, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have <em>different reporting schedules</em>.</p>
+      <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">party committees</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported spending, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have <em>different reporting schedules</em>.</p>
       <div class="content__section">
         <div class="heading--section heading--with-action">
           <h4 class="heading__left t-upper">Cumulative amount spent by committees, 2015–2016</h4>

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -52,7 +52,7 @@
     <h2 class="t-ruled--bottom">Get started with campaign finance data</h2>
     <section class="content__section" id="raising">
       <h3 class="u-no-margin">Raising</h3>
-      <p>The total amount raised, by committee type, until specific points in time.</p>
+      <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">parties</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported raising, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have <em>different reporting schedules</em>.</p>
       <div class="content__section">
         <div class="heading--section heading--with-action">
           <h4 class="heading__left t-upper">Cumulative amount raised by committees, 2015–2016</h4>
@@ -71,7 +71,7 @@
     </section>
     <section class="content__section content__section--ruled" id="spending">
       <h3 class="u-no-margin">Spending</h3>
-      <p>The total amount spent, by committee type, up until specific points in time.</p>
+      <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">parties</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported spending, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have <em>different reporting schedules</em>.</p>
       <div class="content__section">
         <div class="heading--section heading--with-action">
           <h4 class="heading__left t-upper">Cumulative amount spent by committees, 2015–2016</h4>

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -52,7 +52,7 @@
     <h2 class="t-ruled--bottom">Get started with campaign finance data</h2>
     <section class="content__section" id="raising">
       <h3 class="u-no-margin">Raising</h3>
-      <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">parties</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported raising, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have different reporting schedules.</p>
+      <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">party committees</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported raising, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have different reporting schedules.</p>
       <div class="content__section">
         <div class="heading--section heading--with-action">
           <h4 class="heading__left t-upper">Cumulative amount raised by committees, 2015–2016</h4>

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -52,7 +52,7 @@
     <h2 class="t-ruled--bottom">Get started with campaign finance data</h2>
     <section class="content__section" id="raising">
       <h3 class="u-no-margin">Raising</h3>
-      <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">parties</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported raising, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have <em>different reporting schedules</em>.</p>
+      <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">parties</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported raising, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have different reporting schedules.</p>
       <div class="content__section">
         <div class="heading--section heading--with-action">
           <h4 class="heading__left t-upper">Cumulative amount raised by committees, 2015–2016</h4>
@@ -71,7 +71,7 @@
     </section>
     <section class="content__section content__section--ruled" id="spending">
       <h3 class="u-no-margin">Spending</h3>
-      <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">party committees</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported spending, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have <em>different reporting schedules</em>.</p>
+      <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">party committees</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported spending, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have different reporting schedules.</p>
       <div class="content__section">
         <div class="heading--section heading--with-action">
           <h4 class="heading__left t-upper">Cumulative amount spent by committees, 2015–2016</h4>

--- a/openfecwebapp/templates/macros/overviews.html
+++ b/openfecwebapp/templates/macros/overviews.html
@@ -24,7 +24,7 @@
       </div>
       <div class="snapshot__item">
         <div class="snapshot__item-title">
-          <span class="term" data-term="candidate"><span class="swatch candidates"></span>Candidates</span>
+          <span class="swatch candidates"></span>Candidates
         </div>
         <span class="snapshot__item-number">
           <span class="figure__decimals" aria-hidden="true"></span>
@@ -33,7 +33,7 @@
       </div>
       <div class="snapshot__item">
         <div class="snapshot__item-title">
-          <span class="term" data-term="political action committee (pac)"><span class="swatch pacs"></span>PACs</span>
+          <span class="swatch pacs"></span>PACs
         </div>
         <span class="snapshot__item-number">
           <span class="figure__decimals" aria-hidden="true"></span>
@@ -42,7 +42,7 @@
       </div>
       <div class="snapshot__item">
         <div class="snapshot__item-title">
-          <span class="term" data-term="party committee"><span class="swatch parties"></span>Party committees</span>
+          <span class="swatch parties"></span>Party committees
         </div>
         <span class="snapshot__item-number">
           <span class="figure__decimals" aria-hidden="true"></span>


### PR DESCRIPTION
This adds support for the new entity totals API from https://github.com/18F/openFEC/pull/2090

This is a hotfix in order to fix a bug on production where the party totals are broken:
![image](https://cloud.githubusercontent.com/assets/1696495/21060005/3429122c-bdfa-11e6-8661-4dcb70ab6acc.png)

cc @LindsayYoung @xtine 