### PR TITLE
Feature/advanced data

### DIFF
--- a/openfecwebapp/app.py
+++ b/openfecwebapp/app.py
@@ -149,7 +149,7 @@ app.jinja_env.globals.update({
     'today': datetime.date.today,
     'format_election_years': format_election_years,
     'clean_id': clean_id,
-    'legacy_url': constants.LEGACY_URL
+    'transition_url': constants.TRANSITION_URL
 })
 
 app.add_url_rule('/issue/', view_func=views.GithubView.as_view('issue'))

--- a/openfecwebapp/app.py
+++ b/openfecwebapp/app.py
@@ -149,6 +149,7 @@ app.jinja_env.globals.update({
     'today': datetime.date.today,
     'format_election_years': format_election_years,
     'clean_id': clean_id,
+    'legacy_url': constants.LEGACY_URL
 })
 
 app.add_url_rule('/issue/', view_func=views.GithubView.as_view('issue'))

--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -4,6 +4,8 @@ START_YEAR = 1979
 END_YEAR = 2018
 DEFAULT_TIME_PERIOD = 2016
 
+LEGACY_URL = 'http://www.fec.gov'
+
 states = OrderedDict([
     ('AK', 'Alaska'),
     ('AL', 'Alabama'),

--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -4,7 +4,7 @@ START_YEAR = 1979
 END_YEAR = 2018
 DEFAULT_TIME_PERIOD = 2016
 
-LEGACY_URL = 'http://www.fec.gov'
+TRANSITION_URL = 'http://www.fec.gov'
 
 states = OrderedDict([
     ('AK', 'Alaska'),

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -100,15 +100,14 @@
     <div class="main__content--right-full">
       <section class="row" id="raising" aria-hidden="false" role="tabpanel" >
         <h2>Raising</h2>
-        <p>Receipts are anything of value (money, goods, services or property) received by a political committee. Authorized committees take in all receipts for a candidate’s campaign. Receipts include both contributions and other forms of support. This data is updated according to a committee's filing schedule and processing time may vary.</p>
         <div class="post-feed">
           <div class="post">
             <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('receipts', is_individual=True) }}">All receipts</a></h3>
-            <p>All receipts include all data reported by committees on Schedule A, which can come from individuals, organizations and other committees.</p>
+            <p>Receipts are anything of value, like money, services or property. Search candidate and committee receipt data by contributor, amount and date.</p>
           </div>
           <div class="post post--child">
             <h3><a href="{{ url_for('individual_contributions') }}">Individual contributions</a></h3>
-            <p>Individual contributions are a subset of all receipts and show all receipts reported to have been received from anyone other than another political committee. You can search for contributors by name, location, employer and occupation.</p>
+            <p>Search individual contributions to see who is donating to candidates and committees. Search for contributors by name, location, employer and occupation.</p>
           </div>
         </div>
         <div class="content__section--extra">
@@ -120,11 +119,11 @@
       </section>
       <section class="row" id="spending" aria-hidden="true" role="tabpanel" >
         <h2>Spending</h2>
-        <p>Spending includes all the types of <span class="term" data-term="disbursement">disbursements</span> candidates and committees make, including money spent on operating expenditures, money given to other committees, and money spent on election activity, like independent expenditures. This data is updated according to a committee's filing schedule and processing time may vary.</p>
+        <p>Spending includes all the types of <span class="term" data-term="disbursement">disbursements</span> candidates and committees make.</p>
         <div class="post-feed">
           <div class="post">
             <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('disbursements') }}">All disbursements</a></h3>
-            <p>This includes all data reported by committees on Schedule B. You can search all disbursements from committees by the recipient, purpose, amount and date.</p>
+            <p>Search all disbursements from committees by the recipient, purpose, amount and date.</p>
           </div>
           <div class="post">
             <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('independent_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Independent expenditures</a></h3>
@@ -151,15 +150,12 @@
       </section>
       <section class="row" id="loans-debts" aria-hidden="true" role="tabpanel">
         <h2>Loans and debts</h2>
-        <p>Committees may take out loans and owe debts.</p>
         <div class="post-feed">
           <div class="post">
             <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('loans', is_individual=True) }}">Loans</a></h3>
-            <p>Search schedule C forms filed by committees, which report information about loans received by committees.</p>
           </div>
           <div class="post">
-            <h3><i class="icon i-all-files icon--inline--left"></i>Debts (coming soon)</h3>
-            <p>Search schedule D forms filed by committees, which report information about debts owed by committees.</p>
+            <h3 class="is-disabled"><i class="icon i-all-files icon--inline--left"></i>Debts (coming soon)</h3>
           </div>
         </div>
       </section>
@@ -168,19 +164,18 @@
         <div class="post-feed">
           <div class="post">
             <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('candidates', election_year=default_cycles, has_raised_funds='true') }}">All candidates</a></h3>
-            <p>Browse all <span class="term" data-term="candidate">candidate</span> running for federal office</p>
           </div>
           <div class="post post--child">
             <h4><a href="{{ url_for('candidates_office', office='president') }}">Presidential candidates</a></h4>
-            <p>Search presidential candidates and view financial totals including money raised, money spent, cash on hand and debt.</p>
+            <p>Search presidential <span class="term" data-term="candidate">candidate</span> data including money raised, money spent, cash on hand and debt.</p>
           </div>
           <div class="post post--child">
             <h4><a href="{{ url_for('candidates_office', office='senate') }}">Senate candidates</a></h4>
-            <p>Search senate candidates and view financial totals including money raised, money spent, cash on hand and debt.</p>
+            <p>Search Senate candidate data including money raised, money spent, cash on hand and debt.</p>
           </div>
           <div class="post post--child">
             <h4><a href="{{ url_for('candidates_office', office='house') }}">House of Representatives candidates</a></h4>
-            <p>Search candidates for the House of Representatives and view financial totals including money raised, money spent, cash on hand and debt.</p>
+            <p>Search House candidate data including money raised, money spent, cash on hand and debt.</p>
           </div>
           <div class="post">
             <h3><a href="{{ url_for('filings', form_type='F2') }}">Most recent Statements of Candidacy (Form 2)</a></h3>

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block body %}
-  {{ header.header(title, '', show_search=False) }}
+  {{ header.header(title, '') }}
 <div class="tab-interface">
 <div class="main container">
   <header class="heading--main">
@@ -74,6 +74,26 @@
             aria-controls="reports"
             href="#reports"
             aria-selected="false">Reports and filings</a>
+        </li>
+        <li class="side-nav__item" role="presentation">
+          <a
+            class="side-nav__link"
+            role="tab"
+            data-name="other"
+            tabindex="0"
+            aria-controls="other"
+            href="#other"
+            aria-selected="false">Bulk data and other sources</a>
+        </li>
+        <li class="side-nav__item" role="presentation">
+          <a
+            class="side-nav__link"
+            role="tab"
+            data-name="external"
+            tabindex="0"
+            aria-controls="external"
+            href="#external"
+            aria-selected="false">External sources</a>
         </li>
       </ul>
     </nav>
@@ -166,7 +186,7 @@
           <a href="{{ cms_url }}/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Candidate registration and reporting requirements</a>
         </div>
       </section>
-      <section id="committees" class="row" aria-hidden="true" role="tabpanel" >
+      <section id="committees" class="row" aria-hidden="true" role="tabpanel">
         <h2>Committees</h2>
         <p>The term <span class="term" data-term="political committee">committee</span> encompasses several different political groups that receive and spend money in federal elections.</p>
         <div class="post-feed">
@@ -207,6 +227,80 @@
           <!--<li><a href="{{ url_for('reports', form_type='ie-only', is_amended='false') }}">Independent expenditure (Form 5) filer reports</a></li>-->
           <div class="post">
             <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('filings') }}">All filings</span></h3>
+          </div>
+        </div>
+      </section>
+      <section id="other" class="row" aria-hidden="true" role="tabpanel">
+        <h2>Bulk data and other sources</h2>
+        <div class="content__section">
+          <h3><a href="{{ legacy_url }}/press/campaign_finance_statistics.shtml">Historical statistics</a></h3>
+          <p>Data tables that summarize campaign financial activity by filer type, election cycle and reporting period.</p>
+        </div>
+        <div class="content__section">
+          <h3>Bulk data downloads</h3>
+          <p>The FEC prepares some data sets to be downloadable as a complete set.</p>
+          <div class="post-feed">
+            <div class="post">
+              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ legacy_url }}/finance/disclosure/ftpdet.shtml">Detailed data files</a></h4>
+              <p>Here you will find the Committees, Candidates and Linkages, Itemized Records, Contributions to Candidates, Individual Contributions and Operating Expenditures files.</p>
+              <p>These files contain committee, candidate and campaign finance data for the current election cycle and for election cycles through 1980. The files for the current election cycle plus the two most recent election cycles are regularly updated. The Committees, Candidates and Linkages files are updated daily. The Itemized Records, Contributions to Candidates, Individual Contributions and Operating Expenditures files are udated weekly on Sunday. Please note that complete entry from each reporting period takes about 30 days. It is important to be careful when making conclusions from these data because some information may not have completed the entry process when these files where create. Committees do not have the same filing requirements. You should be careful when comparing financial information about committees with different filing requirements.</p>
+            </div>
+            <div class="post">
+              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ legacy_url }}/finance/disclosure/ftpsum.shtml">Summary data files</a></h4>
+              <p>Here you will find the current campaign summary file, the all candidates summary file and the current PAC summary file. The most recent 10 years of data, the current two-year election period plus the most recent five (5) two-year election periods, are updated daily.</p>
+            </div>
+            <div class="post">
+              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ legacy_url }}/finance/disclosure/ftpefile.shtml">Electronically filed reports</a></h4>
+              <p>You will find here a daily compilation of electronically filed reports and statements. These are available from Feburary 2001 to present. Filing formats, valid dates for these formats and header files for version 1 through the most recent version are available.</p>
+            </div>
+            <div class="post">
+              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ legacy_url }}/finance/disclosure/ftppaper.shtml">Paper filed reports</a></h4>
+              <p>The summary financial information and transactions disclosed in paper reports are data entered into an electronic format, and then stored in a downloadable file similar to electronically filed reports, known as a .fec file. Paper filings are data entered in a batch process; therefore, the Commission does not receive converted paper filings every day from our contractor. On days the Commission does not receive converted paper filings, an empty file (YYYYMMDD.nofiles.zip) will be placed on the FTP server. On days the Commission receives converted paper filings, a file (YYYYMMDD.zip) will contain that day's .fec files.</p>
+              <p>Forms 3, 3L, 3X, 5, 6, 7 and 24-hour and 48-hour independent expenditures reports are converted to .fec files. The Commission began this paper to electronic conversion process in October 2005. The first data file was uploaded to the Commission on December 8, 2005.</p>
+            </div>
+          </div>
+        </div>
+        <div class="content__section">
+          <h3>Other FEC data sources</h3>
+          <div class="post-feed">
+            <div class="post">
+              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ legacy_url }}/data/DataCatalog.do">Legacy data catalog</a></h4>
+              <p>Each of the files listed here can be downloaded in either csv or xml formats. Each also has a metadata page that describes the information included and the structure of the file itself. There is a pdf version of each file if you need to print the information. You can also subscribe to RSS feeds for each of the files so you're notified whenever new data is available or a change is made.</p>
+              <p><a href="{{ legacy_url }}/disclosurep/pnational.do">Presidential election map</a> | <a href="{{ legacy_url }}/disclosurehs/hsnational.do">House and Senate elections data map</a>
+            </div>
+            <div class="post">
+              <h4>Presidential campaign matching fund submissions</h4>
+              <p>
+                <a href="{{ legacy_url }}/finance/disclosure/2016MatchingFundSubmissions.shtml">2016</a> |
+                <a href="{{ legacy_url }}/finance/2012matching/2012matching.shtml">2012</a> |
+                <a href="{{ legacy_url }}/finance/2008matching/2008matching.shtml">2008</a> |
+                <a href="{{ legacy_url }}/finance/disclosure/2004MatchingFundSubmissions.shtml">2004</a> |
+                <a href="{{ legacy_url }}/finance/disclosure/submiss.shtml">2000</a>
+              </p>
+              <p>You will find here the threshold files for presidential candidates seeking matching funds.</p>
+              <p>In addition to regular quarterly or monthly disclosure reports, presidential candidates who seek matching funds must submit information about "matchable" contributions to the FEC for review. Contributions from individuals where the aggregate amount contributed by the individual is $250 or less are eligible to be matched on a dollar for dollar basis from the Presidential Election Campaign Fund. This Fund includes proceeds from the voluntary check-off of $3 per person from income tax returns of eligible taxpayers.</p>
+            </div>
+            <div class="post">
+              <h4><i class="icon i-magnifying-glass icon--inline--left"></i><a href="http://docquery.fec.gov/senate/">Senate unofficial electronic filings</a></h4>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section id="external" class="row" aria-hidden="true" role="tabpanel">
+        <h2>External sources</h2>
+        <p>Certain information is reported to the FEC, but more information is reported to other governmental agencies.</p>
+        <div class="post-feed">
+          <div class="post">
+            <h3><i class="icon i-share icon--inline--left"></i><a href="https://www.irs.gov/charities-non-profits/political-organizations/political-organization-filing-and-disclosure">Internal Revenue Service (IRS) filings</h3>
+            <p>Search and download filings and disclosures by political organizations</p>
+          </div>
+          <div class="post">
+            <h3><i class="icon i-share icon--inline--left"></i><a href="http://apps.fcc.gov/ecd/">Federal Communications Commission (FCC) electioneering communications database</a></h3>
+            <p>Search electioneering communications.</p>
+          </div>
+          <div class="post">
+            <h3><i class="icon i-share icon--inline--left"></i><a href="https://www.oge.gov/web/oge.nsf/Presidential%20Candidates?OpenView">Office of Government Ethics (OGE) presidential candidate financial disclosure reports</a></h3>
+            <p>View financial disclosure reports filed by presidential candidates.</p>
           </div>
         </div>
       </section>

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -242,6 +242,16 @@
           </aside>
         </a>
       </div>
+      <div class="grid__item">
+        <a href="https://api.open.fec.gov">
+          <aside class="card card--horizontal card--primary">
+            <div class="card__image__container">
+              <span class="card__icon i-data-flag"><span class="u-visually-hidden">Icon of an American flag</span></span>
+            </div>
+            <div class="card__content">
+                Use the OpenFEC API
+            </div>
+          </aside>
         </a>
       </div>
     </div>

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -39,11 +39,11 @@
           <a
             class="side-nav__link"
             role="tab"
