### PR TITLE
Feature/default cycle

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -8,6 +8,7 @@ from flask import abort
 
 from openfecwebapp import utils
 from openfecwebapp import config
+from openfecwebapp import constants
 
 from collections import OrderedDict
 
@@ -259,7 +260,7 @@ def result_or_404(data):
         abort(404)
     return data['results'][0]
 
-def load_top_candidates(sort, office=None, cycle=2016, per_page=5):
+def load_top_candidates(sort, office=None, cycle=constants.DEFAULT_TIME_PERIOD, per_page=5):
         response = _call_api(
             'candidates', 'totals',
             sort_hide_null=True,
@@ -274,7 +275,7 @@ def load_top_candidates(sort, office=None, cycle=2016, per_page=5):
             return response
         return {}
 
-def load_top_pacs(sort, cycle=2016, per_page=5):
+def load_top_pacs(sort, cycle=constants.DEFAULT_TIME_PERIOD, per_page=5):
         response = _call_api(
             'totals', 'pac',
             sort_hide_null=True, cycle=cycle, sort=sort, per_page=per_page
@@ -283,7 +284,7 @@ def load_top_pacs(sort, cycle=2016, per_page=5):
             return response
         return {}
 
-def load_top_parties(sort, cycle=2016, per_page=5):
+def load_top_parties(sort, cycle=constants.DEFAULT_TIME_PERIOD, per_page=5):
         response = _call_api(
             'totals', 'party',
             sort_hide_null=True, cycle=cycle, sort=sort, per_page=per_page

--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict
 
 START_YEAR = 1979
+END_YEAR = 2018
+DEFAULT_TIME_PERIOD = 2016
 
 states = OrderedDict([
     ('AK', 'Alaska'),

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -24,16 +24,22 @@ def search():
         results = api_caller.load_search_results(query, result_type)
         return views.render_search_results(results, query, result_type)
     else:
+        top_candidates_raising = api_caller.load_top_candidates('-receipts')
+        top_candidates_spending = api_caller.load_top_candidates('-disbursements')
+        top_pacs_raising = api_caller.load_top_pacs('-receipts')
+        top_pacs_spending = api_caller.load_top_pacs('-disbursements')
+        top_parties_raising = api_caller.load_top_parties('-receipts')
+        top_parties_spending = api_caller.load_top_parties('-disbursements')
         return render_template('landing.html',
             page='home',
             parent='data',
             dates=utils.date_ranges(),
-            top_candidates_raising = api_caller.load_top_candidates('-receipts')['results'],
-            top_candidates_spending = api_caller.load_top_candidates('-disbursements')['results'],
-            top_pacs_raising = api_caller.load_top_pacs('-receipts')['results'],
-            top_pacs_spending = api_caller.load_top_pacs('-disbursements')['results'],
-            top_parties_raising = api_caller.load_top_parties('-receipts')['results'],
-            top_parties_spending = api_caller.load_top_parties('-disbursements')['results'],
+            top_candidates_raising = top_candidates_raising['results'] if top_candidates_raising else None,
+            top_candidates_spending = top_candidates_spending['results'] if top_candidates_spending else None,
+            top_pacs_raising = top_pacs_raising['results'] if top_pacs_raising else None,
+            top_pacs_spending = top_pacs_spending['results'] if top_pacs_spending else None,
+            top_parties_raising = top_parties_raising['results'] if top_parties_raising else None,
+            top_parties_spending = top_parties_spending['results'] if top_parties_spending else None,
             title='Campaign finance data')
 
 @app.route('/api/')

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -18,6 +18,9 @@
     API_LOCATION = '{{ api_location }}';
     API_VERSION = '{{ api_version }}';
     API_KEY = '{{ api_key }}';
+    DEFAULT_TIME_PERIOD = '{{ constants.DEFAULT_TIME_PERIOD }}';
+    START_YEAR = '{{ constants.START_YEAR }}';
+    END_YEAR = '{{ constants.END_YEAR }}';
 
     function trackMetric(name, imagesSelector) {
       if (imagesSelector) {

--- a/openfecwebapp/templates/macros/filters/date.html
+++ b/openfecwebapp/templates/macros/filters/date.html
@@ -31,6 +31,7 @@
         </div>
       </div>
       <select id="two-year-transaction-period" name="two_year_transaction_period" aria-describedby="unique-tooltip">
+          <option value="">Select a value</option>
         {% for year in range(constants.END_YEAR, constants.START_YEAR, -2) %}
           <option value="{{year}}">{{ year | fmt_year_range }}</option>
         {% endfor %}

--- a/openfecwebapp/templates/macros/filters/date.html
+++ b/openfecwebapp/templates/macros/filters/date.html
@@ -21,9 +21,8 @@
 {% endmacro %}
 
 {% macro partition_field(name, label, dates) %}
-{% set current_year = dates['year'][1] | date(fmt='%Y') %}
 <div class="filter">
-    <div class="js-filter js-filter-control" data-filter="select" data-validate="true" data-modifies-filter="{{ name }}" data-modifies-property="data-transaction-year" data-required-default="{{ current_year }}">
+    <div class="js-filter js-filter-control" data-filter="select" data-validate="true" data-modifies-filter="{{ name }}" data-modifies-property="data-transaction-year" data-required-default="{{ constants.DEFAULT_TIME_PERIOD }}">
       <label class="label t-inline-block" for="two-year-transaction-period">Time period</label>
       <div class="tooltip__container">
         <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
@@ -32,7 +31,7 @@
         </div>
       </div>
       <select id="two-year-transaction-period" name="two_year_transaction_period" aria-describedby="unique-tooltip">
-        {% for year in range(2016 | int, 1978, -2) %}
+        {% for year in range(constants.END_YEAR, constants.START_YEAR, -2) %}
           <option value="{{year}}">{{ year | fmt_year_range }}</option>
         {% endfor %}
       </select>
@@ -56,9 +55,9 @@
       <div class="date-range__grid js-date-grid">
         <div class="date-range__row">
           <div class="date-range__year">
-          {{ current_year|int - 1 }}
+          {{ constants.DEFAULT_TIME_PERIOD|int - 1 }}
           </div>
-          <ul data-year="{{ current_year|int - 1 }}" class="date-range__months">
+          <ul data-year="{{ constants.DEFAULT_TIME_PERIOD|int - 1 }}" class="date-range__months">
             <li data-month="01"><div>Jan</div></li>
             <li data-month="02"><div>Feb</div></li>
             <li data-month="03"><div>Mar</div></li>
@@ -75,9 +74,9 @@
         </div>
         <div class="date-range__row">
           <div class="date-range__year">
-            {{ current_year }}
+            {{ constants.DEFAULT_TIME_PERIOD }}
           </div>
-          <ul data-year="{{ current_year }}" class="date-range__months">
+          <ul data-year="{{ constants.DEFAULT_TIME_PERIOD }}" class="date-range__months">
             <li data-month="01"><div>Jan</div></li>
             <li data-month="02"><div>Feb</div></li>
             <li data-month="03"><div>Mar</div></li>

--- a/openfecwebapp/templates/macros/overviews.html
+++ b/openfecwebapp/templates/macros/overviews.html
@@ -64,11 +64,12 @@
   {% endif %}
   <div class="top-list js-top-list" data-type="{{type}}">
     <h2 class="top-list__title">{{ title }} overview</h2>
-    <h3 class="top-list__subtitle">Top <span class="js-top-type">raising</span> (2015–2016)</h3>
+    <h3 class="top-list__subtitle">Top <span class="js-top-type">raising</span> ({{ constants.DEFAULT_TIME_PERIOD|fmt_year_range }})</h3>
     <div class="toggles--simple">
       <button class="toggle is-active" aria-controls="{{type}}-top-raising">Top raising</button> |
       <button class="toggle" aria-controls="{{type}}-top-spending">Top spending</button>
     </div>
+    {% if raising_data %}
     <ol class="figure--zero-pad js-top-raising" id="{{type}}-top-raising">
       {% for data in raising_data %}
       <li class="figure__item">
@@ -79,6 +80,8 @@
       </li>
       {% endfor %}
     </ol>
+    {% endif %}
+    {% if spending_data %}
     <ol class="figure--zero-pad js-top-spending" id="{{type}}-top-spending">
       {% for data in spending_data %}
       <li class="figure__item">
@@ -89,5 +92,6 @@
       </li>
       {% endfor %}
     </ol>
+    {% endif %}
   </div>
 {% endmacro %}

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -453,7 +453,7 @@ DataTable.prototype.initTable = function() {
 
   this.$body.css('width', '100%');
   this.$body.find('tbody').addClass('js-panel-toggle');
-}
+};
 
 DataTable.prototype.initFilters = function() {
   // Set `this.filterSet` before instantiating the nested `DataTable` so that


### PR DESCRIPTION
This adds two new constants, an `END_YEAR` and `DEFAULT_TIME_PERIOD` and implements them in a couple places:

1. It updates the date filter on receipts and disbursements pages so that the transaction period is programmatically generated. Resolves https://github.com/18F/openFEC-web-app/issues/1770

![image](https://cloud.githubusercontent.com/assets/1696495/22609408/fb87680e-ea15-11e6-939f-be1535f7d7a6.png)

Now, the max-year of this is the `END_YEAR` constant, but the filter defaults to the `DEFAULT_TIME_PERIOD` constant. That way, for the first few months of the year when there's not transactions to show, we can default to the previous cycle. This requires a small update to `select-filter.js` in fec-style.

2. It also updates the top entities lists on the data landing page to use the same constants.
![image](https://cloud.githubusercontent.com/assets/1696495/22609493/4141314a-ea16-11e6-9ce7-4daeb175a575.png)
