### PR TITLE
Adding links to itemized transactions and glossary definitions

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -268,7 +268,7 @@ table_columns = OrderedDict([
     ('reports-house-senate', ['Committee', 'Report type', 'Receipt date', 'Coverage end date', 'Total receipts', 'Total disbursements']),
     ('reports-pac-party', ['Committee', 'Report type', 'Receipt date', 'Coverage end date', 'Total receipts', 'Total disbursements', 'Total independent expenditures']),
     ('reports-ie-only', ['Filer', 'Report type', 'Receipt date', 'Coverage end date', 'Total contributions', 'Total independent expenditures'])
-    
+
 
 ])
 
@@ -280,84 +280,87 @@ table_columns = OrderedDict([
 # F3 = house and senate; F3P = presidential; F3X = pac and party
 
 RAISING_FORMATTER = OrderedDict([
-    ('receipts', ('Total receipts', '1')), #F3, F3P, #F3X
-    ('contributions', ('Total contributions', '2')), #F3, F3P, F3X
-    ('individual_contributions', ('Total individual contributions', '3')), #F3, F3P, F3X
-    ('individual_itemized_contributions', ('Itemized individual contributions', '4')), #F3, F3P, F3X
-    ('individual_unitemized_contributions', ('Unitemized individual contributions', '4')), #F3, F3P, F3X
-    ('political_party_committee_contributions', ('Party committee contributions', '3')), #F3, F3P, F3X
-    ('other_political_committee_contributions', ('Other committee contributions', '3')), #F3, F3P, F3X
-    ('federal_funds', ('Presidential public funds', '3')), #F3, F3P
-    ('candidate_contribution', ('Candidate contributions', '3')), #F3, F3P
-    ('transfers_from_affiliated_party', ('Transfers from affiliated committees', '2')), #F3X
-    ('transfers_from_affiliated_committee', ('Transfer from affiliated committees', '2')), #F3P
-    ('transfers_from_other_authorized_committee', ('Transfer from authorized committees', '2')), #F3
-    ('all_loans_received', ('Loans received', '2')), #F3X
-    ('loan_repayments_received', ('Loan repayments received', '2')), #F3X
-    ('loans', ('Total loans received', '2')), # F3
-    ('loans_received', ('Total loans received', '2')), #F3P
-    ('loans_received_from_candidate', ('Loans made by candidate', '3')), #F3P
-    ('loans_made_by_candidate', ('Loans made by candidate', '3')), #F3
-    ('other_loans_received', ('Other loans', '3')), #F3P
-    ('all_other_loans', ('Other loans', '3')), #F3
-    ('total_offsets_to_operating_expenditures', ('Total offsets', '2')), #F3P
-    ('subtotal_offsets_to_operating_expenditures', ('Offsets to operating expenditures', '3')), #F3P
-    ('offsets_to_operating_expenditures', ('Offsets to operating expenditures', '2')), #F3, F3X
-    ('offsets_to_fundraising_expenditures', ('Fundraising offsets', '3')), #F3P
-    ('offsets_to_legal_accounting', ('Legal and accounting offsets', '3')), #F3P
-    ('other_receipts', ('Other receipts', '2')), #F3, F3P
-    ('fed_candidate_contribution_refunds', ('Candidate refunds', '2')), #F3X
-    ('other_fed_receipts', ('Other Receipts', '2')), #F3X
-    ('transfers_from_nonfed_account', ('Non-federal transfers', '2')), #F3X
-    ('transfers_from_nonfed_levin', ('Levin funds', '2')), #F3X
-    ('fed_receipts', ('Total federal receipts', '2')), #F3X
+    ('receipts', {'label': 'Total receipts', 'level': '1', 'term': 'total receipts', 'link': 'receipts'}), #F3, F3P, #F3X
+    ('contributions', {'label': 'Total contributions', 'level': '2'}), #F3, F3P, F3X
+    ('individual_contributions', {'label': 'Total individual contributions', 'level': '3'}), #F3, F3P, F3X
+    ('individual_itemized_contributions', {'label': 'Itemized individual contributions', 'level': '4'}), #F3, F3P, F3X
+    ('individual_unitemized_contributions', {'label': 'Unitemized individual contributions', 'level': '4'}), #F3, F3P, F3X
+    ('political_party_committee_contributions', {'label': 'Party committee contributions', 'level': '3'}), #F3, F3P, F3X
+    ('other_political_committee_contributions', {'label': 'Other committee contributions', 'level': '3'}), #F3, F3P, F3X
+    ('federal_funds', {'label': 'Presidential public funds', 'level': '3'}), #F3, F3P
+    ('candidate_contribution', {'label': 'Candidate contributions', 'level': '3'}), #F3, F3P
+    ('transfers_from_affiliated_party', {'label': 'Transfers from affiliated committees', 'level': '2'}), #F3X
+    ('transfers_from_affiliated_committee', {'label': 'Transfer from affiliated committees', 'level': '2'}), #F3P
+    ('transfers_from_other_authorized_committee', {'label': 'Transfer from authorized committees', 'level': '2'}), #F3
+    ('all_loans_received', {'label': 'Loans received', 'level': '2'}), #F3X
+    ('loan_repayments_received', {'label': 'Loan repayments received', 'level': '2'}), #F3X
+    ('loans', {'label': 'Total loans received', 'level': '2'}), # F3
+    ('loans_received', {'label': 'Total loans received', 'level': '2'}), #F3P
+    ('loans_received_from_candidate', {'label': 'Loans made by candidate', 'level': '3'}), #F3P
+    ('loans_made_by_candidate', {'label': 'Loans made by candidate', 'level': '3'}), #F3
+    ('other_loans_received', {'label': 'Other loans', 'level': '3'}), #F3P
+    ('all_other_loans', {'label': 'Other loans', 'level': '3'}), #F3
+    ('total_offsets_to_operating_expenditures', {'label': 'Total offsets', 'level': '2'}), #F3P
+    ('subtotal_offsets_to_operating_expenditures', {'label': 'Offsets to operating expenditures', 'level': '3'}), #F3P
+    ('offsets_to_operating_expenditures', {'label': 'Offsets to operating expenditures', 'level': '2'}), #F3, F3X
+    ('offsets_to_fundraising_expenditures', {'label': 'Fundraising offsets', 'level': '3'}), #F3P
+    ('offsets_to_legal_accounting', {'label': 'Legal and accounting offsets', 'level': '3'}), #F3P
+    ('other_receipts', {'label': 'Other receipts', 'level': '2'}), #F3, F3P
+    ('fed_candidate_contribution_refunds', {'label': 'Candidate refunds', 'level': '2'}), #F3X
+    ('other_fed_receipts', {'label': 'Other Receipts', 'level': '2'}), #F3X
+    ('total_transfers', {'label': 'Levin funds', 'level': '2'}), #F3X
+    ('transfers_from_nonfed_account', {'label': 'Non-federal transfers', 'level': '2'}), #F3X
+    ('transfers_from_nonfed_levin', {'label': 'Levin funds', 'level': '2'}), #F3X
+    ('fed_receipts', {'label': 'Total federal receipts', 'level': '2'}), #F3X
 ])
 
 SPENDING_FORMATTER = OrderedDict([
-    ('disbursements', ('Total disbursements', '1')), #F3, F3P, F3X
-    ('operating_expenditures', ('Operating expenditures', '2')), #F3, F3P, F3X
-    ('shared_fed_operating_expenditures', ('Allocated operating expenditures - federal', '3')), #F3X
-    ('shared_nonfed_operating_expenditures', ('Allocated operating expenditures - non-federal', '3')), #F3X
-    ('other_fed_operating_expenditures', ('Other federal operating expenditures', '3')), #F3X
-    ('transfers_to_other_authorized_committee', ('Transfers to authorized committees', '2')), #F3, F3P
-    ('fundraising_disbursements', ('Fundraising', '2')), #F3P
-    ('exempt_legal_accounting_disbursement', ('Exempt legal and accounting', '2')), #F3P
-    ('transfers_to_affiliated_committee', ('Transfers to affiliated committees', '2')), #F3X
-    ('fed_candidate_committee_contributions', ('Contributions to other committees', '2')), #F3X
-    ('independent_expenditures', ('Independent expenditures', '2')), #F3X
-    ('coordinated_expenditures_by_party_committee', ('Coordinated party expenditures', '2')), #F3X
-    ('loans_made', ('Loans made', '2')), #F3X
-    ('loan_repayments_made', ('Total loan repayments made', '2')), #F3P, #F3X
-    ('repayments_loans_made_by_candidate', ('Candidate loan repayments', '3')), #F3P
-    ('repayments_other_loans', ('Other loan repayments', '3')), #F3P
-    ('contribution_refunds', ('Total contribution refunds', '2')), #F3, F3P, F3X
-    ('refunded_individual_contributions', ('Individual refunds', '3')), #F3, F3P, F3X
-    ('refunded_political_party_committee_contributions', ('Political party refunds', '3')), #F3, F3P, F3X
-    ('refunded_other_political_committee_contributions', ('Other committee refunds', '3')), #F3, F3P, F3X
-    ('loan_repayments', ('Total loan repayments', '2')), #F3
-    ('loan_repayments_candidate_loans', ('Candidate loan repayments', '3')), #F3
-    ('loan_repayments_other_loans', ('Other loan repayments', '3')), #F3
-    ('other_disbursements', ('Other disbursements', '2')), #F3, F3P, F3X
-    ('fed_election_activity', ('Total federal election activity', '2')), #F3X
-    ('shared_fed_activity', ('Allocated federal election activity - federal share', '3')), #F3X
-    ('allocated_federal_election_levin_share', ('Allocated federal election activity - Levin share', '3')), #F3X
-    ('non_allocated_fed_election_activity', ('Federal election activity - federal only', '3')), #F3X
-    ('fed_disbursements', ('Total federal disbursements', '2')), #F3X
+    ('disbursements', {'label': 'Total disbursements', 'level': '1', 'term': 'total disbursements', 'link': 'disbursements'}), #F3, F3P, F3X
+    ('operating_expenditures', {'label': 'Operating expenditures', 'term': 'operating expenditures', 'level': '2'}), #F3, F3P, F3X
+    ('shared_fed_operating_expenditures', {'label': 'Allocated operating expenditures - federal', 'level': '3'}), #F3X
+    ('shared_nonfed_operating_expenditures', {'label': 'Allocated operating expenditures - non-federal', 'level': '3'}), #F3X
+    ('other_fed_operating_expenditures', {'label': 'Other federal operating expenditures', 'level': '3'}), #F3X
+    ('transfers_to_other_authorized_committee', {'label': 'Transfers to authorized committees', 'level': '2'}), #F3, F3P
+    ('fundraising_disbursements', {'label': 'Fundraising', 'level': '2'}), #F3P
+    ('exempt_legal_accounting_disbursement', {'label': 'Exempt legal and accounting', 'level': '2'}), #F3P
+    ('transfers_to_affiliated_committee', {'label': 'Transfers to affiliated committees', 'level': '2'}), #F3X
+    ('fed_candidate_committee_contributions', {'label': 'Contributions to other committees', 'level': '2'}), #F3X
+    ('independent_expenditures', {'label': 'Independent expenditures', 'level': '2', 'link': 'independent_expenditures'}), #F3X
+    ('coordinated_expenditures_by_party_committee', {'label': 'Coordinated party expenditures', 'level': '2'}), #F3X
+    ('loans_made', {'label': 'Loans made', 'level': '2'}), #F3X
+    ('loan_repayments_made', {'label': 'Total loan repayments made', 'level': '2'}), #F3P, #F3X
+    ('repayments_loans_made_by_candidate', {'label': 'Candidate loan repayments', 'level': '3'}), #F3P
+    ('repayments_other_loans', {'label': 'Other loan repayments', 'level': '3'}), #F3P
+    ('contribution_refunds', {'label': 'Total contribution refunds', 'level': '2'}), #F3, F3P, F3X
+    ('refunded_individual_contributions', {'label': 'Individual refunds', 'level': '3'}), #F3, F3P, F3X
+    ('refunded_political_party_committee_contributions', {'label': 'Political party refunds', 'level': '3'}), #F3, F3P, F3X
+    ('refunded_other_political_committee_contributions', {'label': 'Other committee refunds', 'level': '3'}), #F3, F3P, F3X
+    ('loan_repayments', {'label': 'Total loan repayments', 'level': '2'}), #F3
+    ('loan_repayments_candidate_loans', {'label': 'Candidate loan repayments', 'level': '3'}), #F3
+    ('loan_repayments_other_loans', {'label': 'Other loan repayments', 'level': '3'}), #F3
+    ('other_disbursements', {'label': 'Other disbursements', 'level': '2'}), #F3, F3P, F3X
+    ('fed_election_activity', {'label': 'Total federal election activity', 'level': '2'}), #F3X
+    ('shared_fed_activity', {'label': 'Allocated federal election activity - federal share', 'level': '3'}), #F3X
+    ('allocated_federal_election_levin_share', {'label': 'Allocated federal election activity - Levin share', 'level': '3'}), #F3X
+    ('non_allocated_fed_election_activity', {'label': 'Federal election activity - federal only', 'level': '3'}), #F3X
+    ('fed_disbursements', {'label': 'Total federal disbursements', 'level': '2'}), #F3X
 ])
 
 CASH_FORMATTER = OrderedDict([
-    ('last_cash_on_hand_end_period', ('Ending cash on hand', '2')), #F3, F3P, #F3X
-    ('net_contributions', ('Net contributions', '2')), #F3, F3X
-    ('contributions', ('Total contributions', '3')), #F3, #F3P, F3X
-    ('contribution_refunds', ('(Total contribution refunds)', '3')), #F3, F3P, F3X
-    ('net_operating_expenditures', ('Net operating expenditures', '2')), #F3, F3X
-    ('operating_expenditures', ('Operating expenditures', '3')), #F3, F3P, F3X
-    ('offsets_to_operating_expenditures', ('(Offsets to operating expenditures)', '3')), #F3, F3P, F3X
-    ('subtotal_offsets_to_operating_expenditures', ('Offsets to operating expenditures', '3')), #F3P
-    ('last_debts_owed_by_committee', ('Debts/loans owed by committee', '2')), #F3, F3P, F3X
+    ('cash_on_hand_beginning_period', {'label': 'Beginning cash on hand', 'level': '2'}), #F3, F3P, #F3X
+    ('last_cash_on_hand_end_period', {'label': 'Ending cash on hand', 'term': 'ending cash on hand', 'level': '2'}), #F3, F3P, #F3X
+    ('net_contributions', {'label': 'Net contributions', 'level': '2'}), #F3, F3X
+    ('contributions', {'label': 'Total contributions', 'level': '3'}), #F3, #F3P, F3X
+    ('contribution_refunds', {'label': '(Total contribution refunds)', 'level': '3'}), #F3, F3P, F3X
+    ('net_operating_expenditures', {'label': 'Net operating expenditures', 'level': '2'}), #F3, F3X
+    ('operating_expenditures', {'label': 'Operating expenditures', 'level': '3'}), #F3, F3P, F3X
+    ('offsets_to_operating_expenditures', {'label': '(Offsets to operating expenditures)', 'level': '3'}), #F3, F3P, F3X
+    ('subtotal_offsets_to_operating_expenditures', {'label': 'Offsets to operating expenditures', 'level': '3'}), #F3P
+    ('last_debts_owed_to_committee', {'label': 'Debts/loans owed to committee', 'level': '2'}), #F3, F3P, F3X
+    ('last_debts_owed_by_committee', {'label': 'Debts/loans owed by committee', 'level': '2'}), #F3, F3P, F3X
 ])
 
 IE_FORMATTER = OrderedDict([
-    ('total_independent_contributions', ('Contributions received', '1')),
-    ('total_independent_expenditures', ('Independent expenditures', '1'))
+    ('total_independent_contributions', {'label': 'Contributions received', 'level': '1'}),
+    ('total_independent_expenditures', {'label': 'Independent expenditures', 'level': '1'})
 ])

--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -282,7 +282,7 @@ table_columns = OrderedDict([
 RAISING_FORMATTER = OrderedDict([
     ('receipts', {'label': 'Total receipts', 'level': '1', 'term': 'total receipts', 'link': 'receipts'}), #F3, F3P, #F3X
     ('contributions', {'label': 'Total contributions', 'level': '2'}), #F3, F3P, F3X
-    ('individual_contributions', {'label': 'Total individual contributions', 'level': '3'}), #F3, F3P, F3X
+    ('individual_contributions', {'label': 'Total individual contributions', 'level': '3', 'link': 'individual_contributions'}), #F3, F3P, F3X
     ('individual_itemized_contributions', {'label': 'Itemized individual contributions', 'level': '4'}), #F3, F3P, F3X
     ('individual_unitemized_contributions', {'label': 'Unitemized individual contributions', 'level': '4'}), #F3, F3P, F3X
     ('political_party_committee_contributions', {'label': 'Party committee contributions', 'level': '3'}), #F3, F3P, F3X

--- a/openfecwebapp/templates/macros/tables.html
+++ b/openfecwebapp/templates/macros/tables.html
@@ -36,13 +36,27 @@
   </figure>
 {% endmacro %}
 
-{% macro summary(data) %}
+{% macro summary(data, committee_id) %}
 <figure>
 <table class="simple-table">
   {% for item in data %}
-    <tr class="simple-table__row level--{{ item[1][1]}}">
-      <td class="simple-table__cell">{{ item[1][0] }}</td>
-      <td class="simple-table__cell">{{ item[0]|currency }}</td>
+    <tr class="simple-table__row level--{{ item[1]['level']}}">
+      <td class="simple-table__cell">
+        {% if item[1]['term'] %}
+          <span class="term" data-term="{{ item[1]['term'] }}">{{ item[1]['label'] }}</span>
+        {% else %}
+          {{ item[1]['label'] }}
+        {% endif %}
+      </td>
+      <td class="simple-table__cell">
+        {% if item[1]['link'] %}
+          <a href="{{ url_for(item[1]['link'], committee_id=committee_id) }}">
+            {{ item[0]|currency }}
+          </a>
+        {% else %}
+          {{ item[0]|currency }}
+        {% endif %}
+      </td>
     </tr>
   {% endfor %}
 </table>

--- a/openfecwebapp/templates/partials/committee/new/financial-summary.html
+++ b/openfecwebapp/templates/partials/committee/new/financial-summary.html
@@ -33,7 +33,7 @@
                   </a>
               </div>
           </div>
-          {{ tables.summary(raising_summary) }}
+          {{ tables.summary(raising_summary, committee_id) }}
         </div>
         <div class="entity__figure">
           <h3 class="u-no-margin">Spending</h3>
@@ -53,14 +53,14 @@
                   </a>
               </div>
           </div>
-          {{ tables.summary(spending_summary) }}
+          {{ tables.summary(spending_summary, committee_id) }}
         </div>
         <div class="entity__figure">
           <h3 class="u-no-margin">Cash summary</h3>
           <div class="tag__category">
             <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
           </div>
-          {{ tables.summary(cash_summary) }}
+          {{ tables.summary(cash_summary, committee_id) }}
         </div>
       {% endif %}
     {% else %}


### PR DESCRIPTION
This makes the last change needed to close out this issue: https://github.com/18F/openFEC-web-app/issues/1832

It adds support for linking financial summary labels to their glossary definitions and for linking numbers to views of the itemized transactions. Because of the filters we have available, we can only link to total receipts, individual contributions, disbursements, and independent expenditures, but we can add more later.

Happy to receive feedback on the best way to do this. This seemed like maybe a weird use of `constants.py` so if there's a better way, by all means. 

![image](https://cloud.githubusercontent.com/assets/1696495/23316764/c7c297fc-fa99-11e6-9443-3fa7d9835b7a.png)

It also adds support for the fields that @jontours is adding in https://github.com/18F/openFEC/pull/2215