### PR TITLE
making dates required to avoid parse error

### DIFF
--- a/openfecwebapp/templates/macros/legal.html
+++ b/openfecwebapp/templates/macros/legal.html
@@ -23,12 +23,12 @@
     <div class="range range--date js-date-range">
       <div class="range__input range__input--min" data-filter="range">
         <label for="{{ min_name }}">Beginning</label>
-        <input type="text" id="{{ min_name }}" name="{{ min_name }}" value="{{ min_value }}" class="js-date-mask">
+        <input type="text" id="{{ min_name }}" name="{{ min_name }}" value="{{ min_value }}" class="js-date-mask" required="">
       </div>
       <div class="range__hyphen">-</div>
       <div class="range__input range__input--max" data-filter="range">
         <label for="{{ max_name }}">Ending</label>
-        <input type="text" id="{{ max_name }}" name="{{ max_name }}" value="{{ max_value }}" class="js-date-mask">
+        <input type="text" id="{{ max_name }}" name="{{ max_name }}" value="{{ max_value }}" class="js-date-mask" required="">
       </div>
     </div>
   </fieldset>


### PR DESCRIPTION
This makes the date fields required. If they are submitted as empty, webargs throws a parse error that cannot be handled by setting missing=None (since it is not missing, but actively set to an empty string). Long term solution here is to replace native submit functionality with a js submit. 