### PR TITLE
Updating advanced data sidebar to new styles

### DIFF
--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -47,18 +47,12 @@
           </ul>
           </div>
         </div>
-
         <div class="option__aside">
-          <aside class="is-disabled">
-            <i class="icon-circle--candidate"><span class="u-visually-hidden">Icon of a candidate</span></i>
-            <span>Candidate data overview</span>
-          </aside>
-          <aside>
-            <i class="icon-circle--checklist"><span class="u-visually-hidden">Icon of a checklist</span></i>
-            <span><a href="../registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Candidate registration and reporting requirements</a></span>
-          </aside>
+          <i class="icon-circle--candidate is-disabled"><span class="u-visually-hidden">Icon of a candidate</span></i>
+            <a href="#" class="is-disabled">Candidate data overview</a>
+          <i class="icon-circle--checklist card--stacked"><span class="u-visually-hidden">Icon of a checklist</span></i>
+            <a href="../registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Candidate registration and reporting requirements</a>
         </div>
-
       </div>
       <div id="committees" class="option">
         <h2>Committees</h2>

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -49,7 +49,7 @@
         </div>
         <div class="option__aside">
           <i class="icon-circle--checklist card--stacked"><span class="u-visually-hidden">Icon of a checklist</span></i>
-            <a href="../registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Candidate registration and reporting requirements</a>
+            <a href="{{ cms_url }}/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Candidate registration and reporting requirements</a>
         </div>
       </div>
       <div id="committees" class="option">
@@ -81,9 +81,9 @@
         </div>
         <div class="option__aside">
           <i class="icon-circle--checklist card--stacked"><span class="u-visually-hidden">Icon of a checklist</span></i>
-            <a href="#" class="is-disabled">PAC registration and reporting requirements</a><br><br>
-            <a href="../registration-and-reporting/essentials-political-party-committees/">Political party committee registration and reporting requirements</a><br><br>
-            <a href="../registration-and-reporting/">Registration and reporting requirements for other committees</a>
+            <a href="{{ cms_url }}/registration-and-reporting/essentials-nonconnected-committees/">Nonconnected committee registration and reporting requirements</a><br><br>
+            <a href="{{ cms_url }}/registration-and-reporting/essentials-political-party-committees/">Political party committee registration and reporting requirements</a><br><br>
+            <a href="{{ cms_url }}/registration-and-reporting/">Registration and reporting requirements for other committees</a>
         </div>
       </div>
       <div id="receipts" class="option">

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -48,8 +48,6 @@
           </div>
         </div>
         <div class="option__aside">
-          <i class="icon-circle--candidate is-disabled"><span class="u-visually-hidden">Icon of a candidate</span></i>
-            <a href="#" class="is-disabled">Candidate data overview</a>
           <i class="icon-circle--checklist card--stacked"><span class="u-visually-hidden">Icon of a checklist</span></i>
             <a href="../registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Candidate registration and reporting requirements</a>
         </div>
@@ -82,9 +80,6 @@
           </div>
         </div>
         <div class="option__aside">
-          <i class="icon-circle--committee is-disabled"><span class="u-visually-hidden">Icon of a committee</span></i>
-            <a href="#" class="is-disabled">PAC data overview</a><br><br>
-            <a href="#" class="is-disabled">Party committee data overview</a>
           <i class="icon-circle--checklist card--stacked"><span class="u-visually-hidden">Icon of a checklist</span></i>
             <a href="#" class="is-disabled">PAC registration and reporting requirements</a><br><br>
             <a href="../registration-and-reporting/essentials-political-party-committees/">Political party committee registration and reporting requirements</a><br><br>

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -82,18 +82,13 @@
           </div>
         </div>
         <div class="option__aside">
-          <aside class="card card--primary is-disabled">
-            <span class="card__image card__icon i-committee"><span class="u-visually-hidden">Icon representing a committee</span></span>
-            <div class="card__content">
-              PAC interactive overviews
-            </div>
-          </aside>
-          <aside class="card card--primary card--stacked is-disabled">
-            <span class="card__image card__icon i-committee"><span class="u-visually-hidden">Icon representing a committee</span></span>
-            <div class="card__content">
-              Party committee interactive overviews
-            </div>
-          </aside>
+          <i class="icon-circle--committee is-disabled"><span class="u-visually-hidden">Icon of a committee</span></i>
+            <a href="#" class="is-disabled">PAC data overview</a><br><br>
+            <a href="#" class="is-disabled">Party committee data overview</a>
+          <i class="icon-circle--checklist card--stacked"><span class="u-visually-hidden">Icon of a checklist</span></i>
+            <a href="../registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">PAC registration and reporting requirements</a><br><br>
+            <a href="../registration-and-reporting/essentials-political-party-committees/">Political party committee registration and reporting requirements</a><br><br>
+            <a href="../registration-and-reporting/">Registration and reporting requirements for other committees</a>
         </div>
       </div>
       <div id="receipts" class="option">

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -108,12 +108,8 @@
           </div>
         </div>
         <div class="option__aside">
-          <aside class="card card--primary is-disabled">
-            <span class="card__image card__icon i-receipt"><span class="u-visually-hidden">Icon representing fundraising</span></span>
-            <div class="card__content">
-              Fundraising interactive overviews
-            </div>
-          </aside>
+          <i class="icon-circle--raising"><span class="u-visually-hidden">Icon of a piggy bank</span></i>
+            <a href="/#raising">Raising data overview</a>
         </div>
       </div>
       <div id="spending" class="option">
@@ -140,12 +136,8 @@
           </div>
         </div>
         <div class="option__aside">
