### PR TITLE
Dynamically generate list of election cycles

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -361,3 +361,9 @@ IE_FORMATTER = OrderedDict([
     ('total_independent_contributions', ('Contributions received', '1')),
     ('total_independent_expenditures', ('Independent expenditures', '1'))
 ])
+
+SENATE_CLASSES = {
+  '1': ['AZ', 'CA', 'CT', 'DE', 'FL', 'HI', 'IN', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NJ', 'NM', 'NY', 'ND', 'OH', 'PA', 'RI', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'],
+  '2': ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'MD', 'MO', 'NV', 'NH', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'SC', 'SD', 'UT', 'VT', 'WA', 'WI'],
+  '3': ['AL', 'AK', 'AR', 'CO', 'DE', 'GA', 'ID', 'IL', 'IA', 'KS', 'KY', 'LA', 'ME', 'MA', 'MI', 'MN', 'MS', 'MT', 'NE', 'NH', 'NJ', 'NM', 'NC', 'OK', 'OR', 'RI', 'SC', 'SD', 'TN', 'TX', 'VA', 'WV', 'WY']
+}

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -298,11 +298,6 @@ def election_lookup():
 @app.route('/elections/<office>/<state>/<int:cycle>/')
 @app.route('/elections/<office>/<state>/<district>/<int:cycle>/')
 def elections(office, cycle, state=None, district=None):
-    if office.lower() not in ['president', 'senate', 'house']:
-        abort(404)
-    if state and state.upper() not in constants.states:
-        abort(404)
-
     # Get all cycles up until the cycle from the URL if it's beyond the current cycle
     # this fixes the issue of an election page not showing user-provided cycle
     # in the cycle select
@@ -311,6 +306,14 @@ def elections(office, cycle, state=None, district=None):
 
     if office.lower() == 'president':
         cycles = [each for each in cycles if each % 4 == 0]
+
+    if office.lower() not in ['president', 'senate', 'house']:
+        abort(404)
+    if state and state.upper() not in constants.states:
+        abort(404)
+    if cycle not in cycles:
+        abort(404)
+
     return render_template(
         'elections.html',
         office=office,

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -306,6 +306,8 @@ def elections(office, cycle, state=None, district=None):
 
     if office.lower() == 'president':
         cycles = [each for each in cycles if each % 4 == 0]
+    elif office.lower() == 'senate':
+        cycles = utils.get_state_senate_cycles(state)
 
     if office.lower() not in ['president', 'senate', 'house']:
         abort(404)

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -302,7 +302,13 @@ def elections(office, cycle, state=None, district=None):
         abort(404)
     if state and state.upper() not in constants.states:
         abort(404)
-    cycles = utils.get_cycles()
+
+    # Get all cycles up until the cycle from the URL if it's beyond the current cycle
+    # this fixes the issue of an election page not showing user-provided cycle
+    # in the cycle select
+    max_cycle = cycle if cycle > utils.current_cycle() else utils.current_cycle()
+    cycles = utils.get_cycles(max_cycle)
+
     if office.lower() == 'president':
         cycles = [each for each in cycles if each % 4 == 0]
     return render_template(

--- a/openfecwebapp/utils.py
+++ b/openfecwebapp/utils.py
@@ -107,8 +107,9 @@ def date_ranges():
         ),
     }
 
-def get_cycles():
-    return range(current_cycle(), constants.START_YEAR, -2)
+def get_cycles(max_cycle=None):
+    max = max_cycle if max_cycle else current_cycle()
+    return range(max, constants.START_YEAR, -2)
 
 def election_title(cycle, office, state=None, district=None):
     base = ' '.join([str(cycle), 'Election', 'United States', office.capitalize()])

--- a/openfecwebapp/utils.py
+++ b/openfecwebapp/utils.py
@@ -167,3 +167,21 @@ def process_cash_data(totals):
 
 def process_ie_data(totals):
     return financial_summary_processor(totals, constants.IE_FORMATTER)
+
+
+def get_senate_cycles(senate_class):
+    if senate_class == 1:
+        max = 2018
+    if senate_class == 2:
+        max = 2022
+    if senate_class == 3:
+        max = 2020
+    return range(max, constants.START_YEAR, -6)
+
+def get_state_senate_cycles(state):
+    senate_cycles = []
+    for senate_class in [1, 2, 3]:
+        if state.upper() in constants.SENATE_CLASSES[str(senate_class)]:
+            senate_cycles += get_senate_cycles(senate_class)
+    print(senate_cycles)
+    return senate_cycles

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 import locale
 import datetime
+import unittest
+from unittest import mock
 from collections import OrderedDict
 
 from openfecwebapp import filters
@@ -79,4 +81,26 @@ def test_financial_summary_processor():
     ])
     assert utils.financial_summary_processor(totals, formatter) == [(200, ('Total receipts', '1')), (100, ('Total disbursements', '1'))]
 
+def current_cycle():
+    return 2016
 
+class TestCycles(unittest.TestCase):
+    @mock.patch('openfecwebapp.utils.current_cycle')
+    def test_get_cycles(self, current_cycle):
+        # Mock out the current_cycle so it doesn't change in the future
+        current_cycle.return_value = 2016
+        # Check that it returns the correct default when no arg supplied
+        assert utils.get_cycles() == range(2016, 1979, -2)
+        # Check that it returns the correct range when an arg is supplied
+        assert utils.get_cycles(2020) == range(2020, 1979, -2)
+
+    def test_get_senate_cycles(self):
+        assert utils.get_senate_cycles(1) == range(2018, 1979, -6)
+
+    def test_state_senate_cycles(self):
+        # Testing with an example state, Wisconsin
+        # There should be an election in 2016 but not 2014
+        # because of the classes the state has
+        wisconsin = utils.get_state_senate_cycles('wi')
+        assert 2016 in wisconsin
+        assert 2014 not in wisconsin


### PR DESCRIPTION
This fixes several of the election cycle weirdness that @paulclark2 noticed in https://github.com/18F/openFEC-web-app/issues/1863 and https://github.com/18F/openFEC-web-app/issues/1864.

There's two issues. First, the cycle select currently maxes out at the current cycle (in this case, 2018). So even if a user navigated to a future election page, the select wouldn't match the other dates on the page: 

![image](https://cloud.githubusercontent.com/assets/1696495/23487921/2a1eed44-fe9e-11e6-9d51-896462261a21.png)

This patch makes it so that if the cycle entered in the URL path is greater than the current cycle, then the select will build a range up to that point (otherwise it will max out at the current cycle):

![image](https://cloud.githubusercontent.com/assets/1696495/23489997/8178bbb8-feaa-11e6-9671-8113b15f64c7.png)

Second, it checks the cycle for presidential pages so that if it's not a valid presidential year, it throws a 404. 

Third, it adds a `SENATE_CLASSES` constant and checks that when on a state's page, that the year in the URL path is actually a year when one of this state's classes is up for election, otherwising throwing a 404. And also now only shows valid elections:
![image](https://cloud.githubusercontent.com/assets/1696495/23489984/7308ad2c-feaa-11e6-9fc6-79d7438a1b7d.png)

This does not resolve the issue of incorrect election dates showing up in election search results, as those are handled by the API.

@PaulClark2 do you think this resolves those issues? 