-            data-name="debts-loans"
+            data-name="loans-debts"
             tabindex="0"
-            aria-controls="debts-loans"
-            href="#debts-loans"
-            aria-selected="false">Debts and loans</a>
+            aria-controls="loans-debts"
+            href="#loans-debts"
+            aria-selected="false">Loans and debts</a>
         </li>
         <li class="side-nav__item" role="presentation">
           <a
@@ -100,60 +100,66 @@
     <div class="main__content--right-full">
       <section class="row" id="raising" aria-hidden="false" role="tabpanel" >
         <h2>Raising</h2>
+        <p>Receipts are anything of value (money, goods, services or property) received by a political committee. Authorized committees take in all receipts for a candidate’s campaign. Receipts include both contributions and other forms of support. This data is updated according to a committee's filing schedule and processing time may vary.</p>
         <div class="post-feed">
           <div class="post">
             <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('receipts', is_individual=True) }}">All receipts</a></h3>
-            <p><span class="term" data-term="receipt">Receipts</span> are anything of value, like money, services or property. Search candidate and committee receipt data by contributor, amount and date.</p>
+            <p>All receipts include all data reported by committees on Schedule A, which can come from individuals, organizations and other committees.</p>
           </div>
-          <div class="post u-padding--left">
+          <div class="post post--child">
             <h3><a href="{{ url_for('individual_contributions') }}">Individual contributions</a></h3>
-            <p>Search individual contributions to see who is donating to candidates and committees. Search for contributors by name, location, employer and occupation.</p>
+            <p>Individual contributions are a subset of all receipts and show all receipts reported to have been received from anyone other than another political committee. You can search for contributors by name, location, employer and occupation.</p>
           </div>
         </div>
-        <div class="option__aside">
-          <i class="icon-circle--raising"><span class="u-visually-hidden">Icon of a piggy bank</span></i>
-            <a href="/#raising">Raising data overview</a>
+        <div class="content__section--extra">
+          <div class="icon-heading">
+            <i class="icon-heading__image icon-circle--raising"><span class="u-visually-hidden">Icon of a piggy bank</span></i>
+            <div class="icon-heading__content"><a href="/#raising">Raising data overview</a></div>
+          </div>
         </div>
       </section>
       <section class="row" id="spending" aria-hidden="true" role="tabpanel" >
         <h2>Spending</h2>
-        <p>Spending includes all the types of <span class="term" data-term="disbursement">dibsursements</span> candidates and committees make.</p>
+        <p>Spending includes all the types of <span class="term" data-term="disbursement">disbursements</span> candidates and committees make, including money spent on operating expenditures, money given to other committees, and money spent on election activity, like independent expenditures. This data is updated according to a committee's filing schedule and processing time may vary.</p>
         <div class="post-feed">
           <div class="post">
             <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('disbursements') }}">All disbursements</a></h3>
-        <p>Search all disbursements from committees by the recipient, purpose, amount and date.</p>
+            <p>This includes all data reported by committees on Schedule B. You can search all disbursements from committees by the recipient, purpose, amount and date.</p>
           </div>
           <div class="post">
-            <h3><a href="{{ url_for('independent_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Independent expenditures</a></h3>
+            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('independent_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Independent expenditures</a></h3>
             <p>Search <span class="term" data-term="independent expenditure">independent expenditures</span> to find specific spenders, candidates mentioned and transaction information.</p>
           </div>
           <div class="post">
-            <h3><a href="{{ url_for('party_coordinated_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Party coordinated expenditures</a></h3>
+            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('party_coordinated_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Party coordinated expenditures</a></h3>
           </div>
           <div class="post">
-            <h3><a href="{{ url_for('electioneering_communications', max_date=today() | date(fmt='%m-%d-%Y')) }}">Electioneering communications</a></h3>
+            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('electioneering_communications', max_date=today() | date(fmt='%m-%d-%Y')) }}">Electioneering communications</a></h3>
             <p>Search <span class="term" data-term="electioneering communication">electioneering communications</span> for communications that support or oppose specific candidates. Search by date and amount spent.</p>
           </div>
           <div class="post">
-            <h3><a href="{{ url_for('communication_costs', max_date=today() | date(fmt='%m-%d-%Y')) }}">Communication costs</a></h3>
+            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('communication_costs', max_date=today() | date(fmt='%m-%d-%Y')) }}">Communication costs</a></h3>
             <p>Search communication costs for communications that support or oppose specific candidates. Search by date and amount spent.</p>
           </div>
         </div>
-        <div class="option__aside">
-          <i class="icon-circle--spending"><span class="u-visually-hidden">Icon of a spreading dollar sign</span></i>
-            <a href="/#spending">Spending data overview</a>
+        <div class="content__section--extra">
+          <div class="icon-heading">
+            <i class="icon-heading__image icon-circle--spending"><span class="u-visually-hidden">Icon of a spreading dollar sign</span></i>
+            <div class="icon-heading__content"><a href="/#raising">Spending data overview</a></div>
+          </div>
         </div>
       </section>
-      <section class="row" id="debts-loans" aria-hidden="true" role="tabpanel">
-        <h2>Debts and loans</h2>
-        <div class="option__content">
-          <div class="post-feed">
-            <div class="post">
-              <h3><a href="">Debts</a></h3>
-            </div>
-            <div class="post">
-              <h3><a href="{{ url_for('loans', is_individual=True) }}">Loans</a></h3>
-            </div>
+      <section class="row" id="loans-debts" aria-hidden="true" role="tabpanel">
+        <h2>Loans and debts</h2>
+        <p>Committees may take out loans and owe debts.</p>
+        <div class="post-feed">
+          <div class="post">
+            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('loans', is_individual=True) }}">Loans</a></h3>
+            <p>Search schedule C forms filed by committees, which report information about loans received by committees.</p>
+          </div>
+          <div class="post">
+            <h3><i class="icon i-all-files icon--inline--left"></i>Debts (coming soon)</h3>
+            <p>Search schedule D forms filed by committees, which report information about debts owed by committees.</p>
           </div>
         </div>
       </section>
@@ -181,9 +187,13 @@
             <p>Statements of Candidacy (Form 2) contain basic information about individuals running for federal office, including their names, addresses and authorized campaign committees.</p>
           </div>
         </div>
-        <div class="option__aside">
-          <i class="icon-circle--checklist card--stacked"><span class="u-visually-hidden">Icon of a checklist</span></i>
-          <a href="{{ cms_url }}/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Candidate registration and reporting requirements</a>
+        <div class="content__section--extra grid grid--3-wide">
+          <div class="icon-heading grid__item">
+            <i class="icon-heading__image icon-circle--checklist"><span class="u-visually-hidden">Icon of a checklist</span></i>
+            <div class="icon-heading__content">
+              <a href="{{ cms_url }}/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Help for candidates and their committees</a>
+            </div>
+          </div>
         </div>
       </section>
       <section id="committees" class="row" aria-hidden="true" role="tabpanel">
@@ -203,11 +213,40 @@
             <p>Requests for Additional Information (RFAIs) are sent to committees when a Campaign Finance Analyst needs additional clarification on a committee’s filing or identifies an error, omission or possible prohibited activity. Search RFAIs by committee or date.</p>
           </div>
         </div>
-        <div class="option__aside">
-          <i class="icon-circle--checklist card--stacked"><span class="u-visually-hidden">Icon of a checklist</span></i>
-            <a href="{{ cms_url }}/registration-and-reporting/essentials-nonconnected-committees/">Nonconnected committee registration and reporting requirements</a><br><br>
-            <a href="{{ cms_url }}/registration-and-reporting/essentials-political-party-committees/">Political party committee registration and reporting requirements</a><br><br>
-            <a href="{{ cms_url }}/registration-and-reporting/">Registration and reporting requirements for other committees</a>
+        <div class="content__section--extra" data-content-prefix="pacronym">
+          <h3>PACronyms</h3>
+          <p>PACRONYMS, an alphabetical list of acronyms, abbreviations, initials, and common names of federal political action committees (PACs), was prepared to help researchers readily identify committees when their full names are not disclosed on campaign finance reports.</p>
+          <p>The list includes the PACRONYM, FEC ID number, full committee name, city and state, name of sponsoring, connected, or affiliated organization, committee designation and committee type.  Unless noted otherwise in the full committee name, the acronym “PAC” refers to “Political Action Committee.”  The PACRONYM is listed in ITALICS if the committee's PACRONYM is not specifically provided on the committee's Statement of Organization (FEC Form 1).</p>
+          <ul class="list--buttons">
+            <li>
+              <a class="button button--standard button--document" href="http://www.fec.gov/pubrec/pacronyms/Pacronyms.pdf">Open PDF</a>
+            </li>
+            <li>
+              <a class="button button--standard button--download" href="http://www.fec.gov/pubrec/pacronyms/Pacronyms.xlsx">Download for Excel</a>
+            </li>
+          </ul>
+        </div>
+        <div class="content__section--extra">
+          <div class="icon-heading">
+            <i class="icon-heading__image icon-circle--checklist"><span class="u-visually-hidden">Icon of a checklist</span></i>
+            <div class="icon-heading__content">
+              <h4 class="u-no-margin">More information for:</h4>
+              <div class="grid grid--2-wide">
+                <div class="grid__item">
+                  <a href="{{ cms_url }}/registration-and-reporting/essentials-nonconnected-committees/">Candidates and their committees</a>
+                </div>
+                <div class="grid__item">
+                  <a href="{{ cms_url }}/registration-and-reporting/essentials-nonconnected-committees/">Nonconnected committees</a>
+                </div>
+                <div class="grid__item">
+                  <a href="{{ cms_url }}/registration-and-reporting/essentials-political-party-committees/">Political party committees</a>
+                </div>
+                <div class="grid__item">
+                  <a href="{{ cms_url }}/registration-and-reporting/">Corporations and labor organizations</a>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </section>
       <section class="row" id="reports" aria-hidden="true" role="tabpanel">
@@ -215,19 +254,19 @@
         <p>Filings contain all the statements, reports and notices that candidates and committees file. Search by date, type and filing candidate or committee.</p>
         <div class="post-feed">
           <div class="post">
+            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('filings') }}">All filings</span></h3>
+          </div>
+          <div class="post post--child">
             <h3><a href="{{ url_for('reports', form_type='presidential', is_amended='false') }}">Presidential committee reports</a></h3>
           </div>
-          <div class="post">
+          <div class="post post--child">
             <h3><a href="{{ url_for('reports', form_type='house-senate', is_amended='false') }}">House and Senate committee reports</a></h3>
           </div>
-          <div class="post">
+          <div class="post post--child">
             <h3><a href="{{ url_for('reports', form_type='pac-party', is_amended='false') }}">PAC and party committee reports</a></h3>
           </div>
           <!-- Commenting out while page is in progress -->
           <!--<li><a href="{{ url_for('reports', form_type='ie-only', is_amended='false') }}">Independent expenditure (Form 5) filer reports</a></li>-->
-          <div class="post">
-            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('filings') }}">All filings</span></h3>
-          </div>
         </div>
       </section>
       <section id="other" class="row" aria-hidden="true" role="tabpanel">

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -267,7 +267,7 @@
       <section id="other" class="row" aria-hidden="true" role="tabpanel">
         <h2>Bulk data and other sources</h2>
         <div class="content__section">
-          <h3><a href="{{ legacy_url }}/press/campaign_finance_statistics.shtml">Historical statistics</a></h3>
+          <h3><a href="{{ transition_url }}/press/campaign_finance_statistics.shtml">Historical statistics</a></h3>
           <p>Data tables that summarize campaign financial activity by filer type, election cycle and reporting period.</p>
         </div>
         <div class="content__section">
@@ -275,20 +275,20 @@
           <p>The FEC prepares some data sets to be downloadable as a complete set.</p>
           <div class="post-feed">
             <div class="post">
-              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ legacy_url }}/finance/disclosure/ftpdet.shtml">Detailed data files</a></h4>
+              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftpdet.shtml">Detailed data files</a></h4>
               <p>Here you will find the Committees, Candidates and Linkages, Itemized Records, Contributions to Candidates, Individual Contributions and Operating Expenditures files.</p>
               <p>These files contain committee, candidate and campaign finance data for the current election cycle and for election cycles through 1980. The files for the current election cycle plus the two most recent election cycles are regularly updated. The Committees, Candidates and Linkages files are updated daily. The Itemized Records, Contributions to Candidates, Individual Contributions and Operating Expenditures files are udated weekly on Sunday. Please note that complete entry from each reporting period takes about 30 days. It is important to be careful when making conclusions from these data because some information may not have completed the entry process when these files where create. Committees do not have the same filing requirements. You should be careful when comparing financial information about committees with different filing requirements.</p>
             </div>
             <div class="post">
-              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ legacy_url }}/finance/disclosure/ftpsum.shtml">Summary data files</a></h4>
+              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftpsum.shtml">Summary data files</a></h4>
               <p>Here you will find the current campaign summary file, the all candidates summary file and the current PAC summary file. The most recent 10 years of data, the current two-year election period plus the most recent five (5) two-year election periods, are updated daily.</p>
             </div>
             <div class="post">
-              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ legacy_url }}/finance/disclosure/ftpefile.shtml">Electronically filed reports</a></h4>
+              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftpefile.shtml">Electronically filed reports</a></h4>
               <p>You will find here a daily compilation of electronically filed reports and statements. These are available from Feburary 2001 to present. Filing formats, valid dates for these formats and header files for version 1 through the most recent version are available.</p>
             </div>
             <div class="post">
-              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ legacy_url }}/finance/disclosure/ftppaper.shtml">Paper filed reports</a></h4>
+              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftppaper.shtml">Paper filed reports</a></h4>
               <p>The summary financial information and transactions disclosed in paper reports are data entered into an electronic format, and then stored in a downloadable file similar to electronically filed reports, known as a .fec file. Paper filings are data entered in a batch process; therefore, the Commission does not receive converted paper filings every day from our contractor. On days the Commission does not receive converted paper filings, an empty file (YYYYMMDD.nofiles.zip) will be placed on the FTP server. On days the Commission receives converted paper filings, a file (YYYYMMDD.zip) will contain that day's .fec files.</p>
               <p>Forms 3, 3L, 3X, 5, 6, 7 and 24-hour and 48-hour independent expenditures reports are converted to .fec files. The Commission began this paper to electronic conversion process in October 2005. The first data file was uploaded to the Commission on December 8, 2005.</p>
             </div>
@@ -298,18 +298,18 @@
           <h3>Other FEC data sources</h3>
           <div class="post-feed">
             <div class="post">
