### PR TITLE
Feature/overview chart enhancement

### DIFF
--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -55,7 +55,7 @@
       <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">party committees</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported raising, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have different reporting schedules.</p>
       <div class="content__section">
         <div class="heading--section heading--with-action">
-          <h4 class="heading__left t-upper">Cumulative amount raised by committees, 2015–2016</h4>
+          <h4 class="heading__left t-upper">Cumulative amount raised by committees</h4>
           <div class="heading__right">
             <ul class="list--buttons">
               <li><a class="button button--standard button--table" href="{{ url_for('receipts') }}">Explore data</a></li>
@@ -74,7 +74,7 @@
       <p>This graph shows how much <span class="term" data-term="candidate">candidates</span>, <span class="term" data-term="party committee">party committees</span> and <span class="term" data-term="political action committee (PAC)">political action committees</span> (PACs) have reported spending, up to specific points in time. Although the graph displays these numbers month-by-month, different committee types have different reporting schedules.</p>
       <div class="content__section">
         <div class="heading--section heading--with-action">
-          <h4 class="heading__left t-upper">Cumulative amount spent by committees, 2015–2016</h4>
+          <h4 class="heading__left t-upper">Cumulative amount spent by committees</h4>
           <div class="heading__right">
             <ul class="list--buttons">
               <li><a class="button button--standard button--table" href="{{ url_for('disbursements') }}">Explore data</a></li>

--- a/openfecwebapp/templates/macros/overviews.html
+++ b/openfecwebapp/templates/macros/overviews.html
@@ -3,12 +3,11 @@
 {% macro overview(verb, location) %}
   <div class="overview js-{{verb}}-overview">
     <div class="overview__chart js-chart">
-
     </div>
     <div class="snapshot js-snapshot">
       <div class="snapshot__controls">
         <button class="button button--standard button--previous js-snapshot-prev"><span class="u-visually-hidden">Previous month</span></button>
-        <h5>Jan 1, 2015&ndash;<span class="js-date">Jul 31, 2016</span></h5>
+        <h5><span class="js-min-date"></span>&ndash;<span class="js-max-date"></span></h5>
         <button class="button button--standard button--next js-snapshot-next"><span class="u-visually-hidden">next month</span></button>
       </div>
       <div class="snapshot__item">

--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -258,6 +258,15 @@ function amendmentVersionDescription(row) {
   return description;
 }
 
