### PR TITLE
Prepare AO landing page

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -53,11 +53,13 @@ def load_legal_search_results(query, query_type='all', ao_no=None, ao_name=None,
                                 ao_min_date=None, ao_max_date=None,
                                 offset=0, limit=20):
     filters = {}
-    if query:
-        filters['q'] = query
+    if query or query_type == 'advisory_opinions':
         filters['hits_returned'] = limit
         filters['type'] = query_type
         filters['from_hit'] = offset
+
+        if query:
+            filters['q'] = query
 
         if ao_no and ao_no[0]:
             filters['ao_no'] = ao_no

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -384,12 +384,7 @@ def legal_doc_search(query, result_type, ao_no=None, ao_name=None, ao_min_date=N
 
 @app.route('/legal/advisory-opinions/')
 def advisory_opinions_landing():
-    recent_aos = []
-    return render_template('legal-advisory-opinions-landing.html',
-        parent='legal',
-        result_type='advisory_opinions',
-        display_name='advisory opinions',
-        recent_aos=recent_aos)
+    return views.render_legal_ao_landing()
 
 @app.route('/legal/enforcement/')
 def enforcement_landing():

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -384,34 +384,12 @@ def legal_doc_search(query, result_type, ao_no=None, ao_name=None, ao_min_date=N
 
 @app.route('/legal/advisory-opinions/')
 def advisory_opinions_landing():
-    mock_pending = [
-        {
-            'title': 'AO 2011-28: Western Representation PAC',
-            'number': '2011-28',
-            'summary': 'Including the cost of internet ads in independent expenditure reports.',
-            'deadline': 'January 1, 2017'
-        }
-    ]
-
-    mock_recent = [
-        {
-            'title': 'AO 2011-28: Western Representation PAC',
-            'number': '2011-28',
-            'summary': 'Including the cost of internet ads in independent expenditure reports.',
-            'doc': {
-                'title': 'Final opinion',
-                'size': '100kb',
-                'type': 'PDF',
-                'url': ''
-            }
-        }
-    ]
+    recent_aos = []
     return render_template('legal-advisory-opinions-landing.html',
         parent='legal',
         result_type='advisory_opinions',
         display_name='advisory opinions',
-        pending_aos=mock_pending,
-        recent_aos=mock_recent)
+        recent_aos=recent_aos)
 
 @app.route('/legal/enforcement/')
 def enforcement_landing():

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -352,8 +352,8 @@ def legal_doc_search(query, result_type, ao_no=None, ao_name=None, ao_min_date=N
     """Legal search for a specific document type."""
     results = {}
 
-    # Only hit the API if there's an actual query
-    if query:
+    # Only hit the API if there's an actual query or if the result_type is AOs
+    if query or result_type == 'advisory_opinions':
         results = api_caller.load_legal_search_results(query, result_type,
                     ao_no, ao_name, ao_min_date, ao_max_date, **kwargs)
 

--- a/openfecwebapp/templates/legal-advisory-opinions-landing.html
+++ b/openfecwebapp/templates/legal-advisory-opinions-landing.html
@@ -35,7 +35,7 @@
     </div>
   </div>
 </section>
-<section class="content__section content__section--narrow">
+<!-- <section class="content__section content__section--narrow">
   <div class="heading--section">
     <h2>Pending advisory opinion requests</h2>
   </div>
@@ -52,7 +52,7 @@
     </article>
     {% endfor %}
   </div>
-</section>
+</section> -->
 <section class="content__section content__section--narrow">
   <div class="heading--section">
     <h2>Recent advisory opinions issued</h2>

--- a/openfecwebapp/templates/legal-advisory-opinions-landing.html
+++ b/openfecwebapp/templates/legal-advisory-opinions-landing.html
@@ -62,12 +62,14 @@
     <a class="button button--standard button--browse" href="{{url_for('advisory_opinions')}}">Explore all advisory opinions</a>
   </div>
   <div class="post-feed">
-    {% for post in recent_aos %}
+    {% for ao_no in recent_aos %}
+    {% with ao = recent_aos[ao_no] %}
     <article class="post">
-      <h3><a href="{{ url_for('advisory_opinion_page', ao_no=post.number) }}">{{ post.title }}</a></h3>
-      <p class="t-sans">{{ post.summary }}</p>
-      <p class="t-sans post__doc"><a href="{{ post.doc.url }}">{{ post.doc.title }} | {{ post.doc.type }}, {{ post.doc.size }}</a></p>
+      <h3><a href="{{ url_for('advisory_opinion_page', ao_no=ao_no) }}">AO {{ ao_no }} {{ ao[0].name }}</a></h3>
+      <p class="t-sans">{{ ao[0].summary }}</p>
+      <p class="t-sans post__doc"><a href="{{ ao[0].url }}">{{ ao[0].category }} | PDF</a></p>
     </article>
+    {% endwith %}
     {% endfor %}
   </div>
 </section>

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -70,7 +70,7 @@ def render_legal_mur(mur):
 
 def render_legal_ao_landing():
     today = datetime.date.today()
-    ao_min_date = today - datetime.timedelta(weeks=52)
+    ao_min_date = today - datetime.timedelta(weeks=26)
     results = api_caller.load_legal_search_results(query='', query_type='advisory_opinions', ao_min_date=ao_min_date)
     recent_aos=OrderedDict(sorted(results['advisory_opinions'].items(), key=lambda item: item, reverse=True))
     return render_template('legal-advisory-opinions-landing.html',

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -67,6 +67,17 @@ def render_legal_mur(mur):
         parent='legal'
     )
 
+def render_legal_ao_landing():
+    today = datetime.date.today()
+    ao_min_date = today - datetime.timedelta(weeks=20)
+    results = api_caller.load_legal_search_results(query='', query_type='advisory_opinions', ao_min_date=ao_min_date)
+    recent_aos=results['advisory_opinions']
+    return render_template('legal-advisory-opinions-landing.html',
+        parent='legal',
+        result_type='advisory_opinions',
+        display_name='advisory opinions',
+        recent_aos=recent_aos)
+
 
 def to_date(committee, cycle):
     if committee['committee_type'] in ['H', 'S', 'P']:

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -9,6 +9,7 @@ from flask.ext.cors import cross_origin
 from webargs import fields
 from webargs.flaskparser import use_kwargs
 from marshmallow import ValidationError
+from collections import OrderedDict
 
 import github3
 from werkzeug.utils import cached_property
@@ -69,9 +70,9 @@ def render_legal_mur(mur):
 
 def render_legal_ao_landing():
     today = datetime.date.today()
-    ao_min_date = today - datetime.timedelta(weeks=20)
+    ao_min_date = today - datetime.timedelta(weeks=52)
     results = api_caller.load_legal_search_results(query='', query_type='advisory_opinions', ao_min_date=ao_min_date)
-    recent_aos=results['advisory_opinions']
+    recent_aos=OrderedDict(sorted(results['advisory_opinions'].items(), key=lambda item: item, reverse=True))
     return render_template('legal-advisory-opinions-landing.html',
         parent='legal',
         result_type='advisory_opinions',


### PR DESCRIPTION
I forgot to remove the mock data from the new AO landing page before it was merged in, so this removes that and also comments out the pending AO section. I could remove that entirely if we'd prefer to not have commented code, but that should be done soon. 

The remaining task here is to add the last two months of AOs to this page. I'm having local API trouble so can't do this at the moment, but should be able to add on Friday.