-              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ legacy_url }}/data/DataCatalog.do">Legacy data catalog</a></h4>
+              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/data/DataCatalog.do">Legacy data catalog</a></h4>
               <p>Each of the files listed here can be downloaded in either csv or xml formats. Each also has a metadata page that describes the information included and the structure of the file itself. There is a pdf version of each file if you need to print the information. You can also subscribe to RSS feeds for each of the files so you're notified whenever new data is available or a change is made.</p>
-              <p><a href="{{ legacy_url }}/disclosurep/pnational.do">Presidential election map</a> | <a href="{{ legacy_url }}/disclosurehs/hsnational.do">House and Senate elections data map</a>
+              <p><a href="{{ transition_url }}/disclosurep/pnational.do">Presidential election map</a> | <a href="{{ transition_url }}/disclosurehs/hsnational.do">House and Senate elections data map</a>
             </div>
             <div class="post">
               <h4>Presidential campaign matching fund submissions</h4>
               <p>
-                <a href="{{ legacy_url }}/finance/disclosure/2016MatchingFundSubmissions.shtml">2016</a> |
-                <a href="{{ legacy_url }}/finance/2012matching/2012matching.shtml">2012</a> |
-                <a href="{{ legacy_url }}/finance/2008matching/2008matching.shtml">2008</a> |
-                <a href="{{ legacy_url }}/finance/disclosure/2004MatchingFundSubmissions.shtml">2004</a> |
-                <a href="{{ legacy_url }}/finance/disclosure/submiss.shtml">2000</a>
+                <a href="{{ transition_url }}/finance/disclosure/2016MatchingFundSubmissions.shtml">2016</a> |
+                <a href="{{ transition_url }}/finance/2012matching/2012matching.shtml">2012</a> |
+                <a href="{{ transition_url }}/finance/2008matching/2008matching.shtml">2008</a> |
+                <a href="{{ transition_url }}/finance/disclosure/2004MatchingFundSubmissions.shtml">2004</a> |
+                <a href="{{ transition_url }}/finance/disclosure/submiss.shtml">2000</a>
               </p>
               <p>You will find here the threshold files for presidential candidates seeking matching funds.</p>
               <p>In addition to regular quarterly or monthly disclosure reports, presidential candidates who seek matching funds must submit information about "matchable" contributions to the FEC for review. Contributions from individuals where the aggregate amount contributed by the individual is $250 or less are eligible to be matched on a dollar for dollar basis from the Presidential Election Campaign Fund. This Fund includes proceeds from the voluntary check-off of $3 per person from income tax returns of eligible taxpayers.</p>
@@ -350,7 +350,7 @@
         <a href="{{ url_for('election_lookup') }}">
           <aside class="card card--horizontal card--primary">
             <div class="card__image__container">
-                <span class="card__icon i-elections"><span class="u-visually-hidden">Icon representing elections</span></span>
+              <span class="card__icon i-elections"><span class="u-visually-hidden">Icon representing elections</span></span>
             </div>
             <div class="card__content">
               Find elections by location

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -386,6 +386,16 @@
   </div>
 </div>
 </div>
+<div class="slab slab--neutral footer-disclaimer">
+  <div class="container">
+    <div class="usa-width-one-half">
+      <p class="t-sans u-no-margin">Reports and statements filed by political committees may be inspected and copied by anyone. The names and addresses of individual contributors, however, may not be sold or used for any commercial purpose or to solicit any time of contribution or donation.</p>
+    </div>
+    <div class="usa-width-one-half">
+      <p class="t-sans u-no-margin"><a href="{{ transition_url }}/pages/brochures/saleuse.shtml">Read more about the sale and use of this data</a>.</p>
+    </div>
+  </div>
+</div>
 {% endblock %}
 
 {% block scripts %}

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -7,395 +7,395 @@
 
 {% block body %}
   {{ header.header(title, '') }}
-<div class="tab-interface">
-<div class="main container">
-  <header class="heading--main">
-    <h1>{{ title }}</h1>
-  </header>
-  <div class="data-container__wrapper">
-    <nav class="sidebar side-nav-alt">
-      <ul class="tablist" role="tablist" data-name="tab">
-        <li class="side-nav__item" role="presentation">
-          <a
-            class="side-nav__link"
-            role="tab"
-            data-name="raising"
-            tabindex="0"
-            aria-controls="raising"
-            href="#raising"
-            aria-selected="true">Raising</a>
-        </li>
-        <li class="side-nav__item" role="presentation">
-          <a
-            class="side-nav__link"
-            role="tab"
-            data-name="spending"
-            tabindex="0"
-            aria-controls="spending"
-            href="#spending"
-            aria-selected="false">Spending</a>
-        </li>
-        <li class="side-nav__item" role="presentation">
-          <a
-            class="side-nav__link"
-            role="tab"
-            data-name="loans-debts"
-            tabindex="0"
-            aria-controls="loans-debts"
-            href="#loans-debts"
-            aria-selected="false">Loans and debts</a>
-        </li>
-        <li class="side-nav__item" role="presentation">
-          <a
-            class="side-nav__link"
-            role="tab"
-            data-name="candidates"
-            tabindex="0"
-            aria-controls="candidates"
-            href="#candidates"
-            aria-selected="false">Candidates</a>
-        </li>
-        <li class="side-nav__item" role="presentation">
-          <a
-            class="side-nav__link"
-            role="tab"
-            data-name="committees"
-            tabindex="0"
-            aria-controls="committees"
-            href="#committees"
-            aria-selected="false">Committees</a>
-        </li>
-        <li class="side-nav__item" role="presentation">
-          <a
-            class="side-nav__link"
-            role="tab"
-            data-name="reports"
-            tabindex="0"
-            aria-controls="reports"
-            href="#reports"
-            aria-selected="false">Reports and filings</a>
-        </li>
-        <li class="side-nav__item" role="presentation">
-          <a
-            class="side-nav__link"
-            role="tab"
-            data-name="other"
-            tabindex="0"
-            aria-controls="other"
-            href="#other"
-            aria-selected="false">Bulk data and other sources</a>
-        </li>
-        <li class="side-nav__item" role="presentation">
-          <a
-            class="side-nav__link"
-            role="tab"
-            data-name="external"
-            tabindex="0"
-            aria-controls="external"
-            href="#external"
-            aria-selected="false">External sources</a>
-        </li>
-      </ul>
-    </nav>
-    <div class="main__content--right-full">
-      <section class="row" id="raising" aria-hidden="false" role="tabpanel" >
-        <h2>Raising</h2>
-        <div class="post-feed">
-          <div class="post">
-            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('receipts', is_individual=True) }}">All receipts</a></h3>
-            <p>Receipts are anything of value, like money, services or property. Search candidate and committee receipt data by contributor, amount and date.</p>
-          </div>
-          <div class="post post--child">
-            <h3><a href="{{ url_for('individual_contributions') }}">Individual contributions</a></h3>
-            <p>Search individual contributions to see who is donating to candidates and committees. Search for contributors by name, location, employer and occupation.</p>
-          </div>
-        </div>
-        <div class="content__section--extra">
-          <div class="icon-heading">
-            <i class="icon-heading__image icon-circle--raising"><span class="u-visually-hidden">Icon of a piggy bank</span></i>
-            <div class="icon-heading__content"><a href="/#raising">Raising data overview</a></div>
-          </div>
-        </div>
-      </section>
-      <section class="row" id="spending" aria-hidden="true" role="tabpanel" >
-        <h2>Spending</h2>
-        <p>Spending includes all the types of <span class="term" data-term="disbursement">disbursements</span> candidates and committees make.</p>
-        <div class="post-feed">
-          <div class="post">
-            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('disbursements') }}">All disbursements</a></h3>
-            <p>Search all disbursements from committees by the recipient, purpose, amount and date.</p>
-          </div>
-          <div class="post">
-            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('independent_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Independent expenditures</a></h3>
-            <p>Search <span class="term" data-term="independent expenditure">independent expenditures</span> to find specific spenders, candidates mentioned and transaction information.</p>
-          </div>
-          <div class="post">
-            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('party_coordinated_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Party coordinated expenditures</a></h3>
-          </div>
-          <div class="post">
-            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('electioneering_communications', max_date=today() | date(fmt='%m-%d-%Y')) }}">Electioneering communications</a></h3>
-            <p>Search <span class="term" data-term="electioneering communication">electioneering communications</span> for communications that support or oppose specific candidates. Search by date and amount spent.</p>
-          </div>
-          <div class="post">
-            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('communication_costs', max_date=today() | date(fmt='%m-%d-%Y')) }}">Communication costs</a></h3>
-            <p>Search communication costs for communications that support or oppose specific candidates. Search by date and amount spent.</p>
-          </div>
-        </div>
-        <div class="content__section--extra">
-          <div class="icon-heading">
-            <i class="icon-heading__image icon-circle--spending"><span class="u-visually-hidden">Icon of a spreading dollar sign</span></i>
-            <div class="icon-heading__content"><a href="/#raising">Spending data overview</a></div>
-          </div>
-        </div>
-      </section>
-      <section class="row" id="loans-debts" aria-hidden="true" role="tabpanel">
-        <h2>Loans and debts</h2>
-        <div class="post-feed">
-          <div class="post">
-            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('loans', is_individual=True) }}">Loans</a></h3>
-          </div>
-          <div class="post">
-            <h3 class="is-disabled"><i class="icon i-all-files icon--inline--left"></i>Debts (coming soon)</h3>
-          </div>
-        </div>
-      </section>
-      <section id="candidates" class="row" aria-hidden="true" role="tabpanel">
-        <h2>Candidates</h2>
-        <div class="post-feed">
-          <div class="post">
-            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('candidates', election_year=default_cycles, has_raised_funds='true') }}">All candidates</a></h3>
-          </div>
-          <div class="post post--child">
-            <h4><a href="{{ url_for('candidates_office', office='president') }}">Presidential candidates</a></h4>
-            <p>Search presidential <span class="term" data-term="candidate">candidate</span> data including money raised, money spent, cash on hand and debt.</p>
-          </div>
-          <div class="post post--child">
-            <h4><a href="{{ url_for('candidates_office', office='senate') }}">Senate candidates</a></h4>
-            <p>Search Senate candidate data including money raised, money spent, cash on hand and debt.</p>
-          </div>
-          <div class="post post--child">
-            <h4><a href="{{ url_for('candidates_office', office='house') }}">House of Representatives candidates</a></h4>
-            <p>Search House candidate data including money raised, money spent, cash on hand and debt.</p>
-          </div>
-          <div class="post">
-            <h3><a href="{{ url_for('filings', form_type='F2') }}">Most recent Statements of Candidacy (Form 2)</a></h3>
-            <p>Statements of Candidacy (Form 2) contain basic information about individuals running for federal office, including their names, addresses and authorized campaign committees.</p>
-          </div>
-        </div>
-        <div class="content__section--extra grid grid--3-wide">
-          <div class="icon-heading grid__item">
-            <i class="icon-heading__image icon-circle--checklist"><span class="u-visually-hidden">Icon of a checklist</span></i>
-            <div class="icon-heading__content">
-              <a href="{{ cms_url }}/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Help for candidates and their committees</a>
-            </div>
-          </div>
-        </div>
-      </section>
-      <section id="committees" class="row" aria-hidden="true" role="tabpanel">
-        <h2>Committees</h2>
-        <p>The term <span class="term" data-term="political committee">committee</span> encompasses several different political groups that receive and spend money in federal elections.</p>
-        <div class="post-feed">
-          <div class="post">
-            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('committees', election_year=default_cycles) }}">All committees</a></h3>
-            <p>Search for committees by type, years active, political party, location and treasurer.</p>
-          </div>
-          <div class="post">
-            <h3><a href="{{ url_for('filings', form_type='F1') }}">Most recent Statements of Organization (Form 1)</a></h3>
-            <p>Statements of Organization (Form 1) contain basic information about committees, including type, address and treasurer.</p>
-          </div>
-          <div class="post">
-            <h3><a href="{{ url_for('filings', form_type='RFAI') }}">Requests for Additional Information sent to committees</a></h3>
-            <p>Requests for Additional Information (RFAIs) are sent to committees when a Campaign Finance Analyst needs additional clarification on a committee’s filing or identifies an error, omission or possible prohibited activity. Search RFAIs by committee or date.</p>
-          </div>
-        </div>
-        <div class="content__section--extra" data-content-prefix="pacronym">
-          <h3>PACronyms</h3>
-          <p>PACRONYMS, an alphabetical list of acronyms, abbreviations, initials, and common names of federal political action committees (PACs), was prepared to help researchers readily identify committees when their full names are not disclosed on campaign finance reports.</p>
-          <p>The list includes the PACRONYM, FEC ID number, full committee name, city and state, name of sponsoring, connected, or affiliated organization, committee designation and committee type.  Unless noted otherwise in the full committee name, the acronym “PAC” refers to “Political Action Committee.”  The PACRONYM is listed in ITALICS if the committee's PACRONYM is not specifically provided on the committee's Statement of Organization (FEC Form 1).</p>
-          <ul class="list--buttons">
-            <li>
-              <a class="button button--standard button--document" href="http://www.fec.gov/pubrec/pacronyms/Pacronyms.pdf">Open PDF</a>
+  <div class="tab-interface">
+    <div class="main container">
+      <header class="heading--main">
+        <h1>{{ title }}</h1>
+      </header>
+      <div class="data-container__wrapper">
+        <nav class="sidebar side-nav-alt">
+          <ul class="tablist" role="tablist" data-name="tab">
+            <li class="side-nav__item" role="presentation">
+              <a
+                class="side-nav__link"
+                role="tab"
+                data-name="raising"
+                tabindex="0"
+                aria-controls="raising"
+                href="#raising"
+                aria-selected="true">Raising</a>
             </li>
