### PR TITLE
Feature/new efiling ui

### DIFF
--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -181,6 +181,7 @@ def filings():
         title='Filings',
         dates=utils.date_ranges(),
         result_type='committees',
+        has_data_type_toggle=True,
         columns=constants.table_columns['filings']
     )
 
@@ -237,6 +238,7 @@ def reports(form_type):
         title=title,
         table_context=context,
         dates=utils.date_ranges(),
+        has_data_type_toggle=True,
         columns=constants.table_columns['reports-' + form_type.lower()]
     )
 

--- a/openfecwebapp/templates/macros/filters/typeahead-filter.html
+++ b/openfecwebapp/templates/macros/filters/typeahead-filter.html
@@ -1,5 +1,10 @@
-{% macro field(name, title, instructions=False, dataset='committees', allow_text=False) %}
-<div class="filter js-filter typeahead-filter" data-filter="typeahead" id="{{ name }}-field" data-name="{{ name }}" data-dataset="{{ dataset }}" {% if allow_text %}data-allow-text{% endif %}>
+{% macro field(name, title, instructions=False, dataset='committees', allow_text=False, filter_name=False) %}
+<div
+  class="filter js-filter typeahead-filter"
+  data-filter="typeahead"
+  id="{{ name }}-field"
+  {% if filter_name %} data-name="{{ filter_name }}" {% endif %}
+  data-dataset="{{ dataset }}" {% if allow_text %}data-allow-text{% endif %}>
   <label class="label" for="{{ name }}">{{ title }}</label>
   <div class="combo combo--search--mini filter__typeahead">
     <ul class="dropdown__selected"></ul>

--- a/openfecwebapp/templates/macros/filters/typeahead-filter.html
+++ b/openfecwebapp/templates/macros/filters/typeahead-filter.html
@@ -1,9 +1,8 @@
-{% macro field(name, title, instructions=False, dataset='committees', allow_text=False, filter_name=False) %}
+{% macro field(name, title, instructions=False, dataset='committees', allow_text=False) %}
 <div
   class="filter js-filter typeahead-filter"
   data-filter="typeahead"
   id="{{ name }}-field"
-  {% if filter_name %} data-name="{{ filter_name }}" {% endif %}
   data-dataset="{{ dataset }}" {% if allow_text %}data-allow-text{% endif %}>
   <label class="label" for="{{ name }}">{{ title }}</label>
   <div class="combo combo--search--mini filter__typeahead">

--- a/openfecwebapp/templates/macros/filters/typeahead-filter.html
+++ b/openfecwebapp/templates/macros/filters/typeahead-filter.html
@@ -2,6 +2,7 @@
 <div
   class="filter js-filter typeahead-filter"
   data-filter="typeahead"
+  data-name="{{ name }}"
   id="{{ name }}-field"
   data-dataset="{{ dataset }}" {% if allow_text %}data-allow-text{% endif %}>
   <label class="label" for="{{ name }}">{{ title }}</label>

--- a/openfecwebapp/templates/partials/filings-filter.html
+++ b/openfecwebapp/templates/partials/filings-filter.html
@@ -10,10 +10,11 @@
 Filter reports
 {% endblock %}
 
+{% block data_type_toggle %}
+  {% include 'partials/filters/efiling.html' %}
+{% endblock %}
+
 {% block filters %}
-<div class="filters__inner">
-{% include 'partials/filters/efiling.html' %}
-</div>
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
   <button type="button" class="js-accordion-trigger accordion__button">Filer</button>
   <div class="accordion__content">

--- a/openfecwebapp/templates/partials/filings-filter.html
+++ b/openfecwebapp/templates/partials/filings-filter.html
@@ -14,6 +14,13 @@ Filter reports
   {% include 'partials/filters/efiling.html' %}
 {% endblock %}
 
+{% block efiling_filters %}
+  <div class="filters__inner">
+    {{ typeahead.field('committee_id', 'Committee name or ID', '') }}
+    {{ date.field('receipt_date', 'Receipt date', dates ) }}
+  </div>
+{% endblock %}
+
 {% block filters %}
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
   <button type="button" class="js-accordion-trigger accordion__button">Filer</button>

--- a/openfecwebapp/templates/partials/filings-filter.html
+++ b/openfecwebapp/templates/partials/filings-filter.html
@@ -16,7 +16,7 @@ Filter reports
 
 {% block efiling_filters %}
   <div class="filters__inner">
