### PR TITLE
Fixes rendering on ao landing page

### DIFF
--- a/openfecwebapp/templates/legal-advisory-opinions-landing.html
+++ b/openfecwebapp/templates/legal-advisory-opinions-landing.html
@@ -62,14 +62,16 @@
     <a class="button button--standard button--browse" href="{{url_for('advisory_opinions')}}">Explore all advisory opinions</a>
   </div>
   <div class="post-feed">
-    {% for ao_no in recent_aos %}
-    {% with ao = recent_aos[ao_no] %}
+    {% for ao in recent_aos %}
     <article class="post">
-      <h3><a href="{{ url_for('advisory_opinion_page', ao_no=ao_no) }}">AO {{ ao_no }} {{ ao[0].name }}</a></h3>
-      <p class="t-sans">{{ ao[0].summary }}</p>
-      <p class="t-sans post__doc"><a href="{{ ao[0].url }}">{{ ao[0].category }} | PDF</a></p>
+      <h3><a href="{{ url_for('advisory_opinion_page', ao_no=ao.no) }}">AO {{ ao.no }} {{ ao.name }}</a></h3>
+      <p class="t-sans">{{ ao.summary }}</p>
+      {% for doc in ao.documents %}
+        {% if doc.category == 'Final Opinion' %}
+          <p class="t-sans post__doc"><a href="{{ doc.url }}">{{ doc.category }} | PDF</a></p>
+        {% endif %}
+      {% endfor %}
     </article>
-    {% endwith %}
     {% endfor %}
   </div>
 </section>

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -77,13 +77,12 @@ def render_legal_mur(mur):
 def render_legal_ao_landing():
     today = datetime.date.today()
     ao_min_date = today - datetime.timedelta(weeks=26)
-    results = api_caller.load_legal_search_results(query='', query_type='advisory_opinions', ao_min_date=ao_min_date)
-    recent_aos=OrderedDict(sorted(results['advisory_opinions'].items(), key=lambda item: item, reverse=True))
+    ao_results = api_caller.load_legal_search_results(query='', query_type='advisory_opinions', ao_min_date=ao_min_date)
     return render_template('legal-advisory-opinions-landing.html',
         parent='legal',
         result_type='advisory_opinions',
         display_name='advisory opinions',
-        recent_aos=recent_aos)
+        recent_aos=ao_results['advisory_opinions'])
 
 
 def to_date(committee, cycle):

--- a/tests/unit/test_legal_search.py
+++ b/tests/unit/test_legal_search.py
@@ -1,7 +1,8 @@
 import unittest
+import datetime
+
 from unittest import mock
 from urllib.parse import urlparse, parse_qs
-
 
 from openfecwebapp import api_caller
 from openfecwebapp.app import app
@@ -103,6 +104,16 @@ class TestLegalSearch(unittest.TestCase):
         assert results['advisory_opinions_returned'] == 2
         assert results['statutes_returned'] == 4
         assert results['regulations_returned'] == 5
+
+    @mock.patch.object(api_caller, 'load_legal_search_results')
+    def test_ao_landing_page(self, load_legal_search_results):
+        today = datetime.date.today()
+        ao_min_date = today - datetime.timedelta(weeks=26)
+        response = self.app.get('legal/advisory-opinions/')
+
+        assert response.status_code == 200
+        load_legal_search_results.assert_called_once_with(query='', query_type='advisory_opinions', ao_min_date=ao_min_date)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
https://fec-stage-proxy.18f.gov/data/legal/advisory-opinions/ is currently failing because this view and template hadn't been refactored to account for the new AO schema. This makes the necessary fix. 

cc @vrajmohan 