### PR TITLE
Renaming param to correct value

### DIFF
--- a/openfecwebapp/templates/partials/candidates-filter.html
+++ b/openfecwebapp/templates/partials/candidates-filter.html
@@ -8,7 +8,7 @@
 {% block filters %}
 <div class="filters__inner">
   {{ typeahead.field('q', 'Candidate name or ID', '', dataset='candidates', allow_text=True) }}
-  {{ years.years('election_year', 'Election year') }}
+  {{ years.years('cycle', 'Election year') }}
   {% include 'partials/filters/office-sought.html' %}
   {% include 'partials/filters/parties.html' %}
   {{ states.field('state') }}


### PR DESCRIPTION
Renames the param name of the "election year" filter to `cycle` to fix the issue of missing candidates.

Fixes https://github.com/18F/openFEC/issues/2197