### PR TITLE
Update some of the backend tooling for the web app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_script:
   - ". $HOME/.nvm/nvm.sh"
   - nvm install v7.7.4
   - nvm use v7.7.4
-  - travis_retry npm install
   - npm i -g npm
+  - travis_retry npm install
   - npm run build
 script:
   - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,34 +2,35 @@ language: python
 sudo: false
 cache: pip
 python:
-- '3.4'
+  - '3.4'
 env:
   global:
-  - secure: U8r+y8ScnAP/m0AOjYjqX90Wf9SWw5VGv+UXjnF/P6ypQl1dUAyDMXitw0B7XHjqmRP5xATcLGwL3IzFfowb8YFhVKSsO9h1pgpmkCGOhxxqp2jh978nU6df3SdbPmEvPlZaoBsLDVqRMHUPOyDLbaPN6iQtdbRcQhhE+zRcHT8= # dev user name
-  - secure: X1yp0ohu6eZyaw+ybLWYiyTYFemHBUDHeSb8g+SGPxRZRhqt8l/GwElRxwGzZOviPaJ4qwZ7jUUJHN1CPfbSahV3amTXQ1AhAn3g+hZyoqHc1BifuHYBY8rhfthvI1PjGAOT7vnZoD839Oxw4TMA5R/O9l6JT9GG5hGs8SDqOak= # dev password
-  - secure: bxZ84spAuwVNcZFcaN5UW55nf+LIdcegGGlgXsOn4t2R+yimJt9f86v2euCZY0bs9drlJqHVGXF9KYiH32Y1eYchHx3J7oqUWWR5EFT3USAGkoOP3ZFmbdDJ6WCYkqTw/WtnVvLKRNDI6jaDQJf9+XgUafQGoHmZZx1Ocz8Ko1g= # stage password
-  - secure: aHAXGNtzlkaNFdPlVGgJwi6HKzl5/7lv85CFxERypt4fvQCHtSYRrwVjEZMQiqwHOdXCrowV2+MMCjubT9w5A+i4iPVlOoz7iwdgmVYqxSzwpwlGqMFJGRH4H+8wDjbaTZRNYX8Ww7gOa32MtLTPjKQMh+kdgDgmi8zTOp2aZXQ= # stage user name
+    - secure: U8r+y8ScnAP/m0AOjYjqX90Wf9SWw5VGv+UXjnF/P6ypQl1dUAyDMXitw0B7XHjqmRP5xATcLGwL3IzFfowb8YFhVKSsO9h1pgpmkCGOhxxqp2jh978nU6df3SdbPmEvPlZaoBsLDVqRMHUPOyDLbaPN6iQtdbRcQhhE+zRcHT8= # dev user name
+    - secure: X1yp0ohu6eZyaw+ybLWYiyTYFemHBUDHeSb8g+SGPxRZRhqt8l/GwElRxwGzZOviPaJ4qwZ7jUUJHN1CPfbSahV3amTXQ1AhAn3g+hZyoqHc1BifuHYBY8rhfthvI1PjGAOT7vnZoD839Oxw4TMA5R/O9l6JT9GG5hGs8SDqOak= # dev password
+    - secure: bxZ84spAuwVNcZFcaN5UW55nf+LIdcegGGlgXsOn4t2R+yimJt9f86v2euCZY0bs9drlJqHVGXF9KYiH32Y1eYchHx3J7oqUWWR5EFT3USAGkoOP3ZFmbdDJ6WCYkqTw/WtnVvLKRNDI6jaDQJf9+XgUafQGoHmZZx1Ocz8Ko1g= # stage password
+    - secure: aHAXGNtzlkaNFdPlVGgJwi6HKzl5/7lv85CFxERypt4fvQCHtSYRrwVjEZMQiqwHOdXCrowV2+MMCjubT9w5A+i4iPVlOoz7iwdgmVYqxSzwpwlGqMFJGRH4H+8wDjbaTZRNYX8Ww7gOa32MtLTPjKQMh+kdgDgmi8zTOp2aZXQ= # stage user name
 before_script:
-- travis_retry pip install -U pip wheel
-- travis_retry pip install -r requirements.txt
-- travis_retry pip install -r requirements.test.txt
-- ". $HOME/.nvm/nvm.sh"
-- nvm install v5.5.0
-- nvm use v5.5.0
-- travis_retry npm install
-- npm run build
+  - travis_retry pip install -U pip setuptools wheel
+  - travis_retry pip install -r requirements.txt
+  - travis_retry pip install -r requirements.test.txt
+  - ". $HOME/.nvm/nvm.sh"
+  - nvm install v7.7.4
+  - nvm use v7.7.4
+  - travis_retry npm install
+  - npm i -g npm
+  - npm run build
 script:
-- py.test
-- npm run test-single
+  - py.test
+  - npm run test-single
 after_success:
-- travis_retry pip install codecov
-- codecov
+  - travis_retry pip install codecov
+  - codecov
 before_deploy:
-- export PATH=$HOME:$PATH
-- travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.25.0"
-- tar xzvf $HOME/cf.tgz -C $HOME
-- travis_retry cf install-plugin autopilot -f -r CF-Community
-- npm run build
+  - export PATH=$HOME:$PATH
+  - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.25.0"
+  - tar xzvf $HOME/cf.tgz -C $HOME
+  - travis_retry cf install-plugin autopilot -f -r CF-Community
+  - npm run build
 deploy:
   provider: script
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 cache: pip
 python:
-  - '3.4'
+  - "3.6.1"
 env:
   global:
     - secure: U8r+y8ScnAP/m0AOjYjqX90Wf9SWw5VGv+UXjnF/P6ypQl1dUAyDMXitw0B7XHjqmRP5xATcLGwL3IzFfowb8YFhVKSsO9h1pgpmkCGOhxxqp2jh978nU6df3SdbPmEvPlZaoBsLDVqRMHUPOyDLbaPN6iQtdbRcQhhE+zRcHT8= # dev user name

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 cache: pip
 python:
-  - "3.6"
+  - "3.5"
 env:
   global:
     - secure: U8r+y8ScnAP/m0AOjYjqX90Wf9SWw5VGv+UXjnF/P6ypQl1dUAyDMXitw0B7XHjqmRP5xATcLGwL3IzFfowb8YFhVKSsO9h1pgpmkCGOhxxqp2jh978nU6df3SdbPmEvPlZaoBsLDVqRMHUPOyDLbaPN6iQtdbRcQhhE+zRcHT8= # dev user name

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 cache: pip
 python:
-  - "3.6.1"
+  - "3.6"
 env:
   global:
     - secure: U8r+y8ScnAP/m0AOjYjqX90Wf9SWw5VGv+UXjnF/P6ypQl1dUAyDMXitw0B7XHjqmRP5xATcLGwL3IzFfowb8YFhVKSsO9h1pgpmkCGOhxxqp2jh978nU6df3SdbPmEvPlZaoBsLDVqRMHUPOyDLbaPN6iQtdbRcQhhE+zRcHT8= # dev user name

--- a/README.md
+++ b/README.md
@@ -181,8 +181,6 @@ the following keys are set:
 * FEC_WEB_API_KEY
 * FEC_WEB_API_KEY_PUBLIC
 * FEC_GITHUB_TOKEN