-            <li>
-              <a class="button button--standard button--download" href="http://www.fec.gov/pubrec/pacronyms/Pacronyms.xlsx">Download for Excel</a>
+            <li class="side-nav__item" role="presentation">
+              <a
+                class="side-nav__link"
+                role="tab"
+                data-name="spending"
+                tabindex="0"
+                aria-controls="spending"
+                href="#spending"
+                aria-selected="false">Spending</a>
+            </li>
+            <li class="side-nav__item" role="presentation">
+              <a
+                class="side-nav__link"
+                role="tab"
+                data-name="loans-debts"
+                tabindex="0"
+                aria-controls="loans-debts"
+                href="#loans-debts"
+                aria-selected="false">Loans and debts</a>
+            </li>
+            <li class="side-nav__item" role="presentation">
+              <a
+                class="side-nav__link"
+                role="tab"
+                data-name="candidates"
+                tabindex="0"
+                aria-controls="candidates"
+                href="#candidates"
+                aria-selected="false">Candidates</a>
+            </li>
+            <li class="side-nav__item" role="presentation">
+              <a
+                class="side-nav__link"
+                role="tab"
+                data-name="committees"
+                tabindex="0"
+                aria-controls="committees"
+                href="#committees"
+                aria-selected="false">Committees</a>
+            </li>
+            <li class="side-nav__item" role="presentation">
+              <a
+                class="side-nav__link"
+                role="tab"
+                data-name="reports"
+                tabindex="0"
+                aria-controls="reports"
+                href="#reports"
+                aria-selected="false">Reports and filings</a>
+            </li>
+            <li class="side-nav__item" role="presentation">
+              <a
+                class="side-nav__link"
+                role="tab"
+                data-name="other"
+                tabindex="0"
+                aria-controls="other"
+                href="#other"
+                aria-selected="false">Bulk data and other sources</a>
+            </li>
+            <li class="side-nav__item" role="presentation">
+              <a
+                class="side-nav__link"
+                role="tab"
+                data-name="external"
+                tabindex="0"
+                aria-controls="external"
+                href="#external"
+                aria-selected="false">External sources</a>
             </li>
           </ul>
-        </div>
-        <div class="content__section--extra">
-          <div class="icon-heading">
-            <i class="icon-heading__image icon-circle--checklist"><span class="u-visually-hidden">Icon of a checklist</span></i>
-            <div class="icon-heading__content">
-              <h4 class="u-no-margin">More information for:</h4>
-              <div class="grid grid--2-wide">
-                <div class="grid__item">
-                  <a href="{{ cms_url }}/registration-and-reporting/essentials-nonconnected-committees/">Candidates and their committees</a>
-                </div>
-                <div class="grid__item">
-                  <a href="{{ cms_url }}/registration-and-reporting/essentials-nonconnected-committees/">Nonconnected committees</a>
-                </div>
-                <div class="grid__item">
-                  <a href="{{ cms_url }}/registration-and-reporting/essentials-political-party-committees/">Political party committees</a>
-                </div>
-                <div class="grid__item">
-                  <a href="{{ cms_url }}/registration-and-reporting/">Corporations and labor organizations</a>
+        </nav>
+        <div class="main__content--right-full">
+          <section class="row" id="raising" aria-hidden="false" role="tabpanel" >
+            <h2>Raising</h2>
+            <div class="post-feed">
+              <div class="post">
+                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('receipts', is_individual=True) }}">All receipts</a></h3>
+                <p>Receipts are anything of value, like money, services or property. Search candidate and committee receipt data by contributor, amount and date.</p>
+              </div>
+              <div class="post post--child">
+                <h3><a href="{{ url_for('individual_contributions') }}">Individual contributions</a></h3>
+                <p>Search individual contributions to see who is donating to candidates and committees. Search for contributors by name, location, employer and occupation.</p>
+              </div>
+            </div>
+            <div class="content__section--extra">
+              <div class="icon-heading">
+                <i class="icon-heading__image icon-circle--raising"><span class="u-visually-hidden">Icon of a piggy bank</span></i>
+                <div class="icon-heading__content"><a href="/#raising">Raising data overview</a></div>
+              </div>
+            </div>
+          </section>
+          <section class="row" id="spending" aria-hidden="true" role="tabpanel" >
+            <h2>Spending</h2>
+            <p>Spending includes all the types of <span class="term" data-term="disbursement">disbursements</span> candidates and committees make.</p>
+            <div class="post-feed">
+              <div class="post">
+                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('disbursements') }}">All disbursements</a></h3>
+                <p>Search all disbursements from committees by the recipient, purpose, amount and date.</p>
+              </div>
+              <div class="post">
+                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('independent_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Independent expenditures</a></h3>
+                <p>Search <span class="term" data-term="independent expenditure">independent expenditures</span> to find specific spenders, candidates mentioned and transaction information.</p>
+              </div>
+              <div class="post">
+                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('party_coordinated_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Party coordinated expenditures</a></h3>
+              </div>
+              <div class="post">
+                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('electioneering_communications', max_date=today() | date(fmt='%m-%d-%Y')) }}">Electioneering communications</a></h3>
+                <p>Search <span class="term" data-term="electioneering communication">electioneering communications</span> for communications that support or oppose specific candidates. Search by date and amount spent.</p>
+              </div>
+              <div class="post">
+                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('communication_costs', max_date=today() | date(fmt='%m-%d-%Y')) }}">Communication costs</a></h3>
+                <p>Search communication costs for communications that support or oppose specific candidates. Search by date and amount spent.</p>
+              </div>
+            </div>
+            <div class="content__section--extra">
+              <div class="icon-heading">
+                <i class="icon-heading__image icon-circle--spending"><span class="u-visually-hidden">Icon of a spreading dollar sign</span></i>
+                <div class="icon-heading__content"><a href="/#raising">Spending data overview</a></div>
+              </div>
+            </div>
+          </section>
+          <section class="row" id="loans-debts" aria-hidden="true" role="tabpanel">
+            <h2>Loans and debts</h2>
+            <div class="post-feed">
+              <div class="post">
+                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('loans', is_individual=True) }}">Loans</a></h3>
+              </div>
+              <div class="post">
+                <h3 class="is-disabled"><i class="icon i-all-files icon--inline--left"></i>Debts (coming soon)</h3>
+              </div>
+            </div>
+          </section>
+          <section id="candidates" class="row" aria-hidden="true" role="tabpanel">
+            <h2>Candidates</h2>
+            <div class="post-feed">
+              <div class="post">
+                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('candidates', election_year=default_cycles, has_raised_funds='true') }}">All candidates</a></h3>
+              </div>
+              <div class="post post--child">
+                <h4><a href="{{ url_for('candidates_office', office='president') }}">Presidential candidates</a></h4>
+                <p>Search presidential <span class="term" data-term="candidate">candidate</span> data including money raised, money spent, cash on hand and debt.</p>
+              </div>
+              <div class="post post--child">
+                <h4><a href="{{ url_for('candidates_office', office='senate') }}">Senate candidates</a></h4>
+                <p>Search Senate candidate data including money raised, money spent, cash on hand and debt.</p>
+              </div>
+              <div class="post post--child">
+                <h4><a href="{{ url_for('candidates_office', office='house') }}">House of Representatives candidates</a></h4>
+                <p>Search House candidate data including money raised, money spent, cash on hand and debt.</p>
+              </div>
+              <div class="post">
+                <h3><a href="{{ url_for('filings', form_type='F2') }}">Most recent Statements of Candidacy (Form 2)</a></h3>
+                <p>Statements of Candidacy (Form 2) contain basic information about individuals running for federal office, including their names, addresses and authorized campaign committees.</p>
+              </div>
+            </div>
+            <div class="content__section--extra grid grid--3-wide">
+              <div class="icon-heading grid__item">
+                <i class="icon-heading__image icon-circle--checklist"><span class="u-visually-hidden">Icon of a checklist</span></i>
+                <div class="icon-heading__content">
+                  <a href="{{ cms_url }}/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Help for candidates and their committees</a>
                 </div>
               </div>
             </div>
-          </div>
+          </section>
+          <section id="committees" class="row" aria-hidden="true" role="tabpanel">
+            <h2>Committees</h2>
+            <p>The term <span class="term" data-term="political committee">committee</span> encompasses several different political groups that receive and spend money in federal elections.</p>
+            <div class="post-feed">
+              <div class="post">
+                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('committees', election_year=default_cycles) }}">All committees</a></h3>
+                <p>Search for committees by type, years active, political party, location and treasurer.</p>
+              </div>
+              <div class="post">
+                <h3><a href="{{ url_for('filings', form_type='F1') }}">Most recent Statements of Organization (Form 1)</a></h3>
+                <p>Statements of Organization (Form 1) contain basic information about committees, including type, address and treasurer.</p>
+              </div>
+              <div class="post">
+                <h3><a href="{{ url_for('filings', form_type='RFAI') }}">Requests for Additional Information sent to committees</a></h3>
+                <p>Requests for Additional Information (RFAIs) are sent to committees when a Campaign Finance Analyst needs additional clarification on a committee’s filing or identifies an error, omission or possible prohibited activity. Search RFAIs by committee or date.</p>
+              </div>
+            </div>
+            <div class="content__section--extra" data-content-prefix="pacronym">
+              <h3>PACronyms</h3>
+              <p>PACRONYMS, an alphabetical list of acronyms, abbreviations, initials, and common names of federal political action committees (PACs), was prepared to help researchers readily identify committees when their full names are not disclosed on campaign finance reports.</p>
+              <p>The list includes the PACRONYM, FEC ID number, full committee name, city and state, name of sponsoring, connected, or affiliated organization, committee designation and committee type.  Unless noted otherwise in the full committee name, the acronym “PAC” refers to “Political Action Committee.”  The PACRONYM is listed in ITALICS if the committee's PACRONYM is not specifically provided on the committee's Statement of Organization (FEC Form 1).</p>
+              <ul class="list--buttons">
+                <li>
+                  <a class="button button--standard button--document" href="http://www.fec.gov/pubrec/pacronyms/Pacronyms.pdf">Open PDF</a>
+                </li>
+                <li>
+                  <a class="button button--standard button--download" href="http://www.fec.gov/pubrec/pacronyms/Pacronyms.xlsx">Download for Excel</a>
+                </li>
+              </ul>
+            </div>
+            <div class="content__section--extra">
+              <div class="icon-heading">
+                <i class="icon-heading__image icon-circle--checklist"><span class="u-visually-hidden">Icon of a checklist</span></i>
+                <div class="icon-heading__content">
+                  <h4 class="u-no-margin">More information for:</h4>
+                  <div class="grid grid--2-wide">
+                    <div class="grid__item">
+                      <a href="{{ cms_url }}/registration-and-reporting/essentials-nonconnected-committees/">Candidates and their committees</a>
+                    </div>
+                    <div class="grid__item">
+                      <a href="{{ cms_url }}/registration-and-reporting/essentials-nonconnected-committees/">Nonconnected committees</a>
+                    </div>
+                    <div class="grid__item">
+                      <a href="{{ cms_url }}/registration-and-reporting/essentials-political-party-committees/">Political party committees</a>
+                    </div>
+                    <div class="grid__item">
+                      <a href="{{ cms_url }}/registration-and-reporting/">Corporations and labor organizations</a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section class="row" id="reports" aria-hidden="true" role="tabpanel">
+            <h2>Filings</h2>
+            <p>Filings contain all the statements, reports and notices that candidates and committees file. Search by date, type and filing candidate or committee.</p>
+            <div class="post-feed">
+              <div class="post">
+                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('filings') }}">All filings</span></h3>
+              </div>
+              <div class="post post--child">
+                <h3><a href="{{ url_for('reports', form_type='presidential', is_amended='false') }}">Presidential committee reports</a></h3>
+              </div>
+              <div class="post post--child">
+                <h3><a href="{{ url_for('reports', form_type='house-senate', is_amended='false') }}">House and Senate committee reports</a></h3>
+              </div>
+              <div class="post post--child">
+                <h3><a href="{{ url_for('reports', form_type='pac-party', is_amended='false') }}">PAC and party committee reports</a></h3>
+              </div>
+              <!-- Commenting out while page is in progress -->
+              <!--<li><a href="{{ url_for('reports', form_type='ie-only', is_amended='false') }}">Independent expenditure (Form 5) filer reports</a></li>-->
+            </div>
+          </section>
+          <section id="other" class="row" aria-hidden="true" role="tabpanel">
+            <h2>Bulk data and other sources</h2>
+            <div class="content__section">
+              <h3><a href="{{ transition_url }}/press/campaign_finance_statistics.shtml">Historical statistics</a></h3>
+              <p>Data tables that summarize campaign financial activity by filer type, election cycle and reporting period.</p>
+            </div>
+            <div class="content__section">
+              <h3>Bulk data downloads</h3>
+              <p>The FEC prepares some data sets to be downloadable as a complete set.</p>
+              <div class="post-feed">
+                <div class="post">
+                  <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftpdet.shtml">Detailed data files</a></h4>
+                  <p>Here you will find the Committees, Candidates and Linkages, Itemized Records, Contributions to Candidates, Individual Contributions and Operating Expenditures files.</p>
+                  <p>These files contain committee, candidate and campaign finance data for the current election cycle and for election cycles through 1980. The files for the current election cycle plus the two most recent election cycles are regularly updated. The Committees, Candidates and Linkages files are updated daily. The Itemized Records, Contributions to Candidates, Individual Contributions and Operating Expenditures files are udated weekly on Sunday. Please note that complete entry from each reporting period takes about 30 days. It is important to be careful when making conclusions from these data because some information may not have completed the entry process when these files where create. Committees do not have the same filing requirements. You should be careful when comparing financial information about committees with different filing requirements.</p>
+                </div>
+                <div class="post">
+                  <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftpsum.shtml">Summary data files</a></h4>
+                  <p>Here you will find the current campaign summary file, the all candidates summary file and the current PAC summary file. The most recent 10 years of data, the current two-year election period plus the most recent five (5) two-year election periods, are updated daily.</p>
+                </div>
+                <div class="post">
+                  <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftpefile.shtml">Electronically filed reports</a></h4>
+                  <p>You will find here a daily compilation of electronically filed reports and statements. These are available from Feburary 2001 to present. Filing formats, valid dates for these formats and header files for version 1 through the most recent version are available.</p>
+                </div>
+                <div class="post">
+                  <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftppaper.shtml">Paper filed reports</a></h4>
+                  <p>The summary financial information and transactions disclosed in paper reports are data entered into an electronic format, and then stored in a downloadable file similar to electronically filed reports, known as a .fec file. Paper filings are data entered in a batch process; therefore, the Commission does not receive converted paper filings every day from our contractor. On days the Commission does not receive converted paper filings, an empty file (YYYYMMDD.nofiles.zip) will be placed on the FTP server. On days the Commission receives converted paper filings, a file (YYYYMMDD.zip) will contain that day's .fec files.</p>
+                  <p>Forms 3, 3L, 3X, 5, 6, 7 and 24-hour and 48-hour independent expenditures reports are converted to .fec files. The Commission began this paper to electronic conversion process in October 2005. The first data file was uploaded to the Commission on December 8, 2005.</p>
+                </div>
+              </div>
+            </div>
+            <div class="content__section">
+              <h3>Other FEC data sources</h3>
+              <div class="post-feed">
+                <div class="post">
+                  <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/data/DataCatalog.do">Legacy data catalog</a></h4>
+                  <p>Each of the files listed here can be downloaded in either csv or xml formats. Each also has a metadata page that describes the information included and the structure of the file itself. There is a pdf version of each file if you need to print the information. You can also subscribe to RSS feeds for each of the files so you're notified whenever new data is available or a change is made.</p>
+                  <p><a href="{{ transition_url }}/disclosurep/pnational.do">Presidential election map</a> | <a href="{{ transition_url }}/disclosurehs/hsnational.do">House and Senate elections data map</a>
+                </div>
+                <div class="post">
+                  <h4>Presidential campaign matching fund submissions</h4>
+                  <p>
+                    <a href="{{ transition_url }}/finance/disclosure/2016MatchingFundSubmissions.shtml">2016</a> |
+                    <a href="{{ transition_url }}/finance/2012matching/2012matching.shtml">2012</a> |
+                    <a href="{{ transition_url }}/finance/2008matching/2008matching.shtml">2008</a> |
+                    <a href="{{ transition_url }}/finance/disclosure/2004MatchingFundSubmissions.shtml">2004</a> |
+                    <a href="{{ transition_url }}/finance/disclosure/submiss.shtml">2000</a>
+                  </p>
+                  <p>You will find here the threshold files for presidential candidates seeking matching funds.</p>
+                  <p>In addition to regular quarterly or monthly disclosure reports, presidential candidates who seek matching funds must submit information about "matchable" contributions to the FEC for review. Contributions from individuals where the aggregate amount contributed by the individual is $250 or less are eligible to be matched on a dollar for dollar basis from the Presidential Election Campaign Fund. This Fund includes proceeds from the voluntary check-off of $3 per person from income tax returns of eligible taxpayers.</p>
+                </div>
+                <div class="post">
+                  <h4><i class="icon i-magnifying-glass icon--inline--left"></i><a href="http://docquery.fec.gov/senate/">Senate unofficial electronic filings</a></h4>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section id="external" class="row" aria-hidden="true" role="tabpanel">
+            <h2>External sources</h2>
+            <p>Certain information is reported to the FEC, but more information is reported to other governmental agencies.</p>
+            <div class="post-feed">
+              <div class="post">
+                <h3><i class="icon i-share icon--inline--left"></i><a href="https://www.irs.gov/charities-non-profits/political-organizations/political-organization-filing-and-disclosure">Internal Revenue Service (IRS) filings</h3>
+                <p>Search and download filings and disclosures by political organizations</p>
+              </div>
+              <div class="post">
+                <h3><i class="icon i-share icon--inline--left"></i><a href="http://apps.fcc.gov/ecd/">Federal Communications Commission (FCC) electioneering communications database</a></h3>
+                <p>Search electioneering communications.</p>
+              </div>
+              <div class="post">
+                <h3><i class="icon i-share icon--inline--left"></i><a href="https://www.oge.gov/web/oge.nsf/Presidential%20Candidates?OpenView">Office of Government Ethics (OGE) presidential candidate financial disclosure reports</a></h3>
+                <p>View financial disclosure reports filed by presidential candidates.</p>
+              </div>
+            </div>
+          </section>
         </div>
