### PR TITLE
Reverting range

### DIFF
--- a/openfecwebapp/templates/macros/overviews.html
+++ b/openfecwebapp/templates/macros/overviews.html
@@ -64,7 +64,7 @@
   {% endif %}
   <div class="top-list js-top-list" data-type="{{type}}">
     <h2 class="top-list__title">{{ title }} overview</h2>
-    <h3 class="top-list__subtitle">Top <span class="js-top-type">raising</span> (2015 to 2016)</h3>
+    <h3 class="top-list__subtitle">Top <span class="js-top-type">raising</span> (2015–2016)</h3>
     <div class="toggles--simple">
       <button class="toggle is-active" aria-controls="{{type}}-top-raising">Top raising</button> |
       <button class="toggle" aria-controls="{{type}}-top-spending">Top spending</button>

--- a/openfecwebapp/templates/macros/overviews.html
+++ b/openfecwebapp/templates/macros/overviews.html
@@ -8,7 +8,7 @@
     <div class="snapshot js-snapshot">
       <div class="snapshot__controls">
         <button class="button button--standard button--previous js-snapshot-prev"><span class="u-visually-hidden">Previous month</span></button>
-        <h5>Jan 1, 2015 to <span class="js-date">Jul 31, 2016</span></h5>
+        <h5>Jan 1, 2015&ndash;<span class="js-date">Jul 31, 2016</span></h5>
         <button class="button button--standard button--next js-snapshot-next"><span class="u-visually-hidden">next month</span></button>
       </div>
       <div class="snapshot__item">


### PR DESCRIPTION
@xtine — I wasn't paying close enough attention, and two of the ranges were in tables.

Therefore they shouldn't use the word "to". 

This PR reverts the "to" back to a "-"

Two tiny content changes. Sorry 😭😭😭