### PR TITLE
Removing filters and fixing param name

### DIFF
--- a/openfecwebapp/templates/partials/disbursements-filter.html
+++ b/openfecwebapp/templates/partials/disbursements-filter.html
@@ -17,7 +17,6 @@ Filter disbursements
 {% block efiling_filters %}
 <div class="filters__inner">
   {{ typeahead.field('committee_id', 'Committee name or ID', id_suffix='_raw') }}
-  {{ text.field('recipient_name', 'Recipient name', id_suffix='_raw') }}
   {{ text.field('disbursement_description', 'Description', id_suffix='_raw') }}
 </div>
 {% endblock %}

--- a/openfecwebapp/templates/partials/independent-expenditures-filter.html
+++ b/openfecwebapp/templates/partials/independent-expenditures-filter.html
@@ -19,7 +19,7 @@ Filter independent expenditures
 {% block efiling_filters %}
 <div class="filters__inner">
   {{ typeahead.field('committee_id', 'Spender name or ID', id_suffix='_raw') }}
-  {{ text.field('candidate', 'Candidate mentioned', id_suffix='_raw')}}
+  {{ text.field('candidate_name', 'Candidate mentioned', id_suffix='_raw')}}
   {{ misc.support_oppose('_raw') }}
   {{ date.field('expenditure_date', 'Expenditure date', dates, id_suffix='_raw') }}
 </div>

--- a/openfecwebapp/templates/partials/receipts-filter.html
+++ b/openfecwebapp/templates/partials/receipts-filter.html
@@ -21,8 +21,6 @@ Filter receipts
   {{ text.field('contributor_name', 'Contributor name', id_suffix='_raw') }}
   {{ text.field('contributor_city', 'Contributor city', id_suffix='_raw') }}
   {{ states.field('contributor_state', id_suffix='_raw') }}
-  {{ text.field('contributor_employer', 'Contributor employer', id_suffix='_raw') }}
-  {{ text.field('contributor_occupation', 'Contributor occupation', id_suffix='_raw') }}
 </div>
 {% endblock %}
 


### PR DESCRIPTION
Removes the contributor employer and occupation filters on receipts and recipient name on disubrsements. 

Also fixes the parameter of the independent expenditure candidate filter to be `candidate_name`.

Resolves https://github.com/18F/openFEC/issues/2157