-    {{ typeahead.field('committee_id', 'Committee name or ID', '', filter_name='committee_id_efiling') }}
+    {{ typeahead.field('committee_id', 'Committee name or ID', '') }}
     {{ date.field('receipt_date', 'Receipt date', dates) }}
   </div>
 {% endblock %}

--- a/openfecwebapp/templates/partials/filings-filter.html
+++ b/openfecwebapp/templates/partials/filings-filter.html
@@ -16,8 +16,8 @@ Filter reports
 
 {% block efiling_filters %}
   <div class="filters__inner">
-    {{ typeahead.field('committee_id', 'Committee name or ID', '') }}
-    {{ date.field('receipt_date', 'Receipt date', dates ) }}
+    {{ typeahead.field('committee_id', 'Committee name or ID', '', filter_name='committee_id_efiling') }}
+    {{ date.field('receipt_date', 'Receipt date', dates) }}
   </div>
 {% endblock %}
 

--- a/openfecwebapp/templates/partials/filters.html
+++ b/openfecwebapp/templates/partials/filters.html
@@ -1,7 +1,7 @@
 <div id="filters" class="filters">
 {% if has_data_type_toggle %}
   <button type="button" class="filters__header filters__toggle js-filter-toggle">Select data type</button>
-  <div class="filters__content" id="category-filters" aria-hidden="true">
+  <div class="filters__content" id="category-filters" aria-hidden="true" data-efiling-filters=true>
     <div id="data-type-toggle" class="filters__inner data-type">
       {% block data_type_toggle %}{% endblock %}
     </div>

--- a/openfecwebapp/templates/partials/filters.html
+++ b/openfecwebapp/templates/partials/filters.html
@@ -11,6 +11,11 @@
   <div class="filters__content" id="category-filters" aria-hidden="true">
 {% endif %}
     {% block message %}{% endblock %}
-    {% block filters %}{% endblock %}
+    <div class="js-filters" data-filters-data="efiling" aria-hidden="true">
+      {% block efiling_filters %}{% endblock %}
+    </div>
+    <div class="js-filters" data-filters-data="processed">
+      {% block filters %}{% endblock %}
+    </div>
   </div>
 </div>

--- a/openfecwebapp/templates/partials/filters.html
+++ b/openfecwebapp/templates/partials/filters.html
@@ -1,11 +1,16 @@
 <div id="filters" class="filters">
-  <button type="button" class="filters__header js-filter-toggle">Edit filters</button>
-  <div class="filters__content" aria-hidden="true">
-    <div id="category-filters">
-      <div class="filters__message-container">
-        {% block message %}{% endblock %}
-      </div>
-      {% block filters %}{% endblock %}
+{% if has_data_type_toggle %}
+  <button type="button" class="filters__header filters__toggle js-filter-toggle">Edit filters</button>
+  <div class="filters__content" id="category-filters" aria-hidden="true">
+    <div id="data-type-toggle" class="filters__inner data-type">
+      {% block data_type_toggle %}{% endblock %}
     </div>
+    <div class="filters__header">Edit filters</div>
+{% else %}
+  <button type="button" class="filters__header filters__toggle js-filter-toggle">Edit filters</button>
+  <div class="filters__content" id="category-filters" aria-hidden="true">
+{% endif %}
+    {% block message %}{% endblock %}
+    {% block filters %}{% endblock %}
   </div>
 </div>

--- a/openfecwebapp/templates/partials/filters.html
+++ b/openfecwebapp/templates/partials/filters.html
@@ -11,10 +11,10 @@
   <div class="filters__content" id="category-filters" aria-hidden="true">
 {% endif %}
     {% block message %}{% endblock %}
-    <div class="js-filters" data-filters-data="efiling" aria-hidden="true">
+    <div class="js-efiling-filters" aria-hidden="true">
       {% block efiling_filters %}{% endblock %}
     </div>
-    <div class="js-filters" data-filters-data="processed">
+    <div class="js-processed-filters">
       {% block filters %}{% endblock %}
     </div>
   </div>

--- a/openfecwebapp/templates/partials/filters.html
+++ b/openfecwebapp/templates/partials/filters.html
@@ -1,13 +1,13 @@
 <div id="filters" class="filters">
 {% if has_data_type_toggle %}