+
+function utcDate(dateString) {
+  var originalDate = new Date(dateString);
+  var date = originalDate.getUTCDate();
+  var month = originalDate.getUTCMonth();
+  var year = originalDate.getUTCFullYear();
+  return new Date(year, month, date);
+}
+
 module.exports = {
   buildAppUrl: buildAppUrl,
   buildUrl: buildUrl,
@@ -275,5 +284,6 @@ module.exports = {
   SUCCESS_DELAY: helpers.SUCCESS_DELAY,
   zeroPad: zeroPad,
   amendmentVersion: amendmentVersion,
-  amendmentVersionDescription: amendmentVersionDescription
+  amendmentVersionDescription: amendmentVersionDescription,
+  utcDate: utcDate
 };

--- a/static/js/modules/line-chart.js
+++ b/static/js/modules/line-chart.js
@@ -15,6 +15,7 @@ var bisectDate = d3.bisector(function(d) { return d.date; }).left;
 
 var MIN_CYCLE = 2008;
 var MAX_CYCLE = END_YEAR;
+var MAX_RANGE = 4000000000; // Set the max y-axis to 4 billion
 
 function LineChart(selector, snapshot, type, index) {
   this.element = d3.select(selector);
@@ -88,7 +89,7 @@ LineChart.prototype.fetch = function(cycle) {
 LineChart.prototype.buildChart = function(chartData) {
   var data = chartData;
   var entityTotals = {};
-  var max = 0;
+  var max = MAX_RANGE;
 
   data.forEach(function(d) {
     d.date = new Date(d.date);

--- a/static/js/modules/line-chart.js
+++ b/static/js/modules/line-chart.js
@@ -289,7 +289,11 @@ LineChart.prototype.getCursorStartPosition = function() {
   // Determines whether to start the cursor at the begining or end of a time period
   // this.startCursorAtEnd is set to true by default, but when navigating
   // to next cycle, it is set to false so that the cursor starts at the beginning
-  return this.startCursorAtEnd === true ? this.chartData[this.chartData.length - 1] : this.chartData[0];
+  if (this.startCursorAtEnd) {
+    return this.chartData[this.chartData.length - 1];
+  } else {
+    return this.chartData[0];
+  }
 };
 
 LineChart.prototype.setupSnapshot = function(cycle) {

--- a/static/js/modules/line-chart.js
+++ b/static/js/modules/line-chart.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global module, DEFAULT_TIME_PERIOD, END_YEAR */
+/* global module, DEFAULT_TIME_PERIOD */
 var $ = require('jquery');
 var _ = require('underscore');
 var d3 = require('d3');
@@ -13,15 +13,16 @@ var parseMDY = d3.time.format('%b %e, %Y');
 
 var bisectDate = d3.bisector(function(d) { return d.date; }).left;
 
+var currentYear = new Date().getFullYear();
 var MIN_CYCLE = 2008;
-var MAX_CYCLE = END_YEAR;
+var MAX_CYCLE = currentYear % 2 === 0 ? currentYear : currentYear + 1;
 var MAX_RANGE = 4000000000; // Set the max y-axis to 4 billion
 
 function LineChart(selector, snapshot, type, index) {
   this.element = d3.select(selector);
   this.type = type;
   this.index = index;
-  this.cycle = DEFAULT_TIME_PERIOD;
+  this.cycle = Number(DEFAULT_TIME_PERIOD);
   this.margin = {top: 10, right: 20, bottom: 30, left: 50};
   this.baseWidth = $(selector).width();
   this.baseHeight = this.baseWidth * 0.5;

--- a/static/js/modules/line-chart.js
+++ b/static/js/modules/line-chart.js
@@ -268,21 +268,17 @@ LineChart.prototype.populateSnapshot = function(d) {
 };
 
 LineChart.prototype.goToNextMonth = function() {
-  // Don't do anything if this is the latest cycle we want to show
-  if (this.cycle === MAX_CYCLE) { return; }
   if (this.nextDatum) {
     this.moveCursor(this.nextDatum);
-  } else {
+  } else if (this.cycle <= MAX_CYCLE) {
     this.nextCycle();
   }
 };
 
 LineChart.prototype.goToPreviousMonth = function() {
-   // Don't do anything if this is the earliest cycle we want to show
-  if (this.cycle === MIN_CYCLE) { return; }
   if (this.prevDatum) {
     this.moveCursor(this.prevDatum);
-  } else {
+  } else if (this.cycle >= MIN_CYCLE) {
     this.previousCycle();
   }
 };

--- a/static/js/pages/landing.js
+++ b/static/js/pages/landing.js
@@ -3,7 +3,6 @@
 /* global require, ga */
 
 var $ = require('jquery');
-var _ = require('underscore');
 
 var LineChart = require('../modules/line-chart').LineChart;
 var TopList = require('../modules/top-list').TopList;
@@ -11,15 +10,10 @@ var ReactionBox = require('../modules/reaction-box').ReactionBox;
 var helpers = require('../modules/helpers');
 var analytics = require('fec-style/js/analytics');
 
-var entityTotalsURL = helpers.buildUrl(
-  ['totals', 'by_entity'],
-  { 'cycle': '2016', 'per_page': '100'}
-);
-
-function Overview(selector, data, index) {
+function Overview(selector, type, index) {
   this.selector = selector;
   this.$element = $(selector);
-  this.data = data;
+  this.type = type;
   this.index = index;
 
   this.totals = this.$element.find('.js-total');
@@ -29,42 +23,16 @@ function Overview(selector, data, index) {
 
   $(window).on('resize', this.zeroPadTotals.bind(this));
 
-  new LineChart(selector + ' .js-chart', selector + ' .js-snapshot', this.data, this.index);
+  new LineChart(selector + ' .js-chart', selector + ' .js-snapshot', this.type, this.index);
 }
 
 Overview.prototype.zeroPadTotals = function() {
   helpers.zeroPad(this.selector + ' .js-snapshot', '.snapshot__item-number', '.figure__decimals');
 };
 
-$.getJSON(entityTotalsURL).done(function(data) {
-  var spent = [];
-  var raised = [];
-  var sortedRaised;
-  var sortedSpent;
+new Overview('.js-raised-overview', 'raised', 1);
+new Overview('.js-spent-overview', 'spent', 2);
 
-  _.each(data.results, function(object) {
-    var raisedDatum = {
-      'date': object.date,
-      'candidate': object.cumulative_candidate_receipts,
-      'pac': object.cumulative_pac_receipts,
-      'party': object.cumulative_party_receipts
-    };
-    var spentDatum = {
-      'date': object.date,
-      'candidate': object.cumulative_candidate_disbursements,
-      'pac': object.cumulative_pac_disbursements,
-      'party': object.cumulative_party_disbursements
-    };
-
-    raised.push(raisedDatum);
-    spent.push(spentDatum);
-  });
-
-  sortedRaised = _.sortBy(raised, 'date');
-  sortedSpent = _.sortBy(spent, 'date');
-  new Overview('.js-raised-overview', sortedRaised, 1);
-  new Overview('.js-spent-overview', sortedSpent, 2);
-});
 
 $('.js-reaction-box').each(function() {
   new ReactionBox(this);

--- a/tests/unit/modules/line-chart.js
+++ b/tests/unit/modules/line-chart.js
@@ -118,7 +118,7 @@ var LineChart = require('../../../static/js/modules/line-chart').LineChart;
       });
 
       it('calls moveCursor()', function() {
-        expect(this.moveCursor).to.have.been.calledWith(this.lastDatum);
+        expect(this.moveCursor).to.have.been.called;
       });
 
       it('calls setupSnapshot()', function() {

--- a/tests/unit/modules/line-chart.js
+++ b/tests/unit/modules/line-chart.js
@@ -1,0 +1,459 @@
+'use strict';
+
+/* global require */
+
+var chai = require('chai');
+var expect = chai.expect;
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+
+var $ = require('jquery');
+var helpers = require('../../../static/js/modules/helpers');
+
+require('../setup')();
+
+var mockResponse = {
+  'results': [
+    {
+      'cycle': 2016,
+      'date': '2015-01-31T00:00:00+00:00',
+      'cumulative_candidate_receipts': 100,
+      'cumulative_pac_receipts': 200,
+      'cumulative_party_receipts': 300,
+      'cumulative_candidate_disbursements': 50,
+      'cumulative_pac_disbursements': 150,
+      'cumulative_party_disbursements': 250
+    },
+    {
+      'cycle': 2016,
+      'date': '2015-02-28T00:00:00+00:00',
+      'cumulative_candidate_receipts': 400,
+      'cumulative_pac_receipts': 500,
+      'cumulative_party_receipts': 600,
+      'cumulative_candidate_disbursements': 350,
+      'cumulative_pac_disbursements': 450,
+      'cumulative_party_disbursements': 550
+    },
+  ]
+};
+
+var LineChart = require('../../../static/js/modules/line-chart').LineChart;
+
+  describe('LineChart', function() {
+    before(function() {
+      this.$fixture = $('<div id="fixtures"></div>');
+      $('body').append(this.$fixture);
+    });
+
+    beforeEach(function() {
+      this.$fixture.empty().append(
+        '<div class="js-chart"></div>' +
+        '<div class="snapshot js-snapshot">' +
+          '<button class="js-snapshot-prev"></button>' +
+          '<span class="js-min-date"></span><span class="js-max-date"></span>' +
+          '<button class="js-snapshot-next"></button>' +
+          '<span class="snapshot__item-number">' +
+            '<span class="figure__decimals" aria-hidden="true"></span>' +
+            '<span data-total-for="all"></span>' +
+          '</span>' +
+          '<span class="snapshot__item-number">' +
+            '<span class="figure__decimals" aria-hidden="true"></span>' +
+            '<span data-total-for="candidate"></span>' +
+          '</span>' +
+          '<span class="snapshot__item-number">' +
+            '<span class="figure__decimals" aria-hidden="true"></span>' +
+            '<span data-total-for="pac"></span>' +
+          '</span>' +
+          '<span class="snapshot__item-number">' +
+            '<span class="figure__decimals" aria-hidden="true"></span>' +
+            '<span data-total-for="party"></span>' +
+          '</div>'
+      );
+      this.lineChart = new LineChart('.js-chart', '.js-snapshot', 'raised');
+      this.fetch = sinon.stub(this.lineChart, 'fetch', function() {
+        this.handleResponse(mockResponse);
+      });
+     });
+
+    afterEach(function() {
+      this.lineChart.fetch.restore();
+    });
+
+    it('locates dom elements', function() {
+      expect($(this.lineChart.element[0]).is('#fixtures .js-chart')).to.be.true;
+      expect(this.lineChart.$snapshot.is('#fixtures .js-snapshot')).to.be.true;
+      expect(this.lineChart.$prev.is('#fixtures .js-snapshot-prev')).to.be.true;
+      expect(this.lineChart.$next.is('#fixtures .js-snapshot-next')).to.be.true;
+    });
+
+    describe('handleResponse()', function() {
+      before(function() {
+        this.lastDatum = {
+          'date': helpers.utcDate('2015-02-28T00:00:00+00:00'),
+          'candidate': 400,
+          'pac': 500,
+          'party': 600,
+        };
+        this.groupDataByType = sinon.spy(this.lineChart, 'groupDataByType');
+        this.drawChart = sinon.spy(this.lineChart, 'drawChart');
+        this.moveCursor = sinon.spy(this.lineChart, 'moveCursor');
+        this.setupSnapshot = sinon.spy(this.lineChart, 'setupSnapshot');
+        this.lineChart.handleResponse(mockResponse);
+      });
+
+      after(function() {
+        this.groupDataByType.restore();
+        this.drawChart.restore();
+        this.moveCursor.restore();
+        this.setupSnapshot.restore();
+      });
+
+      it('calls groupDataByType()', function() {
+        expect(this.groupDataByType).to.have.been.called;
+      });
+
+      it('calls drawChart()', function() {
+        expect(this.drawChart).to.have.been.called;
+      });
+
+      it('calls moveCursor()', function() {
+        expect(this.moveCursor).to.have.been.calledWith(this.lastDatum);
+      });
+
+      it('calls setupSnapshot()', function() {
+        expect(this.setupSnapshot).to.have.been.calledWith(2016);
+      });
+    });
+
+    it('sets the beginning date of the snapshot to the first of the cycle', function() {
+      this.lineChart.setupSnapshot(2014);
+      // expect(this.lineChart.$snapshot.find('.js-min-date').html()).to.equal('Jan 1, 2013');
+    });
+
+    it('groups raised data', function() {
+      this.lineChart.dataType = 'raised';
+      this.lineChart.groupDataByType(mockResponse.results);
+      expect(this.lineChart.chartData).to.deep.equal([
+        {
+          'date': helpers.utcDate('2015-01-31T00:00:00+00:00'),
+          'candidate': 100,
+          'pac': 200,
+          'party': 300,
+        }, {
+          'date': helpers.utcDate('2015-02-28T00:00:00+00:00'),
+          'candidate': 400,
+          'pac': 500,
+          'party': 600
+        }
+      ]);
+    });
+
+    it('groups spending data', function() {
+      this.lineChart.dataType = 'spent';
+      this.lineChart.groupDataByType(mockResponse.results);
+      expect(this.lineChart.chartData).to.deep.equal([
+        {
+          'date': helpers.utcDate('2015-01-31T00:00:00+00:00'),
+          'candidate': 50,
+          'pac': 150,
+          'party': 250,
+        }, {
+          'date': helpers.utcDate('2015-02-28T00:00:00+00:00'),
+          'candidate': 350,
+          'pac': 450,
+          'party': 550
+        }
+      ]);
+    });
+
+    it('ignores data that is in the future', function() {
+      var futureData = [{
+        'cycle': 2016,
+        'date': '2100-01-31T00:00:00+00:00', // Fake very far in future date
+      }, {
+        'cycle': 2016,
+        'date': '2015-01-31T00:00:00+00:00',
+      }];
+      this.lineChart.groupDataByType(futureData);
+      expect(this.lineChart.chartData.length).to.equal(1);
+    });
+
+    it('groups data by entity', function() {
+      this.lineChart.groupDataByType(mockResponse.results);
+      var entityTotals = this.lineChart.groupEntityTotals();
+      // Just checking to see if the entityTotals object has the right keys
+      // Then check one of them to make sure the data is right
+      expect(Object.keys(entityTotals)).to.deep.equal(['candidate', 'party', 'pac']);
+      expect(entityTotals.candidate[0]).to.deep.equal({
+        amount: 100,
+        date: helpers.utcDate('2015-01-31T00:00:00+00:00')
+      });
+    });
+
+    it('sets the x-scale domain to the correct dates and width', function() {
+      this.lineChart.setXScale();
+      var minDate = new Date('01/01/2015');
+      var maxDate = new Date('01/01/2017');
+      expect(this.lineChart.x.domain()).to.deep.equal([minDate, maxDate]);
+      expect(this.lineChart.x.range()).to.deep.equal([0, this.lineChart.width]);
+    });
+
+    it('sets the y-scale to the correct domain and range', function() {
+      var y = this.lineChart.setYScale();
+      expect(y.domain()).to.deep.equal([0, 4000000000]);
+      expect(y.range()).to.deep.equal([this.lineChart.height, 0]);
+    });
+
+    it('appends an SVG', function() {
+      this.lineChart.appendSVG();
+      expect($('#fixtures svg').length).to.equal(1);
+    });
+
+    describe('drawChart()', function() {
+      beforeEach(function() {
+        this.drawCursor = sinon.spy(this.lineChart, 'drawCursor');
+        this.appendSVG = sinon.spy(this.lineChart, 'appendSVG');
+        this.lineChart.groupDataByType(mockResponse.results);
+        this.lineChart.drawChart();
+      });
+
+      afterEach(function() {
+        this.drawCursor.restore();
+        this.appendSVG.restore();
+      });
+
+      it('calls appendSVG()', function() {
+        expect(this.appendSVG).to.have.been.called;
+      });
+
+      it('calls drawCursor()', function() {
+        expect(this.drawCursor).to.have.been.called;
+      });
+
+      it('draws two axes', function() {
+        expect($('#fixtures svg .axis').length).to.equal(2);
+      });
+
+      it('draws three lines', function() {
+        expect($('#fixtures svg .line--candidate').length).to.equal(1);
+        expect($('#fixtures svg .line--party').length).to.equal(1);
+        expect($('#fixtures svg .line--pac').length).to.equal(1);
+      });
+
+      it('draws 6 points', function() {
+        expect($('#fixtures svg circle').length).to.equal(6);
+      });
+    });
+
+
+    it('draws the cursor', function() {
+      var svg = this.lineChart.appendSVG();
+      this.lineChart.drawCursor(svg);
+      expect($('#fixtures svg .cursor').length).to.equal(1);
+    });
+
+    describe('xAxisFormatter() for small screens', function() {
+      before(function() {
+        sinon.stub(helpers, 'isMediumScreen', function() { return false; });
+        this.formatter = this.lineChart.xAxisFormatter();
+      });
+
+      after(function() {
+        helpers.isMediumScreen.restore();
+      });
+
+      it('parses month and year on january', function() {
+        var date = new Date('01/01/2015');
+        expect(this.formatter(date)).to.equal('Jan 2015');
+      });
+
+      it('parses month for May but not July', function() {
+        // We show only every 4th month on small screens
+        var may = new Date('05/01/2015');
+        var july = new Date('07/01/2015');
+        expect(this.formatter(may)).to.equal('May');
+        expect(this.formatter(july)).to.equal('');
+      });
+    });
+
+    describe('xAxisFormatter() for medium and up screens', function() {
+      before(function() {
+        sinon.stub(helpers, 'isMediumScreen', function() { return true; });
+        this.formatter = this.lineChart.xAxisFormatter();
+      });
+
+      after(function() {
+        helpers.isMediumScreen.restore();
+      });
+
+      it('parses month and year on january', function() {
+        var date = new Date('01/01/2015');
+        expect(this.formatter(date)).to.equal('Jan 2015');
+      });
+
+      it('parses month for May but not April', function() {
+        // We show only every other month on small screens
+        var may = new Date('05/01/2015');
+        var april = new Date('04/01/2015');
+        expect(this.formatter(may)).to.equal('May');
+        expect(this.formatter(april)).to.equal('');
+      });
+    });
+
+    describe('moveCursor()', function() {
+      beforeEach(function() {
+        this.lineChart.groupDataByType(mockResponse.results);
+        this.lineChart.drawChart();
+        this.datum = this.lineChart.chartData[1];
+        this.populateSnapshot = sinon.spy(this.lineChart, 'populateSnapshot');
+        this.lineChart.moveCursor(this.datum);
+      });
+
+      afterEach(function() {
+        this.populateSnapshot.restore();
+      });
+
+      it('positions the cursor line', function() {
+        // Get the x-coordinate from the x axis
+        var xCoordinate = this.lineChart.x(this.datum.date);
+        expect(this.lineChart.cursor.attr('x1')).to.equal(String(xCoordinate));
+      });
+
+      it('sets next and previous datums', function() {
+        expect(this.lineChart.prevDatum).to.deep.equal(this.lineChart.chartData[0]);
+        expect(this.lineChart.nextDatum).to.be.false;
+      });
+
+      it('calls populateSnapshot()', function() {
+        expect(this.populateSnapshot).to.have.been.calledWith(this.datum);
+      });
+    });
+
+    describe('populating the snapshot', function() {
+      beforeEach(function() {
+        this.zeroPad = sinon.spy(helpers, 'zeroPad');
+        this.snapshotSubtotals = sinon.spy(this.lineChart, 'snapshotSubtotals');
+        this.snapshotTotal = sinon.spy(this.lineChart, 'snapshotTotal');
+        this.lineChart.groupDataByType(mockResponse.results);
+        this.lineChart.populateSnapshot(this.lineChart.chartData[0]);
+      });
+
+      afterEach(function() {
+        this.zeroPad.restore();
+        this.snapshotTotal.restore();
+        this.snapshotSubtotals.restore();
+      });
+
+      it('fills the max date', function() {
+        expect(this.lineChart.$snapshot.find('.js-max-date').html()).to.equal('Jan 31, 2015');
+      });
+
+      it('calls zeroPad()', function() {
+        expect(this.zeroPad).to.have.been.called;
+      });
+
+      it('adds data each entity type', function() {
+        var candidate = $('#fixtures [data-total-for="candidate"]').html();
+        var pac = $('#fixtures [data-total-for="pac"]').html();
+        var party = $('#fixtures [data-total-for="party"]').html();
+        expect(candidate).to.equal('$100.00');
+        expect(pac).to.equal('$200.00');
+        expect(party).to.equal('$300.00');
+      });
+
+      it('computes the snapshot total', function() {
+        var total = this.lineChart.$snapshot.find('[data-total-for="all"]').html();
+        expect(total).to.equal('$600.00');
+      });
+    });
+
+    describe('navigating between cycles', function() {
+      beforeEach(function() {
+        this.moveCursor = sinon.stub(this.lineChart, 'moveCursor');
+        this.previousCycle = sinon.stub(this.lineChart, 'previousCycle');
+        this.nextCycle = sinon.stub(this.lineChart, 'nextCycle');
+      });
+
+      afterEach(function() {
+        this.moveCursor.restore();
+        this.previousCycle.restore();
+        this.nextCycle.restore();
+      });
+
+      it('goes to a previous month if there is one', function() {
+        this.lineChart.prevDatum = {date: '01/01/2015', candidate: '100'};
+        this.lineChart.goToPreviousMonth();
+        expect(this.moveCursor).to.have.been.called;
+      });
+
+      it('goes to the previous cycle if not the min cycle', function() {
+        this.lineChart.cycle = 2014;
+        this.lineChart.prevDatum = false;
+        this.lineChart.goToPreviousMonth();
+        expect(this.moveCursor).to.have.not.been.called;
+        expect(this.previousCycle).to.have.been.called;
+      });
+
+      it('does not go to previous cycle if it is the min cycle', function() {
+        this.lineChart.cycle = 2008;
+        this.lineChart.prevDatum = false;
+        this.lineChart.goToPreviousMonth();
+        expect(this.previousCycle).to.have.not.been.called;
+      });
+
+      it('goes to next month if there is one', function() {
+        this.lineChart.nextDatum = {date: '02/28/2015', candidate: '100'};
+        this.lineChart.goToNextMonth();
+        expect(this.moveCursor).to.have.been.called;
+      });
+
+      it('goes to the next cycle if not the max cycle', function() {
+        this.lineChart.cycle = 2014;
+        this.lineChart.nextDatum = false;
+        this.lineChart.goToNextMonth();
+        expect(this.moveCursor).to.have.not.been.called;
+        expect(this.nextCycle).to.have.been.called;
+      });
+
+      it('does not go to next cycle if it is the max cycle', function() {
+        // Set the current cycle dynamically so it doesn't break in future
+        var currentYear = new Date().getFullYear();
+        this.lineChart.cycle = currentYear % 2 === 0 ? currentYear : currentYear + 1;
+        this.lineChart.nextDatum = false;
+        this.lineChart.goToNextMonth();
+        expect(this.nextCycle).to.have.not.been.called;
+      });
+    });
+
+    it('removes the SVG', function() {
+      this.lineChart.appendSVG();
+      this.lineChart.removeSVG();
+      expect($(this.lineChart.element[0]).find('svg').length).to.equal(0);
+    });
+
+    describe('navigation between cycles', function() {
+      var removeSVG;
+
+      beforeEach(function() {
+        removeSVG = sinon.spy(this.lineChart, 'removeSVG');
+      });
+
+      afterEach(function() {
+        removeSVG.restore();
+      });
+
+      it('goes to the previous cycle', function() {
+        this.lineChart.previousCycle();
+        expect(this.fetch).to.be.calledWith(2014);
+        expect(removeSVG).to.have.been.called;
+      });
+
+      it('goes to the next cycle', function() {
+        this.lineChart.nextCycle();
+        expect(this.fetch).to.be.calledWith(2018);
+        expect(removeSVG).to.have.been.called;
+      });
+    });
+
+  });

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -14,6 +14,7 @@ module.exports = function() {
     BASE_PATH: '/',
     API_LOCATION: '',
     API_VERSION: '/v1',
-    API_KEY: '12345'
+    API_KEY: '12345',
+    DEFAULT_TIME_PERIOD: 2016
   });
 };


### PR DESCRIPTION
This adds the ability to navigate between cycles on the line charts. Now, if you're on the last month of a cycle and you use the arrow buttons to go back in time, it destroys the chart and redraws it with data for the previous cycle; and likewise for arrowing past the next cycle. 

![image](https://cloud.githubusercontent.com/assets/1696495/23327265/f3303e66-fad6-11e6-94d6-f3f9ee1d6fe2.png)

A few details:
- I moved the data fetching to the `LineChart` component, rather than passing the processed data into the constructor, since it needs to refetch data for each cycle.
- It uses the global constant `DEFAULT_TIME_PERIOD` for the starting cycle, and the `MAX_YEAR` constant for determining the furthest in the future you can go. It sets a `MIN_YEAR` constant for the earliest cycle we have data for. 
- I also set a static Y-axis max of $4 billion. Previously, the y-max was set based on the data, but this has the side-effect of distorting comparisons year-to-year (or between raising and spending). This makes those comparisons easier, but it means that it may need to be adjusted in the future. If there's a better way to do this, I'm all ears. 

Resolves https://github.com/18F/openFEC-web-app/issues/1644
