### PR TITLE
Fixing link to AO process page

### DIFF
--- a/openfecwebapp/templates/legal-advisory-opinions-landing.html
+++ b/openfecwebapp/templates/legal-advisory-opinions-landing.html
@@ -9,7 +9,7 @@
     <p class="t-lead">
       Advisory opinions are official Commission responses to questions about how federal campaign finance law applies to specific, factual situations.
     </p>
-    <a class="button button--cta button--go" href="{{ cms_url }}/legal/advisory-opinions/process">The advisory opinion process</a>
+    <a class="button button--cta button--go" href="{{ cms_url }}/legal-resources/advisory-opinions-process">The advisory opinion process</a>
   </div>
   <div class="u-no-print">
     <div class="slab slab--neutral slab--inline">


### PR DESCRIPTION
The new AO process page in this upcoming release is a CMS page rather than a static view with a hard-coded URL. This updates the link to go to the correct place.