### PR TITLE
Starting advisory opinions landing page update

### DIFF
--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -385,8 +385,8 @@ def advisory_opinions_landing():
         parent='legal',
         result_type='advisory_opinions',
         display_name='advisory opinions',
-        pending_aos=pending_aos,
-        recent_aos=pending_aos)
+        pending_aos=mock_pending,
+        recent_aos=mock_recent)
 
 @app.route('/legal/enforcement/')
 def enforcement_landing():

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -359,10 +359,34 @@ def legal_doc_search(query, result_type, **kwargs):
 
 @app.route('/legal/advisory-opinions/')
 def advisory_opinions_landing():
+    mock_pending = [
+        {
+            'title': 'AO 2011-28: Western Representation PAC',
+            'number': '2011-28',
+            'summary': 'Including the cost of internet ads in independent expenditure reports.',
+            'deadline': 'January 1, 2017'
+        }
+    ]
+
+    mock_recent = [
+        {
+            'title': 'AO 2011-28: Western Representation PAC',
+            'number': '2011-28',
+            'summary': 'Including the cost of internet ads in independent expenditure reports.',
+            'doc': {
+                'title': 'Final opinion',
+                'size': '100kb',
+                'type': 'PDF',
+                'url': ''
+            }
+        }
+    ]
     return render_template('legal-advisory-opinions-landing.html',
         parent='legal',
         result_type='advisory_opinions',
-        display_name='advisory opinions')
+        display_name='advisory opinions',
+        pending_aos=pending_aos,
+        recent_aos=pending_aos)
 
 @app.route('/legal/enforcement/')
 def enforcement_landing():

--- a/openfecwebapp/templates/legal-advisory-opinions-landing.html
+++ b/openfecwebapp/templates/legal-advisory-opinions-landing.html
@@ -5,10 +5,12 @@
   <h1>Advisory opinions</h1>
 </header>
 <section class="content__section content__section--narrow">
-  <p class="t-lead">
-    Advisory opinions are official Commission responses to questions about how federal campaign finance law applies to specific, factual situations.
-  </p>
-  <a class="button button--cta button--go" href="{{ FEC_CMS_URL }}/legal/advisory-opinions/process">The advisory opinion process</a>
+  <div class="content__section">
+    <p class="t-lead">
+      Advisory opinions are official Commission responses to questions about how federal campaign finance law applies to specific, factual situations.
+    </p>
+    <a class="button button--cta button--go" href="{{ FEC_CMS_URL }}/legal/advisory-opinions/process">The advisory opinion process</a>
+  </div>
   <div class="u-no-print">
     <div class="slab slab--neutral slab--inline">
       <div class="container">
@@ -37,9 +39,11 @@
   <div class="heading--section">
     <h2>Pending advisory opinion requests</h2>
   </div>
-  <p>Once the Office of the General Counsel has determined that an advisory opinion request meets all of the requirements to move forward for conisderation by the Commission, the request is made public and is available for public comment for ten days.</p>
-  <a class="button button--standard button--go" href="{{ FEC_CMS_URL }}/legal/advisory-opinions/process#commenting">Learn how to comment</a>
-  <div class="content__section--ruled">
+  <div class="content__section">
+    <p>Once the Office of the General Counsel has determined that an advisory opinion request meets all of the requirements to move forward for conisderation by the Commission, the request is made public and is available for public comment for ten days.</p>
+    <a class="button button--standard button--go" href="{{ FEC_CMS_URL }}/legal/advisory-opinions/process#commenting">Learn how to comment</a>
+  </div>
+  <div class="post-feed">
     {% for post in pending_aos %}
     <article class="post">
       <h3 class="pending-ao__title"><a href="{{ url_for('advisory_opinion_page', ao_no=post.number) }}">{{ post.title }}</a></h3>
@@ -53,9 +57,11 @@
   <div class="heading--section">
     <h2>Recent advisory opinions issued</h2>
   </div>
