### PR TITLE
Hotfix/fix transaction period

### DIFF
--- a/openfecwebapp/templates/macros/filters/date.html
+++ b/openfecwebapp/templates/macros/filters/date.html
@@ -31,8 +31,8 @@
       </div>
     </div>
     <select id="two-year-transaction-period" name="two_year_transaction_period" aria-describedby="unique-tooltip">
-      {% for year in range(current_year | int, 1978, -2) %}
-        <option value="{{year}}" >{{ year | fmt_year_range }}</option>
+      {% for year in range(2016 | int, 1978, -2) %}
+        <option value="{{year}}">{{ year | fmt_year_range }}</option>
       {% endfor %}
     </select>
   </div>


### PR DESCRIPTION
This is temporary fix to the broken receipts and disbursements pages. The reason they're broken is that the previous code for generating the list of `transaction period` options just started with the current year and built two-year periods off of that. This hard codes the starting value as 2016, which is ok for now because there's no data for the next period. But this should be fixed better and I'll make a new issue for that.