-  <button type="button" class="filters__header filters__toggle js-filter-toggle">Edit filters</button>
+  <button type="button" class="filters__header filters__toggle js-filter-toggle">Select data type</button>
   <div class="filters__content" id="category-filters" aria-hidden="true">
     <div id="data-type-toggle" class="filters__inner data-type">
       {% block data_type_toggle %}{% endblock %}
     </div>
-    <div class="filters__header">Edit filters</div>
+    <div class="filters__header js-filter-header">Edit filters</div>
 {% else %}
-  <button type="button" class="filters__header filters__toggle js-filter-toggle">Edit filters</button>
+  <button type="button" class="filters__header filters__toggle js-filter-header">Edit filters</button>
   <div class="filters__content" id="category-filters" aria-hidden="true">
 {% endif %}
     {% block message %}{% endblock %}

--- a/openfecwebapp/templates/partials/filters/efiling.html
+++ b/openfecwebapp/templates/partials/filters/efiling.html
@@ -6,8 +6,8 @@
         <span class="button--alt">Processed</span>
       </label>
       <label for="switcher-efilings" class="toggle">
-        <input type="radio" class="toggle" value="efiling" id="switcher-efilings" name="data_type" data-prefix="Data type:" data-tag-value="electronic filings" aria-controls="efiling-message">
-        <span class="button--alt">Real-time</span>
+        <input type="radio" class="toggle" value="efiling" id="switcher-efilings" name="data_type" data-prefix="Data type:" data-tag-value="raw" aria-controls="efiling-message">
+        <span class="button--alt">Raw</span>
       </label>
     </div>
     <div class="data-type__message">

--- a/openfecwebapp/templates/partials/filters/efiling.html
+++ b/openfecwebapp/templates/partials/filters/efiling.html
@@ -1,22 +1,21 @@
-  <fieldset class="filter toggles toggles--vertical js-filter js-table-switcher" data-filter="toggle">
+  <fieldset class="filter toggles js-filter js-table-switcher" data-filter="toggle">
     <legend class="label t-inline-block">Data type</legend>
-    <div class="tooltip__container">
-      <button class="tooltip__trigger" type="button" aria-controls="data-type-tooltip"><span class="u-visually-hidden">Learn more</span></button>
-      <div id="data-type-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
-        <div class="tooltip__content">
-          <strong>Electronic filing data</strong>
-          <p class="tooltip__content">Electronic filing data is made available to the public quickly after a committee files a report electronically with the Commission. The information available in these files comes directly from the committee's report in a raw data format. Use processed data to access more comprehensive search options and all years of data.</p>
-          <strong>Processed data</strong>
-          <p class="tooltip__content">Processed data has been reviewed by the FEC using a multi-step process. This process can take days (for electronic filings) or weeks (for paper filings). Use processed data to comprehensively search all FEC data, which includes electronic filings, once they're processed. Use electronic filing data to access the most recent, raw information.</p>
-        </div>
+    <div class="row">
+      <label for="switcher-processed" class="toggle">
+        <input type="radio" class="toggle" value="processed" id="switcher-processed" checked name="data_type" data-prefix="Data type:" data-tag-value="processed" aria-controls="processed-message">
+        <span class="button--alt">Processed</span>
+      </label>
+      <label for="switcher-efilings" class="toggle">
+        <input type="radio" class="toggle" value="efiling" id="switcher-efilings" name="data_type" data-prefix="Data type:" data-tag-value="electronic filings" aria-controls="efiling-message">
+        <span class="button--alt">Real-time</span>
+      </label>
+    </div>
+    <div class="data-type__message">
+      <div id="processed-message" class="js-table-switcher-message" aria-hidden="false">
+        <p>This data <em>has been</em> categorized and coded by the FEC. The FEC's multi-step process can take days (for electronic filings) or weeks (for paper filings).</p>
+      </div>
+      <div id="efiling-message" class="js-table-switcher-message" aria-hidden="true">
+        <p>This data <em>has not</em> yet been categorized and coded by the FEC. It's pulled directly from a committee's raw, electronic reports. It doesn't include paper filings.</p>
       </div>
     </div>