-      </section>
-      <section class="row" id="reports" aria-hidden="true" role="tabpanel">
-        <h2>Filings</h2>
-        <p>Filings contain all the statements, reports and notices that candidates and committees file. Search by date, type and filing candidate or committee.</p>
-        <div class="post-feed">
-          <div class="post">
-            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('filings') }}">All filings</span></h3>
-          </div>
-          <div class="post post--child">
-            <h3><a href="{{ url_for('reports', form_type='presidential', is_amended='false') }}">Presidential committee reports</a></h3>
-          </div>
-          <div class="post post--child">
-            <h3><a href="{{ url_for('reports', form_type='house-senate', is_amended='false') }}">House and Senate committee reports</a></h3>
-          </div>
-          <div class="post post--child">
-            <h3><a href="{{ url_for('reports', form_type='pac-party', is_amended='false') }}">PAC and party committee reports</a></h3>
-          </div>
-          <!-- Commenting out while page is in progress -->
-          <!--<li><a href="{{ url_for('reports', form_type='ie-only', is_amended='false') }}">Independent expenditure (Form 5) filer reports</a></li>-->
-        </div>
-      </section>
-      <section id="other" class="row" aria-hidden="true" role="tabpanel">
-        <h2>Bulk data and other sources</h2>
-        <div class="content__section">
-          <h3><a href="{{ transition_url }}/press/campaign_finance_statistics.shtml">Historical statistics</a></h3>
-          <p>Data tables that summarize campaign financial activity by filer type, election cycle and reporting period.</p>
-        </div>
-        <div class="content__section">
-          <h3>Bulk data downloads</h3>
-          <p>The FEC prepares some data sets to be downloadable as a complete set.</p>
-          <div class="post-feed">
-            <div class="post">
-              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftpdet.shtml">Detailed data files</a></h4>
-              <p>Here you will find the Committees, Candidates and Linkages, Itemized Records, Contributions to Candidates, Individual Contributions and Operating Expenditures files.</p>
-              <p>These files contain committee, candidate and campaign finance data for the current election cycle and for election cycles through 1980. The files for the current election cycle plus the two most recent election cycles are regularly updated. The Committees, Candidates and Linkages files are updated daily. The Itemized Records, Contributions to Candidates, Individual Contributions and Operating Expenditures files are udated weekly on Sunday. Please note that complete entry from each reporting period takes about 30 days. It is important to be careful when making conclusions from these data because some information may not have completed the entry process when these files where create. Committees do not have the same filing requirements. You should be careful when comparing financial information about committees with different filing requirements.</p>
-            </div>
-            <div class="post">
-              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftpsum.shtml">Summary data files</a></h4>
-              <p>Here you will find the current campaign summary file, the all candidates summary file and the current PAC summary file. The most recent 10 years of data, the current two-year election period plus the most recent five (5) two-year election periods, are updated daily.</p>
-            </div>
-            <div class="post">
-              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftpefile.shtml">Electronically filed reports</a></h4>
-              <p>You will find here a daily compilation of electronically filed reports and statements. These are available from Feburary 2001 to present. Filing formats, valid dates for these formats and header files for version 1 through the most recent version are available.</p>
-            </div>
-            <div class="post">
-              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftppaper.shtml">Paper filed reports</a></h4>
-              <p>The summary financial information and transactions disclosed in paper reports are data entered into an electronic format, and then stored in a downloadable file similar to electronically filed reports, known as a .fec file. Paper filings are data entered in a batch process; therefore, the Commission does not receive converted paper filings every day from our contractor. On days the Commission does not receive converted paper filings, an empty file (YYYYMMDD.nofiles.zip) will be placed on the FTP server. On days the Commission receives converted paper filings, a file (YYYYMMDD.zip) will contain that day's .fec files.</p>
-              <p>Forms 3, 3L, 3X, 5, 6, 7 and 24-hour and 48-hour independent expenditures reports are converted to .fec files. The Commission began this paper to electronic conversion process in October 2005. The first data file was uploaded to the Commission on December 8, 2005.</p>
-            </div>
-          </div>
-        </div>
-        <div class="content__section">
-          <h3>Other FEC data sources</h3>
-          <div class="post-feed">
-            <div class="post">
-              <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/data/DataCatalog.do">Legacy data catalog</a></h4>
-              <p>Each of the files listed here can be downloaded in either csv or xml formats. Each also has a metadata page that describes the information included and the structure of the file itself. There is a pdf version of each file if you need to print the information. You can also subscribe to RSS feeds for each of the files so you're notified whenever new data is available or a change is made.</p>
-              <p><a href="{{ transition_url }}/disclosurep/pnational.do">Presidential election map</a> | <a href="{{ transition_url }}/disclosurehs/hsnational.do">House and Senate elections data map</a>
-            </div>
-            <div class="post">
-              <h4>Presidential campaign matching fund submissions</h4>
-              <p>
-                <a href="{{ transition_url }}/finance/disclosure/2016MatchingFundSubmissions.shtml">2016</a> |
-                <a href="{{ transition_url }}/finance/2012matching/2012matching.shtml">2012</a> |
-                <a href="{{ transition_url }}/finance/2008matching/2008matching.shtml">2008</a> |
-                <a href="{{ transition_url }}/finance/disclosure/2004MatchingFundSubmissions.shtml">2004</a> |
-                <a href="{{ transition_url }}/finance/disclosure/submiss.shtml">2000</a>
-              </p>
-              <p>You will find here the threshold files for presidential candidates seeking matching funds.</p>
-              <p>In addition to regular quarterly or monthly disclosure reports, presidential candidates who seek matching funds must submit information about "matchable" contributions to the FEC for review. Contributions from individuals where the aggregate amount contributed by the individual is $250 or less are eligible to be matched on a dollar for dollar basis from the Presidential Election Campaign Fund. This Fund includes proceeds from the voluntary check-off of $3 per person from income tax returns of eligible taxpayers.</p>
-            </div>
-            <div class="post">
-              <h4><i class="icon i-magnifying-glass icon--inline--left"></i><a href="http://docquery.fec.gov/senate/">Senate unofficial electronic filings</a></h4>
-            </div>
-          </div>
-        </div>
-      </section>
-      <section id="external" class="row" aria-hidden="true" role="tabpanel">
-        <h2>External sources</h2>
-        <p>Certain information is reported to the FEC, but more information is reported to other governmental agencies.</p>
-        <div class="post-feed">
-          <div class="post">
-            <h3><i class="icon i-share icon--inline--left"></i><a href="https://www.irs.gov/charities-non-profits/political-organizations/political-organization-filing-and-disclosure">Internal Revenue Service (IRS) filings</h3>
-            <p>Search and download filings and disclosures by political organizations</p>
-          </div>
-          <div class="post">
-            <h3><i class="icon i-share icon--inline--left"></i><a href="http://apps.fcc.gov/ecd/">Federal Communications Commission (FCC) electioneering communications database</a></h3>
-            <p>Search electioneering communications.</p>
-          </div>
-          <div class="post">
-            <h3><i class="icon i-share icon--inline--left"></i><a href="https://www.oge.gov/web/oge.nsf/Presidential%20Candidates?OpenView">Office of Government Ethics (OGE) presidential candidate financial disclosure reports</a></h3>
-            <p>View financial disclosure reports filed by presidential candidates.</p>
-          </div>
-        </div>
-      </section>
+      </div>
     </div>
-  </div>
-</div>
 
-<div class="slab slab--neutral">
-  <div class="container">
-    <h2>More ways to explore data</h2>
-    <div class="grid grid--4-wide">
-      <div class="grid__item">
-        <a href="{{ url_for('election_lookup') }}">
-          <aside class="card card--horizontal card--primary">
-            <div class="card__image__container">
-              <span class="card__icon i-elections"><span class="u-visually-hidden">Icon representing elections</span></span>
-            </div>
-            <div class="card__content">
-              Find elections by location
-            </div>
-          </aside>
-        </a>
-      </div>
-      <div class="grid__item">
-        <a href="{{ url_for('search') }}">
-          <aside class="card card--horizontal card--primary">
-            <div class="card__image__container">
-              <span class="card__icon i-profile"><span class="u-visually-hidden">Icon representing profiles</span></span>
-            </div>
-            <div class="card__content">
-                Search candidate or committee profiles
-            </div>
-          </aside>
-        </a>
-      </div>
-      <div class="grid__item">
-        <a href="https://api.open.fec.gov">
-          <aside class="card card--horizontal card--primary">
-            <div class="card__image__container">
-              <span class="card__icon i-data-flag"><span class="u-visually-hidden">Icon of an American flag</span></span>
-            </div>
-            <div class="card__content">
-                Use the OpenFEC API
-            </div>
-          </aside>
-        </a>
+    <div class="slab slab--neutral">
+      <div class="container">
+        <h2>More ways to explore data</h2>
+        <div class="grid grid--4-wide">
+          <div class="grid__item">
+            <a href="{{ url_for('election_lookup') }}">
+              <aside class="card card--horizontal card--primary">
+                <div class="card__image__container">
+                  <span class="card__icon i-elections"><span class="u-visually-hidden">Icon representing elections</span></span>
+                </div>
+                <div class="card__content">
+                  Find elections by location
+                </div>
+              </aside>
+            </a>
+          </div>
+          <div class="grid__item">
+            <a href="{{ url_for('search') }}">
+              <aside class="card card--horizontal card--primary">
+                <div class="card__image__container">
+                  <span class="card__icon i-profile"><span class="u-visually-hidden">Icon representing profiles</span></span>
+                </div>
+                <div class="card__content">
+                    Search candidate or committee profiles
+                </div>
+              </aside>
+            </a>
+          </div>
+          <div class="grid__item">
+            <a href="https://api.open.fec.gov">
+              <aside class="card card--horizontal card--primary">
+                <div class="card__image__container">
+                  <span class="card__icon i-data-flag"><span class="u-visually-hidden">Icon of an American flag</span></span>
+                </div>
+                <div class="card__content">
+                    Use the OpenFEC API
+                </div>
+              </aside>
+            </a>
+          </div>
+        </div>
       </div>
     </div>
   </div>
-</div>
-</div>
-<div class="slab slab--neutral footer-disclaimer">
-  <div class="container">
-    <div class="usa-width-one-half">
-      <p class="t-sans u-no-margin">Reports and statements filed by political committees may be inspected and copied by anyone. The names and addresses of individual contributors, however, may not be sold or used for any commercial purpose or to solicit any time of contribution or donation.</p>
-    </div>
-    <div class="usa-width-one-half">
-      <p class="t-sans u-no-margin"><a href="{{ transition_url }}/pages/brochures/saleuse.shtml">Read more about the sale and use of this data</a>.</p>
+  <div class="slab slab--neutral footer-disclaimer">
+    <div class="container">
+      <div class="usa-width-one-half">
+        <p class="t-sans u-no-margin">Reports and statements filed by political committees may be inspected and copied by anyone. The names and addresses of individual contributors, however, may not be sold or used for any commercial purpose or to solicit any time of contribution or donation.</p>
+      </div>
+      <div class="usa-width-one-half">
+        <p class="t-sans u-no-margin"><a href="{{ transition_url }}/pages/brochures/saleuse.shtml">Read more about the sale and use of this data</a>.</p>
+      </div>
     </div>
   </div>
-</div>
 {% endblock %}
 
 {% block scripts %}

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -7,76 +7,132 @@
 
 {% block body %}
   {{ header.header(title, '', show_search=False) }}
