### PR TITLE
Improves sorting of MURS participants by type

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -313,11 +313,12 @@ def _get_sorted_participants_by_type(mur):
     for participant in mur['participants']:
         participants_by_type[participant['role']].append(participant['name'])
 
-    # Sort participants, remove roles without participants
+    # Remove roles without participants
+    for role in [key for key, value in participants_by_type.items() if not value]:
+        del participants_by_type[role]
+
+    # Sort remaining participants
     for key, value in participants_by_type.items():
-        if not value:
-            del participants_by_type[key]
-        else:
-            participants_by_type[key] = sorted(participants_by_type[key])
+        participants_by_type[key] = sorted(participants_by_type[key])
 
     return participants_by_type


### PR DESCRIPTION
This changeset addresses a small issue I noticed with the code that handles the sorting of MURS participants by type.  The tests were failing due to an `OrderedDict` being modified during iteration, so I moved the code that removed empty roles outside of the loop over the `OrderedDict` items.  Generally speaking, inserting/deleting items in a container/collection-like structure while iterating over it will produce unpredictable results and is not supported.  I thought `OrderedDict`s were a bit different in that regard, but apparently not due to the failing test I was seeing.  At least in Python 3, the same underlying dictionary views are used, which mentions that a `RuntimeError` can occur in this situation:  https://docs.python.org/3.5/library/stdtypes.html\#dictionary-view-objects

/cc @anthonygarvan, @vrajmohan, @jontours, @LindsayYoung