-    <label for="switcher-processed" class="toggle">
-      <input type="radio" class="toggle" value="processed" id="switcher-processed" checked name="data_type" data-prefix="Data type:" data-tag-value="processed">
-      <span class="button--alt">Processed data</span>
-    </label>
-    <label for="switcher-efilings" class="toggle">
-      <input type="radio" class="toggle" value="efiling" id="switcher-efilings" name="data_type" data-prefix="Data type:" data-tag-value="electronic filings">
-      <span class="button--alt">Electronic filings</span>
-    </label>
   </fieldset>

--- a/openfecwebapp/templates/partials/operating-expenditures-filter.html
+++ b/openfecwebapp/templates/partials/operating-expenditures-filter.html
@@ -9,8 +9,10 @@ Filter operating expenditures
 {% endblock %}
 
 {% block message %}
-<div class="message message--info message--small">
-  <span class="t-block">Due to the large number of transactions, records begin in 2011.</span>
+<div class="filters__message-container">
+  <div class="message message--info message--small">
+    <span class="t-block">Due to the large number of transactions, records begin in 2011.</span>
+  </div>
 </div>
 {% endblock %}
 

--- a/openfecwebapp/templates/partials/reports-filter.html
+++ b/openfecwebapp/templates/partials/reports-filter.html
@@ -16,6 +16,13 @@ Filter reports
   {% include 'partials/filters/efiling.html' %}
 {% endblock %}
 
+{% block efiling_filters %}
+  <div class="filters__inner">
+    {{ typeahead.field('committee_id', 'Committee name or ID', '') }}
+    {{ date.field('receipt_date', 'Receipt date', dates ) }}
+  </div>
+{% endblock %}
+
 {% block filters %}
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
   <button type="button" class="js-accordion-trigger accordion__button">Filer</button>

--- a/openfecwebapp/templates/partials/reports-filter.html
+++ b/openfecwebapp/templates/partials/reports-filter.html
@@ -12,10 +12,11 @@
 Filter reports
 {% endblock %}
 
+{% block data_type_toggle %}
+  {% include 'partials/filters/efiling.html' %}
+{% endblock %}
+
 {% block filters %}
-<div class="filters__inner">
-{% include 'partials/filters/efiling.html' %}
-</div>
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
   <button type="button" class="js-accordion-trigger accordion__button">Filer</button>
   <div class="accordion__content">