-  <div class="main">
-  <div class="container">
-    <header class="heading--main">
-      <h1>{{ title }}</h1>
-    </header>
-  </div>
-  <div id="options" class="container">
-    <div class="sidebar-container sidebar-container--left">
-      <nav class="sidebar sidebar--neutral sidebar--left side-nav js-sticky-side js-toc" data-sticky-container="options">
-        <ul class="sidebar__content">
-          <li class="side-nav__item"><a class="side-nav__link" href="#candidates">Candidates</a></li>
-          <li class="side-nav__item"><a class="side-nav__link" href="#committees">Committees</a></li>
-          <li class="side-nav__item"><a class="side-nav__link" href="#receipts">Receipts</a></li>
-          <li class="side-nav__item"><a class="side-nav__link" href="#spending">Spending</a></li>
-          <li class="side-nav__item"><a class="side-nav__link" href="#filings">Reports and filings</a></li>
-        </ul>
-      </nav>
-    </div>
-    <section class="main__content--right">
-      <div id="candidates" class="option">
+<div class="u-padding--left u-padding--right tab-interface">
+<div class="main">
+  <header class="heading--main">
+    <h1>{{ title }}</h1>
+  </header>
+  <div class="data-container__wrapper">
+    <nav class="sidebar side-nav-alt">
+      <ul class="tablist" role="tablist" data-name="tab">
+        <li class="side-nav__item" role="presentation">
+          <a
+            class="side-nav__link"
+            role="tab"
+            data-name="raising"
+            tabindex="0"
+            aria-controls="raising"
+            href="#raising"
+            aria-selected="true">Raising</a>
+        </li>
+        <li class="side-nav__item" role="presentation">
+          <a
+            class="side-nav__link"
+            role="tab"
+            data-name="spending"
+            tabindex="0"
+            aria-controls="spending"
+            href="#spending"
+            aria-selected="false">Spending</a>
+        </li>
+        <li class="side-nav__item" role="presentation">
+          <a
+            class="side-nav__link"
+            role="tab"
+            data-name="candidates"
+            tabindex="0"
+            aria-controls="candidates"
+            href="#candidates"
+            aria-selected="false">Candidates</a>
+        </li>
+        <li class="side-nav__item" role="presentation">
+          <a
+            class="side-nav__link"
+            role="tab"
+            data-name="committees"
+            tabindex="0"
+            aria-controls="committees"
+            href="#committees"
+            aria-selected="false">Committees</a>
+        </li>
+        <li class="side-nav__item" role="presentation">
+          <a
+            class="side-nav__link"
+            role="tab"
+            data-name="reports"
+            tabindex="0"
+            aria-controls="reports"
+            href="#reports"
+            aria-selected="false">Reports and filings</a>
+        </li>
+      </ul>
+    </nav>
+    <div class="main__content--right-full">
+      <section class="row" id="raising" aria-hidden="false" role="tabpanel" >
+        <h2>Receipts</h2>
+        <div class="option__content">
+          <p><span class="term" data-term="receipt">Receipts</span> are anything of value, like money, services or property. Search candidate and committee receipt data by contributor, amount and date.</p>
+          <p>Search individual contributions to see who is donating to candidates and committees. Search for contributors by name, location, employer and occupation.</p>
+          <div class="post-feed">
+            <a class="post t-block" href="{{ url_for('receipts', is_individual=True) }}"><span class="t-all-data">All receipts</span></a>
+            <a class="post t-block" href="{{ url_for('individual_contributions') }}">Individual contributions</a>
+          </div>
+        </div>
+        <div class="option__aside">
+          <i class="icon-circle--raising"><span class="u-visually-hidden">Icon of a piggy bank</span></i>
+            <a href="/#raising">Raising data overview</a>
+        </div>
+      </section>
+      <section class="row" id="spending" aria-hidden="true" role="tabpanel" >
+        <h2>Spending</h2>
+        <div class="option__content">
+          <p>Spending includes all the types of <span class="term" data-term="disbursement">dibsursements</span> candidates and committees make.</p>
+          <p>Search all disbursements from committees by the recipient, purpose, amount and date.</p>
+          <p>Search <span class="term" data-term="independent expenditure">independent expenditures</span> to find specific spenders, candidates mentioned and transaction information.</p>
+          <p>Search communication costs and <span class="term" data-term="electioneering communication">electioneering communications</span> for communications that support or oppose specific candidates. Search by date and amount spent.</p>
+          <div class="post-feed">
+            <a class="post t-block" href="{{ url_for('disbursements') }}"><span class="t-all-data">All disbursements</span></a>
+            <a class="post t-block" href="{{ url_for('party_coordinated_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Party coordinated expenditures</a>
+            <a class="post t-block" href="{{ url_for('independent_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Independent expenditures</a>
+            <a class="post t-block" href="{{ url_for('electioneering_communications', max_date=today() | date(fmt='%m-%d-%Y')) }}">Electioneering communications</a>
+            <a class="post t-block" href="{{ url_for('communication_costs', max_date=today() | date(fmt='%m-%d-%Y')) }}">Communication costs</a>
+          </div>
+        </div>
+        <div class="option__aside">
+          <i class="icon-circle--spending"><span class="u-visually-hidden">Icon of a spreading dollar sign</span></i>
+            <a href="/#spending">Spending data overview</a>
+        </div>
+      </section>
+      <section id="candidates" class="row" aria-hidden="true" role="tabpanel" >
         <h2>Candidates</h2>
         <div class="option__content">
           <p>Search <span class="term" data-term="candidate">candidate</span> data, including money raised, money spent, cash on hand and debt.</p>
           <p>Statements of Candidacy (Form 2) contain basic information about individuals running
           for federal office, including their names, addresses and authorized campaign committees.</p>
-          <div class="grid--2-wide">
-          <ul class="grid__item list--spacious t-sans">
-            <li><a class="t-all-data" href="{{ url_for('candidates', election_year=default_cycles, has_raised_funds='true') }}">All candidates</a>
-              <ul>
-                <li><a href="{{ url_for('candidates_office', office='president') }}">Presidential candidates</a></li>
-                <li><a href="{{ url_for('candidates_office', office='senate') }}">Senate candidates</a></li>
-                <li><a href="{{ url_for('candidates_office', office='house') }}">House of Representatives candidates</a></li>
-              </ul>
-            </li>
-          </ul>
-          <ul class="grid__item list--spacious t-sans">
-            <li><a href="{{ url_for('filings', form_type='F2') }}">Most recent Statements of Candidacy (Form 2)</a></li>
-          </ul>
+          <div class="post-feed">
+            <a class="post t-block" href="{{ url_for('candidates', election_year=default_cycles, has_raised_funds='true') }}"><span class="t-all-data">All candidates</span></a>
+            <a class="post t-block" href="{{ url_for('candidates_office', office='president') }}">Presidential candidates</a>
+            <a class="post t-block" href="{{ url_for('candidates_office', office='senate') }}">Senate candidates</a>
+            <a class="post t-block" href="{{ url_for('candidates_office', office='house') }}">House of Representatives candidates</a>
+            <a class="post t-block" href="{{ url_for('filings', form_type='F2') }}">Most recent Statements of Candidacy (Form 2)</a>
           </div>
         </div>
         <div class="option__aside">
           <i class="icon-circle--checklist card--stacked"><span class="u-visually-hidden">Icon of a checklist</span></i>
-            <a href="{{ cms_url }}/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Candidate registration and reporting requirements</a>
+          <a href="{{ cms_url }}/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Candidate registration and reporting requirements</a>
         </div>
-      </div>
-      <div id="committees" class="option">
+      </section>
+      <section id="committees" class="row" aria-hidden="true" role="tabpanel" >
         <h2>Committees</h2>
         <div class="option__content">
           <p>The term <span class="term" data-term="political committee">committee</span> encompasses several different political groups that receive and spend money in federal elections.
           Search for committees by type, years active, political party, location and treasurer.</p>
           <p>Statements of Organization (Form 1) contain basic information about committees, including type, address and treasurer.</p>
           <p>Requests for Additional Information (RFAIs) are sent to committees when a Campaign Finance Analyst needs additional clarification on a committee’s filing or identifies an error, omission or possible prohibited activity. Search RFAIs by committee or date.</p>
-          <div class="grid--2-wide">
-            <ul class="grid__item list--spacious t-sans">
-              <li><a class="t-all-data" href="{{ url_for('committees', election_year=default_cycles) }}">All committees</a>
-                <ul>
-                  <li><a href="#" class="is-disabled">Candidate committees</a></li>
-                  <li><a href="#" class="is-disabled">Political action committees (PACs)</a></li>
-                  <li><a href="#" class="is-disabled">Super PACs</a></li>
-                  <li><a href="#" class="is-disabled">Leadership PACs</a></li>
-                  <li><a href="#" class="is-disabled">Joint fundraising committees</a></li>
-                  <li><a href="#" class="is-disabled">Party committees</a></li>
-                  <li><a href="#" class="is-disabled">Separate segregated funds (SSFs)</a></li>
-                </ul>
-              </li>
-            </ul>
-            <ul class="grid__item list--spacious t-sans">
-              <li><a href="{{ url_for('filings', form_type='F1') }}">Most recent Statements of Organization (Form 1)</a></li>
-              <li><a href="{{ url_for('filings', form_type='RFAI') }}">Requests for Additional Information sent to committees</a></li>
-            </ul>
+          <div class="post-feed">
+            <a class="post t-block" href="{{ url_for('committees', election_year=default_cycles) }}"><span class="t-all-data">All committees</span></a>
+            <a class="post t-block" href="{{ url_for('filings', form_type='F1') }}">Most recent Statements of Organization (Form 1)</a>
+            <a class="post t-block" href="{{ url_for('filings', form_type='RFAI') }}">Requests for Additional Information sent to committees</a>
           </div>
         </div>
         <div class="option__aside">
@@ -85,76 +141,22 @@
             <a href="{{ cms_url }}/registration-and-reporting/essentials-political-party-committees/">Political party committee registration and reporting requirements</a><br><br>
             <a href="{{ cms_url }}/registration-and-reporting/">Registration and reporting requirements for other committees</a>
         </div>
-      </div>
-      <div id="receipts" class="option">
-        <h2>Receipts</h2>
-        <div class="option__content">
-          <p><span class="term" data-term="receipt">Receipts</span> are anything of value, like money, services or property. Search candidate and committee receipt data by contributor, amount and date.</p>
-          <p>Search individual contributions to see who is donating to candidates and committees. Search for contributors by name, location, employer and occupation.</p>
-          <div class="grid--2-wide">
-          <ul class="grid__item list--spacious t-sans">
-            <li><a class="t-all-data" href="{{ url_for('receipts', is_individual=True) }}">All receipts</a>
-              <ul>
-                <li><a href="{{ url_for('individual_contributions') }}">Individual contributions</a></li>
-                <li><a href="#" class="is-disabled">Contributions from other committees</a></li>
-              </ul>
-            </li>
-          </ul>
-          </div>
-        </div>
-        <div class="option__aside">
-          <i class="icon-circle--raising"><span class="u-visually-hidden">Icon of a piggy bank</span></i>
-            <a href="/#raising">Raising data overview</a>
-        </div>
-      </div>
-      <div id="spending" class="option">
-        <h2>Spending</h2>
-        <div class="option__content">
-          <p>Spending includes all the types of <span class="term" data-term="disbursement">dibsursements</span> candidates and committees make.</p>
-          <p>Search all disbursements from committees by the recipient, purpose, amount and date.</p>
-          <p>Search <span class="term" data-term="independent expenditure">independent expenditures</span> to find specific spenders, candidates mentioned and transaction information.</p>
-          <p>Search communication costs and <span class="term" data-term="electioneering communication">electioneering communications</span> for communications that support or oppose specific candidates. Search by date and amount spent.</p>
-          <div class="grid--2-wide">
-            <ul class="grid__item list--spacious t-sans">
-              <li><a class="t-all-data" href="{{ url_for('disbursements') }}">All disbursements</a>
-                <ul>
-                  <li><a href="#" class="is-disabled">Operating expenditures</a></li>
-                  <li><a href="#" class="is-disabled">Expenditures to committees</a></li>
-                </ul>
-              </li>
-            </ul>
-            <ul class="grid__item list--spacious t-sans">
-              <li><a href="{{ url_for('party_coordinated_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Party coordinated expenditures</a></li>
-              <li><a href="{{ url_for('independent_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Independent expenditures</a></li>
-              <li><a href="{{ url_for('electioneering_communications', max_date=today() | date(fmt='%m-%d-%Y')) }}">Electioneering communications</a></li>
-              <li><a href="{{ url_for('communication_costs', max_date=today() | date(fmt='%m-%d-%Y')) }}">Communication costs</a></li>
-            </ul>
-          </div>
-        </div>
-        <div class="option__aside">
-          <i class="icon-circle--spending"><span class="u-visually-hidden">Icon of a spreading dollar sign</span></i>
-            <a href="/#spending">Spending data overview</a>
-        </div>
-      </div>
-      <div id="filings" class="option">
+      </section>
+      <section class="row" id="reports" aria-hidden="true" role="tabpanel" >
         <h2>Filings</h2>
         <div class="option__content">
           <p>Filings contain all the statements, reports and notices that candidates and committees file. Search by date, type and filing candidate or committee.</p>
-          <div class="grid--2-wide">
-            <ul class="grid__item list--spacious t-sans">
-              <li><a href="{{ url_for('reports', form_type='presidential', is_amended='false') }}">Presidential committee reports</a></li>
-              <li><a href="{{ url_for('reports', form_type='house-senate', is_amended='false') }}">House and Senate committee reports</a></li>
-              <li><a href="{{ url_for('reports', form_type='pac-party', is_amended='false') }}">PAC and party committee reports</a></li>
-              <!-- Commenting out while page is in progress -->
-              <!--<li><a href="{{ url_for('reports', form_type='ie-only', is_amended='false') }}">Independent expenditure (Form 5) filer reports</a></li>-->
-            </ul>
-            <ul class="grid__item list--spacious t-sans">
-              <li><a class="t-all-data" href="{{ url_for('filings') }}">All filings</a></li>
-            </ul>
+          <div class="post-feed">
+            <a class="post t-block" href="{{ url_for('reports', form_type='presidential', is_amended='false') }}">Presidential committee reports</a>
+            <a class="post t-block" href="{{ url_for('reports', form_type='house-senate', is_amended='false') }}">House and Senate committee reports</a>
+            <a class="post t-block" href="{{ url_for('reports', form_type='pac-party', is_amended='false') }}">PAC and party committee reports</a>
+            <!-- Commenting out while page is in progress -->
+            <!--<li><a href="{{ url_for('reports', form_type='ie-only', is_amended='false') }}">Independent expenditure (Form 5) filer reports</a></li>-->
+            <a class="post t-block" href="{{ url_for('filings') }}"><span class="t-all-data">All filings</span></a>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+    </div>
   </div>
 </div>
 
