### PR TITLE
Feature/report filter

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -258,16 +258,16 @@ table_columns = OrderedDict([
     ('communication-costs', ['Committee', 'Support/Oppose', 'Candidate', 'Amount', 'Date']),
     ('disbursements', ['Spender', 'Recipient', 'State', 'Description', 'Disbursement date', 'Amount']),
     ('electioneering-communications', ['Spender', 'Candidate mentioned','Number of candidates', 'Amount per candidate', 'Date', 'Disbursement amount' ]),
-    ('filings', ['Filer name', 'Document', 'Version', 'Filing date']),
+    ('filings', ['Filer name', 'Document', 'Version', 'Receipt date']),
     ('independent-expenditures', ['Spender', 'Support/Oppose', 'Candidate', 'Description', 'Payee', 'Expenditure date', 'Amount']),
     ('individual-contributions', ['Contributor name', 'Recipient', 'State', 'Employer', 'Receipt date', 'Amount']),
     ('loans', ['Committee Name', 'Loaner name', 'Incurred date', 'Payment to date', 'Original loan amount']),
     ('party-coordinated-expenditures', ['Spender', 'Candidate', 'Payee name', 'Expenditure date', 'Amount']),
     ('receipts', ['Contributor name', 'Recipient', 'Election', 'State', 'Receipt date', 'Amount']),
-    ('reports-presidential', ['Committee', 'Report type', 'Version', 'Filing date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
-    ('reports-house-senate', ['Committee', 'Report type', 'Version', 'Filing date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
-    ('reports-pac-party', ['Committee', 'Report type', 'Version', 'Filing date', 'Coverage end date', 'Total receipts', 'Total disbursements', 'Total independent expenditures']),
-    ('reports-ie-only', ['Filer', 'Report type', 'Version', 'Filing date', 'Coverage end date', 'Total contributions', 'Total independent expenditures'])
+    ('reports-presidential', ['Committee', 'Report type', 'Version', 'Receipt date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
+    ('reports-house-senate', ['Committee', 'Report type', 'Version', 'Receipt date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
+    ('reports-pac-party', ['Committee', 'Report type', 'Version', 'Receipt date', 'Coverage end date', 'Total receipts', 'Total disbursements', 'Total independent expenditures']),
+    ('reports-ie-only', ['Filer', 'Report type', 'Version', 'Receipt date', 'Coverage end date', 'Total contributions', 'Total independent expenditures'])
 
 
 ])

--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -258,17 +258,17 @@ table_columns = OrderedDict([
     ('communication-costs', ['Committee', 'Support/Oppose', 'Candidate', 'Amount', 'Date']),
     ('disbursements', ['Spender', 'Recipient', 'State', 'Description', 'Disbursement date', 'Amount']),
     ('electioneering-communications', ['Spender', 'Candidate mentioned','Number of candidates', 'Amount per candidate', 'Date', 'Disbursement amount' ]),
-    ('filings', ['Filer name', 'Document', 'Version', 'Receipt date']),
+    ('filings', ['Filer name', 'Document', 'Version', 'Filing date']),
     ('independent-expenditures', ['Spender', 'Support/Oppose', 'Candidate', 'Description', 'Payee', 'Expenditure date', 'Amount']),
     ('individual-contributions', ['Contributor name', 'Recipient', 'State', 'Employer', 'Receipt date', 'Amount']),
     ('loans', ['Committee Name', 'Loaner name', 'Incurred date', 'Payment to date', 'Original loan amount']),
     ('party-coordinated-expenditures', ['Spender', 'Candidate', 'Payee name', 'Expenditure date', 'Amount']),
     ('receipts', ['Contributor name', 'Recipient', 'Election', 'State', 'Receipt date', 'Amount']),
-    ('reports-presidential', ['Committee', 'Report type', 'Receipt date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
-    ('reports-house-senate', ['Committee', 'Report type', 'Receipt date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
-    ('reports-pac-party', ['Committee', 'Report type', 'Receipt date', 'Coverage end date', 'Total receipts', 'Total disbursements', 'Total independent expenditures']),
-    ('reports-ie-only', ['Filer', 'Report type', 'Receipt date', 'Coverage end date', 'Total contributions', 'Total independent expenditures'])
-    
+    ('reports-presidential', ['Committee', 'Report type', 'Version', 'Filing date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
+    ('reports-house-senate', ['Committee', 'Report type', 'Version', 'Filing date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
+    ('reports-pac-party', ['Committee', 'Report type', 'Version', 'Filing date', 'Coverage end date', 'Total receipts', 'Total disbursements', 'Total independent expenditures']),
+    ('reports-ie-only', ['Filer', 'Report type', 'Version', 'Filing date', 'Coverage end date', 'Total contributions', 'Total independent expenditures'])
+
 
 ])
 

--- a/openfecwebapp/templates/partials/communication-costs-filter.html
+++ b/openfecwebapp/templates/partials/communication-costs-filter.html
@@ -6,6 +6,7 @@
 {% import 'macros/filters/date.html' as date %}
 {% import 'macros/filters/years.html' as years %}
 {% import 'macros/filters/range.html' as range %}
+{% import 'macros/filters/misc.html' as misc %}
 
 {% block heading %}
 Filter communication costs
@@ -20,7 +21,7 @@ Filter communication costs
   <button type="button" class="js-accordion-trigger accordion__button">Candidate mentioned</button>
   <div class="accordion__content">
     {{ typeahead.field('candidate_id', 'Candidate name or ID', dataset='candidates') }}
-    {% include 'partials/filters/support-oppose.html' %}
+    {{ misc.support_oppose('_processed') }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Transaction information</button>
   <div class="accordion__content">

--- a/openfecwebapp/templates/partials/filings-filter.html
+++ b/openfecwebapp/templates/partials/filings-filter.html
@@ -38,33 +38,7 @@ Filter reports
 
   <button type="button" class="js-accordion-trigger accordion__button">Filing information</button>
   <div class="accordion__content">
-    <div class="filter">
-      <fieldset class="js-filter" data-filter="checkbox">
-        <legend class="label">Version</legend>
-        <ul>
-          <li>
-            <input id="most_recent_true" name="most_recent" type="checkbox" value="true">
-            <label for="most_recent_true">Most recent version</label>
-          </li>
-        </ul>
-      </fieldset>
-    </div>
-
-    <div class="filter">
-      <fieldset class="js-filter" data-filter="checkbox">
-        <legend class="label">Document status</legend>
-        <ul>
-          <li>
-            <input id="amendment_indicator_original" name="amendment_indicator" type="checkbox" value="N">
-            <label for="amendment_indicator_original">Original</label>
-          </li>
-          <li>
-            <input id="amendment_indicator_amendment" name="amendment_indicator" type="checkbox" value="A">
-            <label for="amendment_indicator_amendment">Amendment</label>
-          </li>
-        </ul>
-      </fieldset>
-    </div>
+    {% include 'partials/filters/version-status.html' %}
     {% include 'partials/filters/form-type.html' %}
   </div>
 </div>

--- a/openfecwebapp/templates/partials/filters/version-status.html
+++ b/openfecwebapp/templates/partials/filters/version-status.html
@@ -1,0 +1,27 @@
+<div class="filter">
+  <fieldset class="js-filter" data-filter="checkbox">
+    <legend class="label">Version</legend>
+    <ul>
+      <li>
+        <input id="most_recent_true" name="most_recent" type="checkbox" value="true">
+        <label for="most_recent_true">Most recent version</label>
+      </li>
+    </ul>
+  </fieldset>
+</div>
+
+<div class="filter">
+  <fieldset class="js-filter" data-filter="checkbox">
+    <legend class="label">Document status</legend>
+    <ul>
+      <li>
+        <input id="amendment_indicator_original" name="amendment_indicator" type="checkbox" value="N">
+        <label for="amendment_indicator_original">Original</label>
+      </li>
+      <li>
+        <input id="amendment_indicator_amendment" name="amendment_indicator" type="checkbox" value="A">
+        <label for="amendment_indicator_amendment">Amendment</label>
+      </li>
+    </ul>
+  </fieldset>
+</div>

--- a/openfecwebapp/templates/partials/independent-expenditures-filter.html
+++ b/openfecwebapp/templates/partials/independent-expenditures-filter.html
@@ -36,7 +36,7 @@ Filter independent expenditures
   <button type="button" class="js-accordion-trigger accordion__button">Candidate mentioned</button>
   <div class="accordion__content">
     {{ typeahead.field('candidate_id', 'Candidate', dataset='candidates') }}
-    {{ misc.support_oppose('raw') }}
+    {{ misc.support_oppose('_processed') }}
   </div>
 
   <button type="button" class="js-accordion-trigger accordion__button">Transaction information</button>

--- a/openfecwebapp/templates/partials/reports-filter.html
+++ b/openfecwebapp/templates/partials/reports-filter.html
@@ -29,21 +29,12 @@ Filter reports
   <div class="accordion__content">
     {{ typeahead.field('committee_id', 'Committee name or ID', '') }}
   </div>
-  <button type="button" class="js-accordion-trigger accordion__button">Report details</button>
+  <button type="button" class="js-accordion-trigger accordion__button">Version</button>
   <div class="accordion__content">
-    <fieldset class="filter js-filter" data-filter="checkbox">
-      <legend class="label">Report status</legend>
-      <ul>
-        <li>
-          <input id="is_amended_true" name="is_amended" type="checkbox" value="true">
-          <label for="is_amended_true">Amended report</label>
-        </li>
-        <li>
-          <input id="is_amended_false" name="is_amended" type="checkbox" value="false">
-          <label for="is_amended_false">Non-amended report</label>
-        </li>
-      </ul>
-    </fieldset>
+    {% include 'partials/filters/version-status.html' %}
+  </div>
+  <button type="button" class="js-accordion-trigger accordion__button">Totals</button>
+  <div class="accordion__content">
     {{ range.amount('receipts_amount', 'Total receipts') }}
     {{ range.amount('disbursements_amount', 'Total disbursements') }}
     {{ range.amount('cash_on_hand_amount', 'Ending cash on hand') }}
@@ -54,7 +45,7 @@ Filter reports
      {{ range.amount('party_coordinated_expenditures', 'Total party coordinated expenditures') }}
     {% endif %}
   </div>
-  <button type="button" class="js-accordion-trigger accordion__button">Report date</button>
+  <button type="button" class="js-accordion-trigger accordion__button">Date</button>
   <div class="accordion__content">
     {{ years.years('cycle', 'Years')  }}
     {{ date.field('receipt_date', 'Receipt date', dates ) }}

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -32,6 +32,7 @@ var amendmentIndicatorColumn = {
 var versionColumn = {
   data: 'most_recent',
   className: 'hide-panel hide-efiling column--med min-desktop',
+  orderable: false,
   render: function(data, type, row) {
     var version = helpers.amendmentVersion(data);
     if (version === 'Version unknown') {

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -57,7 +57,7 @@ var modalTriggerColumn = {
 
 var receiptDateColumn = {
   data: 'receipt_date',
-  className: 'min-tablet hide-panel column--med',
+  className: 'min-tablet hide-panel column--small',
   orderable: true,
   render: function(data, type, row, meta) {
     var parsed;
@@ -518,27 +518,30 @@ var reports = {
     orderable: false,
     render: function(data, type, row) {
       var doc_description = row.document_description ? row.document_description : row.form_type;
+      var amendment_version = helpers.amendmentVersionDescription(row);
       var pdf_url = row.pdf_url ? row.pdf_url : null;
       var csv_url = row.csv_url ? row.csv_url : null;
       var fec_url = row.fec_url ? row.fec_url : null;
 
       return reportType({
         doc_description: doc_description,
+        amendment_version: amendment_version,
         pdf_url: pdf_url,
         fec_url: fec_url,
         csv_url: csv_url
       });
     }
   },
+  version: versionColumn,
   receipt_date: receiptDateColumn,
   coverage_start_date: dateColumn({
     data: 'coverage_start_date',
-    className: 'min-tablet hide-panel column--med',
+    className: 'min-tablet hide-panel column--small',
     orderable: true
   }),
   coverage_end_date: dateColumn({
     data: 'coverage_end_date',
-    className: 'min-tablet hide-panel column--med',
+    className: 'min-tablet hide-panel column--small',
     orderable: true
   }),
   receipts: currencyColumn({

--- a/static/js/modules/filings.js
+++ b/static/js/modules/filings.js
@@ -23,24 +23,26 @@ function resolveTemplate(row) {
   return templates[row.form_type](row);
 }
 
+function fetchReportDetails(row) {
+  var url = helpers.buildUrl(
+    ['committee', row.committee_id, 'reports'],
+    {beginning_image_number: row.beginning_image_number}
+  );
+  return $.getJSON(url).then(function(response) {
+    var result = response.results.length ?
+      response.results[0] :
+      {};
+
+    result.amendment_version = helpers.amendmentVersion(result.most_recent);
+    result.amendment_version_description = helpers.amendmentVersionDescription(row);
+
+    return _.extend({}, row, result);
+  });
+}
+
 var renderModal = tables.modalRenderFactory(
   resolveTemplate,
-  function(row) {
-    var url = helpers.buildUrl(
-      ['committee', row.committee_id, 'reports'],
-      {beginning_image_number: row.beginning_image_number}
-    );
-    return $.getJSON(url).then(function(response) {
-      var result = response.results.length ?
-        response.results[0] :
-        {};
-
-      result.amendment_version = helpers.amendmentVersion(result.most_recent);
-      result.amendment_version_description = helpers.amendmentVersionDescription(row);
-
-      return _.extend({}, row, result);
-    });
-  }
+  fetchReportDetails
 );
 
 function renderRow(row, data, index) {
@@ -51,5 +53,6 @@ function renderRow(row, data, index) {
 
 module.exports = {
   renderModal: renderModal,
-  renderRow: renderRow
+  renderRow: renderRow,
+  fetchReportDetails: fetchReportDetails
 };

--- a/static/js/pages/reports.js
+++ b/static/js/pages/reports.js
@@ -6,6 +6,7 @@ var $ = require('jquery');
 
 var tables = require('../modules/tables');
 var columns = require('../modules/columns');
+var filings = require('../modules/filings');
 var columnHelpers = require('../modules/column-helpers');
 var TableSwitcher = require('../modules/table-switcher').TableSwitcher;
 var dropdown = require('fec-style/js/dropdowns');
@@ -56,7 +57,7 @@ $(document).ready(function() {
     useFilters: true,
     useExport: true,
     callbacks: {
-      afterRender: tables.modalRenderFactory(pageTemplate)
+      afterRender: tables.modalRenderFactory(pageTemplate, filings.fetchReportDetails)
     },
     drawCallback: function () {
       this.dropdowns = $table.find('.dropdown').map(function(idx, elm) {

--- a/static/js/pages/reports.js
+++ b/static/js/pages/reports.js
@@ -18,7 +18,7 @@ var ieOnlyTemplate = require('../../templates/reports/ie-only.hbs');
 var pageTitle,
     pageTemplate,
     pageColumns,
-    columnKeys = ['committee', 'document_type', 'receipt_date', 'coverage_end_date'];
+    columnKeys = ['committee', 'document_type', 'version', 'receipt_date', 'coverage_end_date'];
 
 if (context.form_type === 'presidential') {
   pageTitle = 'Presidential committee reports';
@@ -53,7 +53,7 @@ $(document).ready(function() {
     columns: pageColumns,
     rowCallback: tables.modalRenderRow,
     // Order by coverage date descending
-    order: [[2, 'desc']],
+    order: [[3, 'desc']],
     useFilters: true,
     useExport: true,
     callbacks: {


### PR DESCRIPTION
This adds the "version" and "document status" to the reports pages, along with adding those values to the columns and details panels. By tightening up the width of the date columns I was able to fit the version column in this table, which after using the filter and not having it there, felt necessary.

![image](https://cloud.githubusercontent.com/assets/1696495/23169610/69546aa0-f81a-11e6-9061-365aaf462044.png)

![image](https://cloud.githubusercontent.com/assets/1696495/23169620/7519d1ae-f81a-11e6-9912-4379963df953.png)

It also turns off the sorting on the version column, which is not supported by the API, which resolves https://github.com/18F/openFEC-web-app/issues/1827 