-  <p>The Commission issues an advisory opinion when four or more Commissioners vote to approve it. These votes almost always occur during an <a href="{{ FEC_CMS_URL }}/calendar/?category=Open+Meetings">open meeting</a>.</p>
-  <a class="button button--standard button--browse" href="{{url_for('advisory_opinions')}}">Explore all advisory opinions</a>
-  <div class="content__section--ruled">
+  <div class="content__section">
+    <p>The Commission issues an advisory opinion when four or more Commissioners vote to approve it. These votes almost always occur during an <a href="{{ FEC_CMS_URL }}/calendar/?category=Open+Meetings">open meeting</a>.</p>
+    <a class="button button--standard button--browse" href="{{url_for('advisory_opinions')}}">Explore all advisory opinions</a>
+  </div>
+  <div class="post-feed">
     {% for post in recent_aos %}
     <article class="post">
       <h3><a href="{{ url_for('advisory_opinion_page', ao_no=post.number) }}">{{ post.title }}</a></h3>

--- a/openfecwebapp/templates/legal-advisory-opinions-landing.html
+++ b/openfecwebapp/templates/legal-advisory-opinions-landing.html
@@ -24,8 +24,8 @@
           </form>
         </div>
         <div class="row">
-          <div class="usa-width-one-whole">
-            <span class="t-note t-sans search__example">Examples: spending prohibitions; 2003-38</span>
+          <div class="row search__example">
+            <span class="t-note t-sans">Examples: spending prohibitions; 2003-38</span>
             <a class="u-float-right t-sans" href="{{url_for('advisory_opinions')}}">Advanced search</a>
           </div>
         </div>
@@ -39,7 +39,15 @@
   </div>
   <p>Once the Office of the General Counsel has determined that an advisory opinion request meets all of the requirements to move forward for conisderation by the Commission, the request is made public and is available for public comment for ten days.</p>
   <a class="button button--standard button--go" href="{{ FEC_CMS_URL }}/legal/advisory-opinions/process#commenting">Learn how to comment</a>
-
+  <div class="content__section--ruled">
+    {% for post in pending_aos %}
+    <article class="post">
+      <h3 class="pending-ao__title"><a href="{{ url_for('advisory_opinion_page', ao_no=post.number) }}">{{ post.title }}</a></h3>
+      <p class="t-sans">{{ post.summary }}</p>
+      <p>Deadline for comments: {{ post.deadline }}</p>
+    </article>
+    {% endfor %}
+  </div>
 </section>
 <section class="content__section content__section--narrow">
   <div class="heading--section">
@@ -47,5 +55,14 @@
   </div>
   <p>The Commission issues an advisory opinion when four or more Commissioners vote to approve it. These votes almost always occur during an <a href="{{ FEC_CMS_URL }}/calendar/?category=Open+Meetings">open meeting</a>.</p>
   <a class="button button--standard button--browse" href="{{url_for('advisory_opinions')}}">Explore all advisory opinions</a>
+  <div class="content__section--ruled">
+    {% for post in recent_aos %}
+    <article class="post">
+      <h3><a href="{{ url_for('advisory_opinion_page', ao_no=post.number) }}">{{ post.title }}</a></h3>
+      <p class="t-sans">{{ post.summary }}</p>
+      <p class="t-sans post__doc"><a href="{{ post.doc.url }}">{{ post.doc.title }} | {{ post.doc.type }}, {{ post.doc.size }}</a></p>
+    </article>
+    {% endfor %}
+  </div>
 </section>
 {% endblock %}

--- a/openfecwebapp/templates/legal-advisory-opinions-landing.html
+++ b/openfecwebapp/templates/legal-advisory-opinions-landing.html
@@ -4,55 +4,48 @@
 <header class="heading--main">
   <h1>Advisory opinions</h1>
 </header>