@@ -189,7 +191,7 @@
     </div>
   </div>
 </div>
-
+</div>
 {% endblock %}
 
 {% block scripts %}

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -7,8 +7,8 @@
 
 {% block body %}
   {{ header.header(title, '', show_search=False) }}
-<div class="u-padding--left u-padding--right tab-interface">
-<div class="main">
+<div class="tab-interface">
+<div class="main container">
   <header class="heading--main">
     <h1>{{ title }}</h1>
   </header>
@@ -34,6 +34,16 @@
             aria-controls="spending"
             href="#spending"
             aria-selected="false">Spending</a>
+        </li>
+        <li class="side-nav__item" role="presentation">
+          <a
+            class="side-nav__link"
+            role="tab"
+            data-name="debts-loans"
+            tabindex="0"
+            aria-controls="debts-loans"
+            href="#debts-loans"
+            aria-selected="false">Debts and loans</a>
         </li>
         <li class="side-nav__item" role="presentation">
           <a
@@ -69,13 +79,15 @@
     </nav>
     <div class="main__content--right-full">
       <section class="row" id="raising" aria-hidden="false" role="tabpanel" >
-        <h2>Receipts</h2>
-        <div class="option__content">
-          <p><span class="term" data-term="receipt">Receipts</span> are anything of value, like money, services or property. Search candidate and committee receipt data by contributor, amount and date.</p>
-          <p>Search individual contributions to see who is donating to candidates and committees. Search for contributors by name, location, employer and occupation.</p>
-          <div class="post-feed">
-            <a class="post t-block" href="{{ url_for('receipts', is_individual=True) }}"><span class="t-all-data">All receipts</span></a>
-            <a class="post t-block" href="{{ url_for('individual_contributions') }}">Individual contributions</a>
+        <h2>Raising</h2>
+        <div class="post-feed">
+          <div class="post">
+            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('receipts', is_individual=True) }}">All receipts</a></h3>
+            <p><span class="term" data-term="receipt">Receipts</span> are anything of value, like money, services or property. Search candidate and committee receipt data by contributor, amount and date.</p>
+          </div>
+          <div class="post u-padding--left">
+            <h3><a href="{{ url_for('individual_contributions') }}">Individual contributions</a></h3>
+            <p>Search individual contributions to see who is donating to candidates and committees. Search for contributors by name, location, employer and occupation.</p>
           </div>
         </div>
         <div class="option__aside">
@@ -85,17 +97,26 @@
       </section>
       <section class="row" id="spending" aria-hidden="true" role="tabpanel" >
         <h2>Spending</h2>
-        <div class="option__content">
-          <p>Spending includes all the types of <span class="term" data-term="disbursement">dibsursements</span> candidates and committees make.</p>
-          <p>Search all disbursements from committees by the recipient, purpose, amount and date.</p>
-          <p>Search <span class="term" data-term="independent expenditure">independent expenditures</span> to find specific spenders, candidates mentioned and transaction information.</p>
-          <p>Search communication costs and <span class="term" data-term="electioneering communication">electioneering communications</span> for communications that support or oppose specific candidates. Search by date and amount spent.</p>
-          <div class="post-feed">
-            <a class="post t-block" href="{{ url_for('disbursements') }}"><span class="t-all-data">All disbursements</span></a>
-            <a class="post t-block" href="{{ url_for('party_coordinated_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Party coordinated expenditures</a>
-            <a class="post t-block" href="{{ url_for('independent_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Independent expenditures</a>
-            <a class="post t-block" href="{{ url_for('electioneering_communications', max_date=today() | date(fmt='%m-%d-%Y')) }}">Electioneering communications</a>
-            <a class="post t-block" href="{{ url_for('communication_costs', max_date=today() | date(fmt='%m-%d-%Y')) }}">Communication costs</a>
+        <p>Spending includes all the types of <span class="term" data-term="disbursement">dibsursements</span> candidates and committees make.</p>
+        <div class="post-feed">
+          <div class="post">
+            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('disbursements') }}">All disbursements</a></h3>
+        <p>Search all disbursements from committees by the recipient, purpose, amount and date.</p>
+          </div>
+          <div class="post">
+            <h3><a href="{{ url_for('independent_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Independent expenditures</a></h3>
+            <p>Search <span class="term" data-term="independent expenditure">independent expenditures</span> to find specific spenders, candidates mentioned and transaction information.</p>
+          </div>
+          <div class="post">
+            <h3><a href="{{ url_for('party_coordinated_expenditures', max_date=today() | date(fmt='%m-%d-%Y')) }}">Party coordinated expenditures</a></h3>
+          </div>
+          <div class="post">
+            <h3><a href="{{ url_for('electioneering_communications', max_date=today() | date(fmt='%m-%d-%Y')) }}">Electioneering communications</a></h3>
+            <p>Search <span class="term" data-term="electioneering communication">electioneering communications</span> for communications that support or oppose specific candidates. Search by date and amount spent.</p>
+          </div>
+          <div class="post">
+            <h3><a href="{{ url_for('communication_costs', max_date=today() | date(fmt='%m-%d-%Y')) }}">Communication costs</a></h3>
+            <p>Search communication costs for communications that support or oppose specific candidates. Search by date and amount spent.</p>
           </div>
         </div>
         <div class="option__aside">
@@ -103,18 +124,41 @@
             <a href="/#spending">Spending data overview</a>
         </div>
       </section>
-      <section id="candidates" class="row" aria-hidden="true" role="tabpanel" >
-        <h2>Candidates</h2>
+      <section class="row" id="debts-loans" aria-hidden="true" role="tabpanel">
+        <h2>Debts and loans</h2>
         <div class="option__content">
-          <p>Search <span class="term" data-term="candidate">candidate</span> data, including money raised, money spent, cash on hand and debt.</p>
-          <p>Statements of Candidacy (Form 2) contain basic information about individuals running
-          for federal office, including their names, addresses and authorized campaign committees.</p>
           <div class="post-feed">
-            <a class="post t-block" href="{{ url_for('candidates', election_year=default_cycles, has_raised_funds='true') }}"><span class="t-all-data">All candidates</span></a>
-            <a class="post t-block" href="{{ url_for('candidates_office', office='president') }}">Presidential candidates</a>
-            <a class="post t-block" href="{{ url_for('candidates_office', office='senate') }}">Senate candidates</a>
-            <a class="post t-block" href="{{ url_for('candidates_office', office='house') }}">House of Representatives candidates</a>
-            <a class="post t-block" href="{{ url_for('filings', form_type='F2') }}">Most recent Statements of Candidacy (Form 2)</a>
+            <div class="post">
+              <h3><a href="">Debts</a></h3>
+            </div>
+            <div class="post">
+              <h3><a href="{{ url_for('loans', is_individual=True) }}">Loans</a></h3>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section id="candidates" class="row" aria-hidden="true" role="tabpanel">
+        <h2>Candidates</h2>
+        <div class="post-feed">
+          <div class="post">
+            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('candidates', election_year=default_cycles, has_raised_funds='true') }}">All candidates</a></h3>
+            <p>Browse all <span class="term" data-term="candidate">candidate</span> running for federal office</p>
+          </div>
+          <div class="post post--child">
+            <h4><a href="{{ url_for('candidates_office', office='president') }}">Presidential candidates</a></h4>
+            <p>Search presidential candidates and view financial totals including money raised, money spent, cash on hand and debt.</p>
+          </div>
+          <div class="post post--child">
+            <h4><a href="{{ url_for('candidates_office', office='senate') }}">Senate candidates</a></h4>
+            <p>Search senate candidates and view financial totals including money raised, money spent, cash on hand and debt.</p>
+          </div>
+          <div class="post post--child">
+            <h4><a href="{{ url_for('candidates_office', office='house') }}">House of Representatives candidates</a></h4>
+            <p>Search candidates for the House of Representatives and view financial totals including money raised, money spent, cash on hand and debt.</p>
+          </div>
+          <div class="post">
+            <h3><a href="{{ url_for('filings', form_type='F2') }}">Most recent Statements of Candidacy (Form 2)</a></h3>
+            <p>Statements of Candidacy (Form 2) contain basic information about individuals running for federal office, including their names, addresses and authorized campaign committees.</p>
           </div>
         </div>
         <div class="option__aside">
@@ -124,15 +168,19 @@
       </section>
       <section id="committees" class="row" aria-hidden="true" role="tabpanel" >
         <h2>Committees</h2>
-        <div class="option__content">
-          <p>The term <span class="term" data-term="political committee">committee</span> encompasses several different political groups that receive and spend money in federal elections.
-          Search for committees by type, years active, political party, location and treasurer.</p>
-          <p>Statements of Organization (Form 1) contain basic information about committees, including type, address and treasurer.</p>
-          <p>Requests for Additional Information (RFAIs) are sent to committees when a Campaign Finance Analyst needs additional clarification on a committee’s filing or identifies an error, omission or possible prohibited activity. Search RFAIs by committee or date.</p>
-          <div class="post-feed">
-            <a class="post t-block" href="{{ url_for('committees', election_year=default_cycles) }}"><span class="t-all-data">All committees</span></a>
-            <a class="post t-block" href="{{ url_for('filings', form_type='F1') }}">Most recent Statements of Organization (Form 1)</a>
-            <a class="post t-block" href="{{ url_for('filings', form_type='RFAI') }}">Requests for Additional Information sent to committees</a>
+        <p>The term <span class="term" data-term="political committee">committee</span> encompasses several different political groups that receive and spend money in federal elections.</p>
+        <div class="post-feed">
+          <div class="post">
+            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('committees', election_year=default_cycles) }}">All committees</a></h3>
+            <p>Search for committees by type, years active, political party, location and treasurer.</p>
+          </div>
+          <div class="post">
+            <h3><a href="{{ url_for('filings', form_type='F1') }}">Most recent Statements of Organization (Form 1)</a></h3>
+            <p>Statements of Organization (Form 1) contain basic information about committees, including type, address and treasurer.</p>
+          </div>
+          <div class="post">
+            <h3><a href="{{ url_for('filings', form_type='RFAI') }}">Requests for Additional Information sent to committees</a></h3>
+            <p>Requests for Additional Information (RFAIs) are sent to committees when a Campaign Finance Analyst needs additional clarification on a committee’s filing or identifies an error, omission or possible prohibited activity. Search RFAIs by committee or date.</p>
           </div>
         </div>
         <div class="option__aside">
@@ -142,17 +190,23 @@
             <a href="{{ cms_url }}/registration-and-reporting/">Registration and reporting requirements for other committees</a>
         </div>
       </section>
-      <section class="row" id="reports" aria-hidden="true" role="tabpanel" >
+      <section class="row" id="reports" aria-hidden="true" role="tabpanel">
         <h2>Filings</h2>
-        <div class="option__content">
-          <p>Filings contain all the statements, reports and notices that candidates and committees file. Search by date, type and filing candidate or committee.</p>
-          <div class="post-feed">
-            <a class="post t-block" href="{{ url_for('reports', form_type='presidential', is_amended='false') }}">Presidential committee reports</a>
-            <a class="post t-block" href="{{ url_for('reports', form_type='house-senate', is_amended='false') }}">House and Senate committee reports</a>
-            <a class="post t-block" href="{{ url_for('reports', form_type='pac-party', is_amended='false') }}">PAC and party committee reports</a>
-            <!-- Commenting out while page is in progress -->
-            <!--<li><a href="{{ url_for('reports', form_type='ie-only', is_amended='false') }}">Independent expenditure (Form 5) filer reports</a></li>-->
-            <a class="post t-block" href="{{ url_for('filings') }}"><span class="t-all-data">All filings</span></a>
+        <p>Filings contain all the statements, reports and notices that candidates and committees file. Search by date, type and filing candidate or committee.</p>
+        <div class="post-feed">
+          <div class="post">
+            <h3><a href="{{ url_for('reports', form_type='presidential', is_amended='false') }}">Presidential committee reports</a></h3>
+          </div>
+          <div class="post">
+            <h3><a href="{{ url_for('reports', form_type='house-senate', is_amended='false') }}">House and Senate committee reports</a></h3>
+          </div>
+          <div class="post">
+            <h3><a href="{{ url_for('reports', form_type='pac-party', is_amended='false') }}">PAC and party committee reports</a></h3>
+          </div>
+          <!-- Commenting out while page is in progress -->
+          <!--<li><a href="{{ url_for('reports', form_type='ie-only', is_amended='false') }}">Independent expenditure (Form 5) filer reports</a></li>-->
+          <div class="post">
+            <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('filings') }}">All filings</span></h3>
           </div>
         </div>
       </section>
@@ -186,6 +240,8 @@
                 Search candidate or committee profiles
             </div>
           </aside>
+        </a>
+      </div>
         </a>
       </div>
     </div>

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -69,11 +69,11 @@
               <a
                 class="side-nav__link"
                 role="tab"
-                data-name="reports"
+                data-name="filings"
                 tabindex="0"
-                aria-controls="reports"
-                href="#reports"
-                aria-selected="false">Reports and filings</a>
+                aria-controls="filings"
+                href="#filings"
+                aria-selected="false">Filings and reports</a>
             </li>
             <li class="side-nav__item" role="presentation">
               <a
@@ -106,7 +106,7 @@
                 <p>Receipts are anything of value, like money, services or property. Search candidate and committee receipt data by contributor, amount and date.</p>
               </div>
               <div class="post post--child">
-                <h3><a href="{{ url_for('individual_contributions') }}">Individual contributions</a></h3>
+                <h4><a href="{{ url_for('individual_contributions') }}">Individual contributions</a></h4>
                 <p>Search individual contributions to see who is donating to candidates and committees. Search for contributors by name, location, employer and occupation.</p>
               </div>
             </div>
@@ -210,8 +210,8 @@
             </div>
             <div class="content__section--extra" data-content-prefix="pacronym">
               <h3>PACronyms</h3>