-* SENTRY_DSN
-* SENTRY_PUBLIC_DSN
 * NEW_RELIC_LICENSE_KEY
 
 Deploys of a single app can be performed manually by targeting the env/space, and specifying the corresponding manifest, as well as the app you want, like so:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We’re thrilled you want to get involved!
 ### Installation
 This application is in [Flask](http://flask.pocoo.org/). Client side features are managed using [Browserify](http://browserify.org/) and [npm](https://www.npmjs.org/).
 
-It uses Python version 3.4. It's recommended that you create a [virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/) before installing Python dependencies. Don't put your virtualenv in this directory.
+It uses Python version 3.5.3. It's recommended that you create a [virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/) before installing Python dependencies. Don't put your virtualenv in this directory.
 
 Install Python dependencies:
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,9 +23,6 @@ var appEnv = require('cfenv').getAppEnv();
 var debug = !!process.env.FEC_WEB_DEBUG;
 var analytics = !!process.env.FEC_WEB_GOOGLE_ANALYTICS;
 var production = ['stage', 'prod'].indexOf(process.env.FEC_WEB_ENVIRONMENT) !== -1;
-var sentryPublicDsn = process.env.SENTRY_PUBLIC_DSN;
-var sentryPublicDsn = (appEnv.getServiceCreds(/fec-creds/) || {}).SENTRY_PUBLIC_DSN ||
-  process.env.SENTRY_PUBLIC_DSN;
 
 gulp.task('copy-vendor-images', function() {
   return gulp.src('./node_modules/datatables/media/images/**/*')
@@ -125,8 +122,7 @@ gulp.task('build-js', function() {
   })
   .transform(preprocessify({
     DEBUG: debug,
-    ANALYTICS: analytics,
-    SENTRY_PUBLIC_DSN: sentryPublicDsn
+    ANALYTICS: analytics
   }))
   .transform({global: true}, stringify(['.html']))
   .transform({global: true}, hbsfy)

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -5,7 +5,7 @@ services:
   - fec-creds-dev
 env:
   FEC_CMS_URL: https://fec-dev-proxy.app.cloud.gov
-  FEC_WEB_API_URL: https://fec-api-stage.app.cloud.gov
+  FEC_WEB_API_URL: https://fec-dev-api.app.cloud.gov
   FEC_WEB_DEBUG: true
   FEC_WEB_ENVIRONMENT: dev
   NEW_RELIC_APP_NAME: govcloud | web | dev

--- a/openfecwebapp/app.py
+++ b/openfecwebapp/app.py
@@ -6,7 +6,6 @@ import logging
 import datetime
 
 import furl
-from raven.contrib.flask import Sentry
 
 from hmac_authentication import hmacauth
 from flask import Flask, render_template, request, url_for
@@ -195,9 +194,6 @@ def initialize_newrelic():
         newrelic.agent.initialize()
 
 initialize_newrelic()
-
-if config.sentry_dsn:
-    Sentry(app, dsn=config.sentry_dsn)
 
 app.wsgi_app = utils.ReverseProxied(app.wsgi_app)
 app.wsgi_app = ProxyFix(app.wsgi_app)

--- a/openfecwebapp/config.py
+++ b/openfecwebapp/config.py
@@ -40,7 +40,6 @@ force_https = bool(os.getenv('FEC_FORCE_HTTPS', ''))
 use_analytics = bool(os.getenv('FEC_WEB_GOOGLE_ANALYTICS'))
 
 github_token = env.get_credential('FEC_GITHUB_TOKEN')
-sentry_dsn = env.get_credential('SENTRY_DSN')
 
 hmac_secret = env.get_credential('HMAC_SECRET')
 hmac_headers = env.get_credential('HMAC_HEADERS', '').split(',')

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -4,7 +4,7 @@ import furl
 
 from flask.views import MethodView
 from flask import request, render_template, redirect, url_for, jsonify
-from flask.ext.cors import cross_origin
+from flask_cors import cross_origin
 
 from webargs import fields
 from webargs.flaskparser import use_kwargs

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "moment": "2.10.3",
     "numeral": "1.5.3",
     "perfbar": "git://github.com/jmcarp/perfBar.git#issue-24",
-    "raven-js": "1.2.0",
     "topojson": "1.6.19",
     "underscore": "1.8.3",
     "underscore.string": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
     "es6-weak-map": "2.0.1",
-    "fec-style": "7.6.0",
+    "fec-style": "7.7.0",
     "glossary-panel": "0.2.1",
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,5 +1,5 @@
 fake-factory==0.6.0
 mock>=1.3.0
-pytest>=3.0.2
+pytest>=3.0.7
 pytest-cov>=1.8.1
 WebTest>=2.0.18

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,5 +1,5 @@
 fake-factory==0.6.0
 mock>=1.3.0
-pytest>=2.7.0
+pytest>=3.0.2
 pytest-cov>=1.8.1
 WebTest>=2.0.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,13 @@ Flask-BasicAuth==0.2.0
 Flask-Cors==3.0.2
 Flask-Script==2.0.5
 Flask-SSLify==0.1.5
-furl==0.4.5
-github3.py==0.9.4
+furl==0.5.7
+github3.py==0.9.6
 hmac-authentication==1.0.0
 python-dateutil==2.4.2
 requests==2.13.0
 newrelic==2.78.0.57
-gunicorn==19.3.0
+gunicorn==19.7.1
 webargs==0.18.0
 CacheControl==0.11.5
 cachetools==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==0.10.1
+Flask==0.12
 Flask-BasicAuth==0.2.0
 Flask-Cors==2.1.0
 Flask-Script==2.0.5
@@ -7,7 +7,7 @@ furl==0.4.5
 github3.py==0.9.4
 hmac-authentication==1.0.0
 python-dateutil==2.4.2
-requests==2.10.0
+requests==2.13.0
 newrelic==2.78.0.57
 gunicorn==19.3.0
 webargs==0.18.0
@@ -18,5 +18,5 @@ cfenv==0.5.2
 slacker==0.8.6
 
 # Development
-invoke==0.10.1
+invoke==0.15.0
 GitPython==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==0.12
 Flask-BasicAuth==0.2.0
-Flask-Cors==2.1.0
+Flask-Cors==3.0.2
 Flask-Script==2.0.5
 Flask-SSLify==0.1.5
 furl==0.4.5
@@ -13,7 +13,6 @@ gunicorn==19.3.0
 webargs==0.18.0
 CacheControl==0.11.5
 cachetools==1.0.2
-raven[flask]==5.8.1
 cfenv==0.5.2
 slacker==0.8.6
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.1
+python-3.6.0

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.6.1

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.0
+python-3.5.3

--- a/static/js/init.js
+++ b/static/js/init.js
@@ -26,10 +26,6 @@ var stickyBar = require('fec-style/js/sticky-bar');
 var toc = require('fec-style/js/toc');
 var Search = require('fec-style/js/search');
 
-// @if SENTRY_PUBLIC_DSN
-require('raven-js').config('/* @echo SENTRY_PUBLIC_DSN */').install();
-// @endif
-
 // Include vendor scripts
 require('./vendor/tablist').init();
 

--- a/tasks.py
+++ b/tasks.py
@@ -10,15 +10,15 @@ from openfecwebapp.env import env
 
 
 @task
-def add_hooks():
-    run('ln -s ../../bin/post-merge .git/hooks/post-merge')
-    run('ln -s ../../bin/post-checkout .git/hooks/post-checkout')
+def add_hooks(ctx):
+    ctx.run('ln -s ../../bin/post-merge .git/hooks/post-merge')
+    ctx.run('ln -s ../../bin/post-checkout .git/hooks/post-checkout')
 
 
 @task
-def remove_hooks():
-    run('rm .git/hooks/post-merge')
-    run('rm .git/hooks/post-checkout')
+def remove_hooks(ctx):
+    ctx.run('rm .git/hooks/post-merge')
+    ctx.run('rm .git/hooks/post-checkout')
 
 
 def _detect_prod(repo, branch):
@@ -77,7 +77,7 @@ DEPLOY_RULES = (
 
 
 @task
-def deploy(space=None, branch=None, login=None, yes=False):
+def deploy(ctx, space=None, branch=None, login=None, yes=False):
     """Deploy app to Cloud Foundry. Log in using credentials stored in
     `FEC_CF_USERNAME` and `FEC_CF_PASSWORD`; push to either `space` or the space
     detected from the name and tags of the current branch. Note: Must pass `space`
@@ -92,18 +92,18 @@ def deploy(space=None, branch=None, login=None, yes=False):
 
     # Build static assets
     # These must be built prior to deploying.
-    run('npm run build', echo=True)
+    ctx.run('npm run build', echo=True)
 
     # Set api
     api = 'https://api.fr.cloud.gov'
-    run('cf api {0}'.format(api), echo=True)
+    ctx.run('cf api {0}'.format(api), echo=True)
 
     # Log in if necessary
     if login == 'True':
-        run('cf auth "$FEC_CF_USERNAME_{0}" "$FEC_CF_PASSWORD_{0}"'.format(space.upper()), echo=True)
+        ctx.run('cf auth "$FEC_CF_USERNAME_{0}" "$FEC_CF_PASSWORD_{0}"'.format(space.upper()), echo=True)
 
     # Target space
-    run('cf target -o fec-beta-fec -s {0}'.format(space), echo=True)
+    ctx.run('cf target -o fec-beta-fec -s {0}'.format(space), echo=True)
 
     # Set deploy variables
     with open('.cfmeta', 'w') as fp:
@@ -112,12 +112,12 @@ def deploy(space=None, branch=None, login=None, yes=False):
     # Deploy web-app
     deployed = run('cf app web', echo=True, warn=True)
     cmd = 'zero-downtime-push' if deployed.ok else 'push'
-    run('cf {0} web -f manifest_{1}.yml'.format(cmd, space), echo=True)
+    ctx.run('cf {0} web -f manifest_{1}.yml'.format(cmd, space), echo=True)
 
 
 # not calling this function for now
 @task
-def notify():
+def notify(ctx):
     try:
         meta = json.load(open('.cfmeta'))
     except OSError:


### PR DESCRIPTION
This changeset updates some of the tooling and infrastructure in the web app to bring things up to date.  It focuses more on the backend and Python as opposed to the front-end components, but includes the following:

* Cleanup of .travis.yml
* Updates fec-style to latest release (7.7.0)
* Updates a handful Python dependencies
* Cleanup of `invoke` tasks
* Removal of all references to Sentry/Raven
* Updates cloud.gov Python runtime to 3.5.3
* Fixes reference to API in the `manifest_dev.yml` config
* A handful of `README.md` updates

The Travis cleanup includes updating nvm to make use of the latest stable release of Node.js, which I have been running locally for a while now with no issues.

I also attempted to run things in Python 3.6, but one or two of our dependencies seem to be struggling with it, so I opted to go with 3.5.3 for now and leave the troublesome dependencies alone for now.  Several others (GitPython and webargs, for instance) have a few backwards-incompatible changes with newer releases and will also take a bit more time to update and work through to make sure nothing breaks.  I'd rather keep things smaller and more manageable than roll it all in together!