-<div class="content__section content__section--narrow">
-  <p>
+<section class="content__section content__section--narrow">
+  <p class="t-lead">
     Advisory opinions are official Commission responses to questions about how federal campaign finance law applies to specific, factual situations.
   </p>
-  <p>
-    This archive contains advisory opinions from 1975 to the present. It also contains documents related to advisory opinions — such as requests, drafts and public comments — from 1990 to the present.
-  </p>
-  <p>
-    Learn how to <a href="http://www.fec.gov/pages/brochures/ao.shtml">request an advisory opinion or submit a public comment</a> on an advisory opinion.
-  </p>
+  <a class="button button--cta button--go" href="{{ FEC_CMS_URL }}/legal/advisory-opinions/process">The advisory opinion process</a>
   <div class="u-no-print">
     <div class="slab slab--neutral slab--inline">
       <div class="container">
         <div class="row">
-          <div class="usa-width-one-whole">
-            <form action="{{ url_for('advisory_opinions') }}" autocomplete="off" class="search__container  js-search">
-              <label for="search-input" class="label">Search advisory opinions</label>
-              <div class="combo combo--search--medium combo--search--inline">
-                <input id="search-input" type="text" name="search" class="combo__input">
-                <button class="combo__button button--search button--standard" type="submit">
-                  <span class="u-visually-hidden">Search</span>
-                </button>
-              </div>
-            </form>
-          </div>
+          <form action="{{ url_for('advisory_opinions') }}" autocomplete="off" class="search__container  js-search">
+            <label for="search-input" class="label">Search or browse advisory opinions</label>
+            <div class="combo combo--search--medium combo--search--inline">
+              <input id="search-input" type="text" name="search" class="combo__input">
+              <button class="combo__button button--search button--standard" type="submit">
+                <span class="u-visually-hidden">Search</span>
+              </button>
+            </div>
+          </form>
         </div>
         <div class="row">
           <div class="usa-width-one-whole">
             <span class="t-note t-sans search__example">Examples: spending prohibitions; 2003-38</span>
+            <a class="u-float-right t-sans" href="{{url_for('advisory_opinions')}}">Advanced search</a>
           </div>
         </div>
       </div>
     </div>
   </div>
-</div>
-<div class="content__section is-disabled">
+</section>
+<section class="content__section content__section--narrow">
   <div class="heading--section">
     <h2>Pending advisory opinion requests</h2>
   </div>
-  <div class="content__section">
-    <p>Coming soon.</p>
-  </div>
-</div>
-<div class="content__section is-disabled">
+  <p>Once the Office of the General Counsel has determined that an advisory opinion request meets all of the requirements to move forward for conisderation by the Commission, the request is made public and is available for public comment for ten days.</p>
+  <a class="button button--standard button--go" href="{{ FEC_CMS_URL }}/legal/advisory-opinions/process#commenting">Learn how to comment</a>
+
+</section>
+<section class="content__section content__section--narrow">
   <div class="heading--section">
-    <h2>Latest advisory opinions</h2>
+    <h2>Recent advisory opinions issued</h2>
   </div>
-  <div class="content__section">
-    <p>Coming soon.</p>
-  </div>
-</div>
+  <p>The Commission issues an advisory opinion when four or more Commissioners vote to approve it. These votes almost always occur during an <a href="{{ FEC_CMS_URL }}/calendar/?category=Open+Meetings">open meeting</a>.</p>
+  <a class="button button--standard button--browse" href="{{url_for('advisory_opinions')}}">Explore all advisory opinions</a>
+</section>
 {% endblock %}


### PR DESCRIPTION
This updates the AO landing page as part of https://github.com/18F/fec-eregs/issues/290

In order to get the feeds of latest and pending AOs, this requires the API work from https://github.com/18F/openFEC/pull/2091 as well as upcoming work to allow filtering by document type. 

It's also dependent on https://github.com/18F/fec-cms/pull/654 in order for links to that page to work.

---

Changes to make:
- [ ] Recent advisory opinions should be the last two months

