### PR TITLE
Feature/about links

### DIFF
--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -53,7 +53,6 @@
       <img src="{{ url_for('static', filename='img/print-logo.png') }}" class="u-print-only" alt="FEC logo">
       <a title="Home" href="{{ cms_url }}/" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
       <ul class="utility-nav list--flat">
-        <li class="utility-nav__item is-disabled">About</li>
         <li class="utility-nav__item"><a href="{{ cms_url }}/calendar/">Calendar</a></li>
         <li class="utility-nav__item"><button class="js-glossary-toggle glossary__toggle">Glossary</button></li>
       </ul>
@@ -82,6 +81,9 @@
       <ul>
         <li>
           <a href="{{ cms_url }}/contact-us/">Contact us</a>
+        </li>
+        <li>
+          <a href="{{ cms_url }}/about/">About</a>
         </li>
         <li>
           <a href="{{ cms_url }}/press/">Press</a>

--- a/openfecwebapp/templates/partials/navigation.html
+++ b/openfecwebapp/templates/partials/navigation.html
@@ -12,9 +12,6 @@
       <li class="site-nav__item">
         <a href="{{ cms_url }}/legal-resources" class="site-nav__link {% if parent == 'legal' %}is-parent{% endif %}">Legal resources</a>
       </li>
-      <li class="site-nav__item utility-nav__item is-disabled">
-        <a href="#" class="site-nav__link">About</a>
-      </li>
       <li class="site-nav__item utility-nav__item">
         <a href="{{ cms_url }}/contact-us/" class="site-nav__link">Contact</a>
       </li>

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
     "es6-weak-map": "2.0.1",
-    "fec-style": "6.1.0",
+    "fec-style": "6.2.0",
     "glossary-panel": "0.2.0",
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",


### PR DESCRIPTION
This adds a link to the about page in the footer and removes it from the utility nav, for consistency.

Unrelated, it includes the hotfix we merged in earlier to hard code the transaction period year so that it try to build invalid values.