-          <aside class="card card--primary is-disabled">
-            <span class="card__image card__icon i-disbursement"><span class="u-visually-hidden">Icon representing spending</span></span>
-            <div class="card__content">
-              Spending interactive overviews
-            </div>
-          </aside>
+          <i class="icon-circle--spending"><span class="u-visually-hidden">Icon of a spreading dollar sign</span></i>
+            <a href="/#spending">Spending data overview</a>
         </div>
       </div>
       <div id="filings" class="option">

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -86,7 +86,7 @@
             <a href="#" class="is-disabled">PAC data overview</a><br><br>
             <a href="#" class="is-disabled">Party committee data overview</a>
           <i class="icon-circle--checklist card--stacked"><span class="u-visually-hidden">Icon of a checklist</span></i>
-            <a href="../registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">PAC registration and reporting requirements</a><br><br>
+            <a href="#" class="is-disabled">PAC registration and reporting requirements</a><br><br>
             <a href="../registration-and-reporting/essentials-political-party-committees/">Political party committee registration and reporting requirements</a><br><br>
             <a href="../registration-and-reporting/">Registration and reporting requirements for other committees</a>
         </div>

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -47,14 +47,18 @@
           </ul>
           </div>
         </div>
+
         <div class="option__aside">
-          <aside class="card card--primary is-disabled">
-            <span class="card__image card__icon i-candidate"><span class="u-visually-hidden">Icon representing a candidate</span></span>
-            <div class="card__content">
-              Candidate interactive overviews
-            </div>
+          <aside class="is-disabled">
+            <i class="icon-circle--candidate"><span class="u-visually-hidden">Icon of a candidate</span></i>
+            <span>Candidate data overview</span>
+          </aside>
+          <aside>
+            <i class="icon-circle--checklist"><span class="u-visually-hidden">Icon of a checklist</span></i>
+            <span><a href="../registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Candidate registration and reporting requirements</a></span>
           </aside>
         </div>
+
       </div>
       <div id="committees" class="option">
         <h2>Committees</h2>

--- a/openfecwebapp/templates/legal-advisory-opinions-landing.html
+++ b/openfecwebapp/templates/legal-advisory-opinions-landing.html
@@ -9,7 +9,7 @@
     <p class="t-lead">
       Advisory opinions are official Commission responses to questions about how federal campaign finance law applies to specific, factual situations.
     </p>
-    <a class="button button--cta button--go" href="{{ FEC_CMS_URL }}/legal/advisory-opinions/process">The advisory opinion process</a>
+    <a class="button button--cta button--go" href="{{ cms_url }}/legal/advisory-opinions/process">The advisory opinion process</a>
   </div>
   <div class="u-no-print">
     <div class="slab slab--neutral slab--inline">
@@ -41,7 +41,7 @@
   </div>
   <div class="content__section">
     <p>Once the Office of the General Counsel has determined that an advisory opinion request meets all of the requirements to move forward for conisderation by the Commission, the request is made public and is available for public comment for ten days.</p>
-    <a class="button button--standard button--go" href="{{ FEC_CMS_URL }}/legal/advisory-opinions/process#commenting">Learn how to comment</a>
+    <a class="button button--standard button--go" href="{{ cms_url }}/legal/advisory-opinions/process#commenting">Learn how to comment</a>
   </div>
   <div class="post-feed">
     {% for post in pending_aos %}
@@ -58,7 +58,7 @@
     <h2>Recent advisory opinions issued</h2>
   </div>
   <div class="content__section">
-    <p>The Commission issues an advisory opinion when four or more Commissioners vote to approve it. These votes almost always occur during an <a href="{{ FEC_CMS_URL }}/calendar/?category=Open+Meetings">open meeting</a>.</p>
+    <p>The Commission issues an advisory opinion when four or more Commissioners vote to approve it. These votes almost always occur during an <a href="{{ cms_url }}/calendar/?category=Open+Meetings">open meeting</a>.</p>
     <a class="button button--standard button--browse" href="{{url_for('advisory_opinions')}}">Explore all advisory opinions</a>
   </div>
   <div class="post-feed">


### PR DESCRIPTION
## Summary

When @noahmanger and I paired through the design & front end implementation review of the [advisory opinion process](https://fec-stage-proxy.18f.gov/legal/advisory-opinions/process/) page, we were able to clarify some styles for how to use icons & cross-site links in the sidebar.

<img width="735" alt="screen shot 2016-12-16 at 3 59 11 pm" src="https://cloud.githubusercontent.com/assets/11636908/21278340/a0eab20e-c3a8-11e6-989b-fad7c37a58b6.png">

I wanted to refresh myself on the code ahead of learning more about the pattern library, so I tried to implement an update of this pattern on the [Advanced Data page](https://beta.fec.gov/data/advanced/) 

There are places where my implementation is Frankenstein-ish and ill-informed, so I'd appreciate help pointing out my errors. I'll try to mark the ones I know about with comments.

## Screenshots

<img width="995" alt="screen shot 2016-12-16 at 3 51 17 pm" src="https://cloud.githubusercontent.com/assets/11636908/21278427/1f2f3b30-c3a9-11e6-969e-571e5dc8d629.png">
<img width="1040" alt="screen shot 2016-12-16 at 3 53 10 pm" src="https://cloud.githubusercontent.com/assets/11636908/21278425/1f2e837a-c3a9-11e6-8d37-3a82b9239e2c.png">
<img width="1024" alt="screen shot 2016-12-16 at 3 53 20 pm" src="https://cloud.githubusercontent.com/assets/11636908/21278426/1f2efff8-c3a9-11e6-8a99-35c45d25aaf1.png">
<img width="986" alt="screen shot 2016-12-16 at 3 53 30 pm" src="https://cloud.githubusercontent.com/assets/11636908/21278428/1f2f823e-c3a9-11e6-9aac-b9b33f946aec.png">

Depends on https://github.com/18F/fec-style/pull/588 for icons