-              <p>PACRONYMS, an alphabetical list of acronyms, abbreviations, initials, and common names of federal political action committees (PACs), was prepared to help researchers readily identify committees when their full names are not disclosed on campaign finance reports.</p>
-              <p>The list includes the PACRONYM, FEC ID number, full committee name, city and state, name of sponsoring, connected, or affiliated organization, committee designation and committee type.  Unless noted otherwise in the full committee name, the acronym “PAC” refers to “Political Action Committee.”  The PACRONYM is listed in ITALICS if the committee's PACRONYM is not specifically provided on the committee's Statement of Organization (FEC Form 1).</p>
+              <p>PACronyms, an alphabetical list of acronyms, abbreviations, initials and common names of federal political action committees (PACs), was prepared to help researchers readily identify committees when their full names are not disclosed on campaign finance reports.</p>
+              <p>The list includes the PACronym, FEC ID number, full committee name, city and state, name of sponsoring, connected, or affiliated organization, committee designation and committee type.  Unless noted otherwise in the full committee name, the acronym “PAC” refers to “political action committee.”  The PACronym is listed in italics if the committee's PACronym is not specifically provided on the committee's Statement of Organization (FEC Form 1).</p>
               <ul class="list--buttons">
                 <li>
                   <a class="button button--standard button--document" href="http://www.fec.gov/pubrec/pacronyms/Pacronyms.pdf">Open PDF</a>
@@ -225,7 +225,7 @@
               <div class="icon-heading">
                 <i class="icon-heading__image icon-circle--checklist"><span class="u-visually-hidden">Icon of a checklist</span></i>
                 <div class="icon-heading__content">
-                  <h4 class="u-no-margin">More information for:</h4>
+                  <h4>More information about:</h4>
                   <div class="grid grid--2-wide">
                     <div class="grid__item">
                       <a href="{{ cms_url }}/registration-and-reporting/essentials-nonconnected-committees/">Candidates and their committees</a>
@@ -244,8 +244,8 @@
               </div>
             </div>
           </section>
-          <section class="row" id="reports" aria-hidden="true" role="tabpanel">
-            <h2>Filings</h2>
+          <section class="row" id="filings" aria-hidden="true" role="tabpanel">
+            <h2>Filings and reports</h2>
             <p>Filings contain all the statements, reports and notices that candidates and committees file. Search by date, type and filing candidate or committee.</p>
             <div class="post-feed">
               <div class="post">
@@ -276,12 +276,12 @@
               <div class="post-feed">
                 <div class="post">
                   <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftpdet.shtml">Detailed data files</a></h4>
-                  <p>Here you will find the Committees, Candidates and Linkages, Itemized Records, Contributions to Candidates, Individual Contributions and Operating Expenditures files.</p>
-                  <p>These files contain committee, candidate and campaign finance data for the current election cycle and for election cycles through 1980. The files for the current election cycle plus the two most recent election cycles are regularly updated. The Committees, Candidates and Linkages files are updated daily. The Itemized Records, Contributions to Candidates, Individual Contributions and Operating Expenditures files are udated weekly on Sunday. Please note that complete entry from each reporting period takes about 30 days. It is important to be careful when making conclusions from these data because some information may not have completed the entry process when these files where create. Committees do not have the same filing requirements. You should be careful when comparing financial information about committees with different filing requirements.</p>
+                  <p>Here you will find the committees, candidates and linkages, itemized records, contributions to candidates, individual contributions and cperating expenditures files.</p>
+                  <p>These files contain committee, candidate and campaign finance data for the current election cycle and for election cycles through 1980. The files for the current election cycle plus the two most recent election cycles are regularly updated. The committees, candidates and linkages files are updated daily. The itemized records, contributions to candidates, individual contributions and operating expenditures files are udated weekly on Sunday. Please note that complete entry from each reporting period takes about 30 days. It is important to be careful when making conclusions from these data because some information may not have completed the entry process when these files where create. Committees do not have the same filing requirements. You should be careful when comparing financial information about committees with different filing requirements.</p>
                 </div>
                 <div class="post">
                   <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftpsum.shtml">Summary data files</a></h4>
-                  <p>Here you will find the current campaign summary file, the all candidates summary file and the current PAC summary file. The most recent 10 years of data, the current two-year election period plus the most recent five (5) two-year election periods, are updated daily.</p>
+                  <p>Here you will find the current campaign summary file, the all candidates summary file and the current PAC summary file. The most recent 10 years of data, the current two-year election period plus the five most recent two-year election periods, are updated daily.</p>
                 </div>
                 <div class="post">
                   <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/finance/disclosure/ftpefile.shtml">Electronically filed reports</a></h4>
@@ -299,7 +299,7 @@
               <div class="post-feed">
                 <div class="post">
                   <h4><i class="icon i-all-files icon--inline--left"></i><a href="{{ transition_url }}/data/DataCatalog.do">Legacy data catalog</a></h4>
-                  <p>Each of the files listed here can be downloaded in either csv or xml formats. Each also has a metadata page that describes the information included and the structure of the file itself. There is a pdf version of each file if you need to print the information. You can also subscribe to RSS feeds for each of the files so you're notified whenever new data is available or a change is made.</p>
+                  <p>Each of the files listed here can be downloaded in either CSV or XML formats. Each also has a metadata page that describes the information included and the structure of the file itself. There is a PDF version of each file if you need to print the information. You can also subscribe to RSS feeds for each of the files so you're notified whenever new data is available or a change is made.</p>
                   <p><a href="{{ transition_url }}/disclosurep/pnational.do">Presidential election map</a> | <a href="{{ transition_url }}/disclosurehs/hsnational.do">House and Senate elections data map</a>
                 </div>
                 <div class="post">
@@ -311,7 +311,7 @@
                     <a href="{{ transition_url }}/finance/disclosure/2004MatchingFundSubmissions.shtml">2004</a> |
                     <a href="{{ transition_url }}/finance/disclosure/submiss.shtml">2000</a>
                   </p>
-                  <p>You will find here the threshold files for presidential candidates seeking matching funds.</p>
+                  <p>You will find here the threshold files for Presidential candidates seeking matching funds.</p>
                   <p>In addition to regular quarterly or monthly disclosure reports, presidential candidates who seek matching funds must submit information about "matchable" contributions to the FEC for review. Contributions from individuals where the aggregate amount contributed by the individual is $250 or less are eligible to be matched on a dollar for dollar basis from the Presidential Election Campaign Fund. This Fund includes proceeds from the voluntary check-off of $3 per person from income tax returns of eligible taxpayers.</p>
                 </div>
                 <div class="post">
@@ -325,8 +325,8 @@
             <p>Certain information is reported to the FEC, but more information is reported to other governmental agencies.</p>
             <div class="post-feed">
               <div class="post">
-                <h3><i class="icon i-share icon--inline--left"></i><a href="https://www.irs.gov/charities-non-profits/political-organizations/political-organization-filing-and-disclosure">Internal Revenue Service (IRS) filings</h3>
-                <p>Search and download filings and disclosures by political organizations</p>
+                <h3><i class="icon i-share icon--inline--left"></i><a href="https://www.irs.gov/charities-non-profits/political-organizations/political-organization-filing-and-disclosure">Internal Revenue Service (IRS) filings</a></h3>
+                <p>Search and download filings and disclosures by political organizations.</p>
               </div>
               <div class="post">
                 <h3><i class="icon i-share icon--inline--left"></i><a href="http://apps.fcc.gov/ecd/">Federal Communications Commission (FCC) electioneering communications database</a></h3>
@@ -389,10 +389,8 @@
   <div class="slab slab--neutral footer-disclaimer">
     <div class="container">
       <div class="usa-width-one-half">
-        <p class="t-sans u-no-margin">Reports and statements filed by political committees may be inspected and copied by anyone. The names and addresses of individual contributors, however, may not be sold or used for any commercial purpose or to solicit any time of contribution or donation.</p>
-      </div>
-      <div class="usa-width-one-half">
-        <p class="t-sans u-no-margin"><a href="{{ transition_url }}/pages/brochures/saleuse.shtml">Read more about the sale and use of this data</a>.</p>
+        <p class="t-sans">Anyone can inspect and copy reports and statements filed by political committees. But the names and addresses of individual contributors may not be sold or used for commercial purposes or to solicit contributions or donations.</p>
+        <p class="t-sans u-no-margin"><a href="{{ transition_url }}/pages/brochures/saleuse.shtml">Read more about the sale and use of FEC data</a>.</p>
       </div>
     </div>
   </div>

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -70,16 +70,6 @@
     {% block body %}{% endblock %}
   </main>
 
-<div class="slab slab--neutral footer-disclaimer">
-  <div class="container">
-    <div class="usa-width-one-half">
-      <p class="t-sans u-no-margin">Reports and statements filed by political committees may be inspected and copied by anyone. The names and addresses of individual contributors, however, may not be sold or used for any commercial purpose or to solicit any time of contribution or donation.</p>
-    </div>
-    <div class="usa-width-one-half">
-      <p class="t-sans u-no-margin"><a href="{{ transition_url }}/pages/brochures/saleuse.shtml">Read more about the sale and use of this data</a>.</p>
-    </div>
-  </div>
-</div>
 <nav class="footer-links">
   <div class="container">
     <div class="footer-links__column">

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -70,6 +70,16 @@
     {% block body %}{% endblock %}
   </main>
 
+<div class="slab slab--neutral footer-disclaimer">
+  <div class="container">
+    <div class="usa-width-one-half">
+      <p class="t-sans u-no-margin">Reports and statements filed by political committees may be inspected and copied by anyone. The names and addresses of individual contributors, however, may not be sold or used for any commercial purpose or to solicit any time of contribution or donation.</p>
+    </div>
+    <div class="usa-width-one-half">
+      <p class="t-sans u-no-margin"><a href="{{ transition_url }}/pages/brochures/saleuse.shtml">Read more about the sale and use of this data</a>.</p>
+    </div>
+  </div>
+</div>
 <nav class="footer-links">
   <div class="container">
     <div class="footer-links__column">

--- a/openfecwebapp/templates/partials/navigation.html
+++ b/openfecwebapp/templates/partials/navigation.html
@@ -9,8 +9,8 @@
         <button class="site-nav__link button--nav-panel js-panel-trigger u-under-lg-only" aria-controls="nav-data">Campaign finance data</button>
       </li>
       <li class="site-nav__item site-nav__item--secondary" data-submenu="services">
-        <a href="{{ cms_url }}/registration-and-reporting/" class="site-nav__link">
-          <span class="site-nav__link__title">Candidate and committee services</span>
+        <a href="{{ cms_url }}/help-candidates-committees/" class="site-nav__link">
+          <span class="site-nav__link__title">Help for candidates and committees</span>
         </a>
       </li>
       <li class="site-nav__item" data-submenu="legal">

--- a/openfecwebapp/templates/partials/navigation.html
+++ b/openfecwebapp/templates/partials/navigation.html
@@ -3,14 +3,20 @@
     <ul class="site-nav__panel site-nav__panel--main">
       <li><h3 class="site-nav__title u-under-lg-only">Menu</h3></li>
       <li class="site-nav__item site-nav__item--with-dropdown" data-submenu="data">
-        <a href="{{ url_for('search') }}" class="site-nav__link {% if parent == 'data' %}is-parent{% endif %} u-lg-only">Campaign finance data</a>
+        <a href="{{ url_for('search') }}" class="site-nav__link {% if parent == 'data' %}is-parent{% endif %} u-lg-only">
+          <span class="site-nav__link__title">Campaign finance data<span class="site-nav__link__title">
+        </a>
         <button class="site-nav__link button--nav-panel js-panel-trigger u-under-lg-only" aria-controls="nav-data">Campaign finance data</button>
       </li>
       <li class="site-nav__item site-nav__item--secondary" data-submenu="services">
-        <a href="{{ cms_url }}/registration-and-reporting/" class="site-nav__link">Registration and reporting</a>
+        <a href="{{ cms_url }}/registration-and-reporting/" class="site-nav__link">
+          <span class="site-nav__link__title">Candidate and committee services</span>
+        </a>
       </li>
       <li class="site-nav__item" data-submenu="legal">
-        <a href="{{ cms_url }}/legal-resources" class="site-nav__link {% if parent == 'legal' %}is-parent{% endif %}">Legal resources</a>
+        <a href="{{ cms_url }}/legal-resources" class="site-nav__link {% if parent == 'legal' %}is-parent{% endif %}">
+          <span class="site-nav__link__title">Legal resources</span>
+        </a>
       </li>
       <li class="site-nav__item utility-nav__item">
         <a href="{{ cms_url }}/contact-us/" class="site-nav__link">Contact</a>

--- a/openfecwebapp/templates/partials/navigation.html
+++ b/openfecwebapp/templates/partials/navigation.html
@@ -4,7 +4,7 @@
       <li><h3 class="site-nav__title u-under-lg-only">Menu</h3></li>
       <li class="site-nav__item site-nav__item--with-dropdown" data-submenu="data">
         <a href="{{ url_for('search') }}" class="site-nav__link {% if parent == 'data' %}is-parent{% endif %} u-lg-only">
-          <span class="site-nav__link__title">Campaign finance data<span class="site-nav__link__title">
+          <span class="site-nav__link__title">Campaign finance data</span>
         </a>
         <button class="site-nav__link button--nav-panel js-panel-trigger u-under-lg-only" aria-controls="nav-data">Campaign finance data</button>
       </li>

--- a/openfecwebapp/templates/partials/navigation.html
+++ b/openfecwebapp/templates/partials/navigation.html
@@ -6,10 +6,10 @@
         <a href="{{ url_for('search') }}" class="site-nav__link {% if parent == 'data' %}is-parent{% endif %} u-lg-only">Campaign finance data</a>
         <button class="site-nav__link button--nav-panel js-panel-trigger u-under-lg-only" aria-controls="nav-data">Campaign finance data</button>
       </li>
-      <li class="site-nav__item">
+      <li class="site-nav__item site-nav__item--secondary" data-submenu="services">
         <a href="{{ cms_url }}/registration-and-reporting/" class="site-nav__link">Registration and reporting</a>
       </li>
-      <li class="site-nav__item">
+      <li class="site-nav__item" data-submenu="legal">
         <a href="{{ cms_url }}/legal-resources" class="site-nav__link {% if parent == 'legal' %}is-parent{% endif %}">Legal resources</a>
       </li>
       <li class="site-nav__item utility-nav__item">


### PR DESCRIPTION
PR implementing the new layout for the Advanced Data page.

Resolves https://github.com/18F/openFEC-web-app/issues/1877
Resolves https://github.com/18F/openFEC-web-app/issues/1838

---

## Update
This updates the Advance Data page to use the sidebar tabs like so:

![image](https://cloud.githubusercontent.com/assets/1696495/24432108/c7742c3a-13d4-11e7-98f5-a658267fb665.png)

I implemented this with all of the same copy as we had before, but in some cases broke things out slightly to fit the new organization. I still think we need to put some more thought into this content, but this will do for now.

It also:
- Adds the disclaimer 
- Adds the link to the API
- Adds links to legacy data tools