--- a/static/js/modules/table-switcher.js
+++ b/static/js/modules/table-switcher.js
@@ -4,6 +4,8 @@ var $ = require('jquery');
 
 /* TableSwitcher
  * For switching between efile and processed results
+ * All this does toggle the visibility of the appropriate message
+ * And trigger an event with a set of options that is then received by DataTable
  */
 
 function TableSwitcher(control, opts) {

--- a/static/js/modules/table-switcher.js
+++ b/static/js/modules/table-switcher.js
@@ -1,8 +1,6 @@
 'use strict';
 
 var $ = require('jquery');
-var tables = require('./tables');
-var URI = require('urijs');
 
 /* TableSwitcher
  * For switching between efile and processed results
@@ -11,7 +9,6 @@ var URI = require('urijs');
 function TableSwitcher(control, opts) {
   this.$control = $(control);
   this.opts = opts;
-
   this.$control.on('change', this.handleChange.bind(this));
 }
 
@@ -24,7 +21,14 @@ TableSwitcher.prototype.init = function() {
 TableSwitcher.prototype.handleChange = function(e) {
   var table = $(e.target).val();
   var opts = this.opts[table];
+  this.toggleMessage(table);
   this.$control.trigger('table:switch', opts);
+};
+
+TableSwitcher.prototype.toggleMessage = function(table) {
+  // Hide the visible message and show the message for the selected toggle
+  this.$control.find('.js-table-switcher-message[aria-hidden="false"]').attr('aria-hidden', true);
+  this.$control.find('#' + table + '-message').attr('aria-hidden', false);
 };
 
 module.exports = {TableSwitcher: TableSwitcher};

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -250,7 +250,8 @@ function filterSuccessUpdates(changeCount) {
   // check if there is a changed form element
   if (updateChangedEl) {
     var $label;
-    var type = $(updateChangedEl).attr('type');
+    var $elm = $(updateChangedEl);
+    var type = $elm.attr('type');
     var message = '';
     var filterAction = '';
     var filterResult = '';
@@ -264,33 +265,32 @@ function filterSuccessUpdates(changeCount) {
 
       filterAction = 'Filter added';
 
-      if (!$(updateChangedEl).is(':checked')) {
+      if (!$elm.is(':checked')) {
         filterAction = 'Filter removed';
       }
     } else if (type === 'radio') {
       // Add the message after the last radio button / toggle
       $label = $('label[for="' + updateChangedEl.id + '"]').closest('fieldset');
-      filterAction = 'Filter applied.';
+      filterAction = $elm.attr('name') == 'data_type' ?
+        'Data type changed.' : 'Filter applied.';
 
-      if (!$(updateChangedEl).is(':checked')) {
+      if (!$elm.is(':checked')) {
         filterAction = 'Filter removed.';
       }
     }
     else if (type === 'text') {
       // typeahead
-      if ($(updateChangedEl).hasClass('tt-input')) {
+      if ($elm.hasClass('tt-input')) {
         // show message after generated checkbox (last item in list)
         $label = $('[data-filter="typeahead"] li').last();
         filterAction = 'Filter added';
       }
-      else if ($(updateChangedEl).closest('.range').hasClass('range--currency')) {
-        $label = $(updateChangedEl).closest('.range');
-
+      else if ($elm.closest('.range').hasClass('range--currency')) {
+        $label = $elm.closest('.range');
         filterAction = 'Filter applied';
       }
-      else if ($(updateChangedEl).closest('.range').hasClass('range--date')) {
+      else if ($elm.closest('.range').hasClass('range--date')) {
         $label = $('.date-range-grid');
-
         filterAction = 'Filter applied';
       }
       // text input search
@@ -301,8 +301,8 @@ function filterSuccessUpdates(changeCount) {
     }
     else {
       // probably a select dropdown
-      $label = $(updateChangedEl);
-      filterAction = '"' + $(updateChangedEl).find('option:selected').text() + '" applied.';
+      $label = $elm;
+      filterAction = '"' + $elm.find('option:selected').text() + '" applied.';
     }
 
     $('.is-loading').removeClass('is-loading').addClass('is-successful');

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -709,12 +709,7 @@ DataTable.prototype.handleSwitch = function(e, opts) {
   this.opts.hideColumns = opts.hideColumns;
   this.opts.disableExport = opts.disableExport;
   this.opts.path = opts.path;
-
-  if (opts.disableFilters) {
-    this.filterSet.disableFilters(opts.enabledFilters);
-  } else {
-    this.filterSet.enableFilters();
-  }
+  this.filterSet.switchFilters(opts.dataType);
 
   if (!this.api) {
     this.initTable();

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -497,7 +497,7 @@ DataTable.prototype.destroy = function() {
 };
 
 DataTable.prototype.handlePopState = function() {
-  this.filterSet.activate();
+  this.filterSet.activateAll();
   var filters = this.filterSet.serialize();
   if (!_.isEqual(filters, this.filters)) {
     this.api.ajax.reload();

--- a/static/js/pages/filings.js
+++ b/static/js/pages/filings.js
@@ -44,12 +44,12 @@ $(document).ready(function() {
   new TableSwitcher('.js-table-switcher', {
     efiling: {
       path: ['efile', 'filings'],
-      disableFilters: true,
-      enabledFilters: ['committee_id', 'data_type', 'receipt_date'],
+      dataType: 'efiling',
       hideColumns: '.hide-efiling'
     },
     processed: {
       path: ['filings'],
+      dataType: 'processed',
       hideColumns: '.hide-processed'
     }
   }).init();

--- a/static/js/pages/reports.js
+++ b/static/js/pages/reports.js
@@ -67,11 +67,11 @@ $(document).ready(function() {
 
   new TableSwitcher('.js-table-switcher', {
     efiling: {
-      path: ['efile', 'reports', context.form_type],
-      disableFilters: true,
-      enabledFilters: ['committee_id', 'data_type', 'receipt_date']
+      dataType: 'efiling',
+      path: ['efile', 'reports', context.form_type]
     },
     processed: {
+      dataType: 'processed',
       path: ['reports', context.form_type]
     }
   }).init();

--- a/tests/unit/modules/table-switcher.js
+++ b/tests/unit/modules/table-switcher.js
@@ -1,0 +1,95 @@
+'use strict';
+
+/* global require */
+
+var chai = require('chai');
+var expect = chai.expect;
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+
+var $ = require('jquery');
+require('../setup')();
+
+var TableSwitcher = require('../../../static/js/modules/table-switcher').TableSwitcher;
+
+  describe('Table switcher', function() {
+    before(function() {
+      this.$fixture = $('<div id="fixtures"></div>');
+      $('body').append(this.$fixture);
+    });
+
+    beforeEach(function() {
+      this.$fixture.empty().append(
+      '<fieldset>' +
+        '<legend>Data type</legend>' +
+        '<label for="switcher-processed">' +
+          '<input type="radio" value="processed" id="switcher-processed" checked name="data_type">' +
+          '<span>Processed</span>' +
+        '</label>' +
+        '<label for="switcher-efilings">' +
+          '<input type="radio" value="efiling" id="switcher-efilings" name="data_type">' +
+          '<span>Raw</span>' +
+        '</label>' +
+        '<div id="processed-message" class="js-table-switcher-message" aria-hidden="false">' +
+          '<p>Processed message.</p>' +
+        '</div>' +
+        '<div id="efiling-message" class="js-table-switcher-message" aria-hidden="true">' +
+          '<p>Raw message</p>' +
+        '</div>' +
+      '</fieldset>'
+      );
+      this.tableSwitcher = new TableSwitcher(this.$fixture.find('fieldset'), {
+          efiling: {
+            path: ['efile', 'filings'],
+            dataType: 'efiling',
+          },
+          processed: {
+            path: ['filings'],
+            dataType: 'processed',
+          }
+        }
+       );
+
+      this.trigger = sinon.spy($.prototype, 'trigger');
+    });
+
+    afterEach(function() {
+      $.prototype.trigger.restore();
+    });
+
+
+    it('locates dom elements', function() {
+      expect(this.tableSwitcher.$control.is('#fixtures fieldset')).to.be.true;
+    });
+
+    it('triggers an event with the options for the checked input on init', function() {
+      this.tableSwitcher.init();
+      expect(this.trigger).to.have.been.calledWith('table:switch',
+        {
+          path: ['filings'],
+          dataType: 'processed',
+        }
+      );
+    });
+
+    it('triggers an the table:switch with the correct options on change', function() {
+      var target = $('#fixtures input[value="efiling"]');
+      var e = {
+        target: target
+      };
+      this.tableSwitcher.handleChange(e);
+      expect(this.trigger).to.have.been.calledWith('table:switch',
+        {
+          path: ['efile', 'filings'],
+          dataType: 'efiling',
+        }
+      );
+    });
+
+    it('toggles visibility of the message', function() {
+      this.tableSwitcher.toggleMessage('efiling');
+      expect($('#efiling-message').attr('aria-hidden')).to.equal('false');
+      expect($('#processed-message').attr('aria-hidden')).to.equal('true');
+    });
+  });

--- a/tests/unit/modules/tables.js
+++ b/tests/unit/modules/tables.js
@@ -241,7 +241,7 @@ describe('data table', function() {
     it('calls fetch on reload', function() {
       var serialized = {name: 'bartlet'};
       this.table.filterSet = {
-        activate: function() {},
+        activateAll: function() {},
         serialize: function() { return serialized; }
       };
       this.table.filters = null;
@@ -252,7 +252,7 @@ describe('data table', function() {
     it('does not call fetch on reload when state is unchanged', function() {
       var serialized = {name: 'bartlet'};
       this.table.filterSet = {
-        activate: function() {},
+        activateAll: function() {},
         serialize: function() { return serialized; }
       };
       this.table.filters = serialized;


### PR DESCRIPTION
This does a few things in order to implement the new efiling UI. 

![demo](http://g.recordit.co/z9dbjb75aN.gif)

Basically, pages that have a processed and raw data set now have two separate chunks of filters. If a data page has multiple data sets, the route needs to pass the `has_data_type_toggle` flag, which then tells the template to add the data type toggle and make two separate `divs` of filters, one for raw data and one for processed and these pages then add a separate block for `efiling_filters`.

This also contains the change to make the toggle horizontal and includes the explanatory messages.

The rest of the logic happens in https://github.com/18F/fec-style/pull/593 because that's where `filter-set.js` lives.

Requires https://github.com/18F/fec-style/pull/593
Resolves https://github.com/18F/openFEC-web-app/issues/1734