### PR TITLE
Removing presidential results that with incorrect dates

### DIFF
--- a/static/js/modules/election-lookup.js
+++ b/static/js/modules/election-lookup.js
@@ -212,6 +212,18 @@ ElectionLookup.prototype.serialize = function() {
   return _.extend(helpers.filterNull(params));
 };
 
+ElectionLookup.prototype.removeWrongPresidentialElections = function(results, cycle) {
+  // Hack to remove the presidential result in non-presidential years
+  // Eventually this will be handled by the API
+  if (Number(cycle) % 4 > 0) {
+    return _.filter(results, function(result) {
+      return result.office !== 'P';
+    });
+  } else {
+    return results;
+  }
+};
+
 ElectionLookup.prototype.search = function(e, opts) {
   e && e.preventDefault();
   opts = _.extend({pushState: true}, opts || {});
@@ -222,10 +234,10 @@ ElectionLookup.prototype.search = function(e, opts) {
       // Requested search options differ from saved options; request new data.
       self.xhr && self.xhr.abort();
       self.xhr = $.getJSON(self.getUrl(serialized)).done(function(response) {
+        self.results = self.removeWrongPresidentialElections(response.results, serialized.cycle);
         // Note: Update district color map before rendering results
-        self.results = response.results;
         self.drawDistricts(self.results);
-        self.draw(response.results);
+        self.draw(self.results);
       });
       self.serialized = serialized;
       if (opts.pushState) {

--- a/tests/unit/modules/election-lookup.js
+++ b/tests/unit/modules/election-lookup.js
@@ -176,4 +176,13 @@ describe('election lookup', function() {
       expect(this.el.draw).not.to.have.been.called;
     });
   });
+
+  it('removes incorrect presidential elections', function() {
+    var raw = [
+      {cycle: 2018, office: 'P'},
+      {cycle: 2018, office: 'S'}
+    ];
+    var results = this.el.removeWrongPresidentialElections(raw, '2018');
+    expect(results).to.deep.equal([{cycle: 2018, office: 'S'}]);
+  });
 });


### PR DESCRIPTION
This is a temporary hack to remove presidential elections from the election lookup tool on non-presidential years. Eventually this will be handled by the API but in the mean time this will get rid of a glaring error.

![image](https://cloud.githubusercontent.com/assets/1696495/23562469/6c0ac1ce-fff7-11e6-95da-fa9d1b29ab76.png)

![image](https://cloud.githubusercontent.com/assets/1696495/23562472/712f4094-fff7-11e6-8689-16fa6fcb55e6.png)
