### PR TITLE
Feature/server side datatables

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -254,7 +254,7 @@ table_columns = OrderedDict([
     ('candidates-office-president', ['Name', 'Party', 'Receipts', 'Disbursements']),
     ('candidates-office-senate', ['Name', 'Party', 'State', 'Receipts', 'Disbursements']),
     ('candidates-office-house', ['Name', 'Party', 'State', 'District', 'Receipts', 'Disbursements']),
-    ('committees', ['Name', 'Treasurer', 'Type', 'Designation', 'First file date']),
+    ('committees', ['Name', 'Treasurer', 'Type', 'Designation']),
     ('communication-costs', ['Committee', 'Support/Oppose', 'Candidate', 'Amount', 'Date']),
     ('disbursements', ['Spender', 'Recipient', 'State', 'Description', 'Disbursement date', 'Amount']),
     ('electioneering-communications', ['Spender', 'Candidate mentioned','Number of candidates', 'Amount per candidate', 'Date', 'Disbursement amount' ]),

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -124,13 +124,10 @@ def advanced():
 
 @app.route('/candidates/')
 @use_kwargs({
-  'name': fields.Str(missing=None, load_from="q"),
-  'office': fields.Str(missing=None),
   'page': fields.Int(missing=1)
 })
 def candidates(**kwargs):
     candidates = api_caller._call_api('candidates', **kwargs)
-    print(candidates)
     return render_template(
         'datatable.html',
         parent='data',
@@ -157,14 +154,19 @@ def candidates_office(office):
     )
 
 @app.route('/committees/')
-def committees():
+@use_kwargs({
+  'page': fields.Int(missing=1)
+})
+def committees( **kwargs):
+    committees = api_caller._call_api('committees', **kwargs)
     return render_template(
         'datatable.html',
         parent='data',
         result_type='committees',
         slug='committees',
         title='Committees',
-        dates=utils.date_ranges(),
+        data=committees['results'],
+        query=kwargs,
         columns=constants.table_columns['committees']
     )
 

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -123,13 +123,22 @@ def advanced():
     )
 
 @app.route('/candidates/')
-def candidates():
+@use_kwargs({
+  'name': fields.Str(missing=None, load_from="q"),
+  'office': fields.Str(missing=None),
+  'page': fields.Int(missing=1)
+})
+def candidates(**kwargs):
+    candidates = api_caller._call_api('candidates', **kwargs)
+    print(candidates)
     return render_template(
         'datatable.html',
         parent='data',
         result_type='candidates',
         slug='candidates',
         title='Candidates',
+        data=candidates['results'],
+        query=kwargs,
         columns=constants.table_columns['candidates']
     )
 

--- a/openfecwebapp/templates/datatable.html
+++ b/openfecwebapp/templates/datatable.html
@@ -30,7 +30,11 @@
             </tr>
           </thead>
           <noscript>
-            {{ datatables.candidates(data) }}
+            {% if result_type == 'candidates' %}
+              {{ datatables.candidates(data) }}
+            {% elif result_type == 'committees' %}
+              {{ datatables.committees(data) }}
+            {% endif %}
           </noscript>
         </table>
         <noscript>

--- a/openfecwebapp/templates/datatable.html
+++ b/openfecwebapp/templates/datatable.html
@@ -1,6 +1,6 @@
 {% extends 'layouts/main.html' %}
 {% import 'macros/page-header.html' as header %}
-
+{% import 'macros/datatables.html' as datatables %}
 {% set breadcrumbs_title=title %}
 {% set breadcrumbs=[(url_for('advanced'), 'Advanced data')] %}
 
@@ -29,7 +29,20 @@
               <th scope="col"></th>
             </tr>
           </thead>
+          <noscript>
+            {{ datatables.candidates(data) }}
+          </noscript>
         </table>
+        <noscript>
+          <div class="results-info">
+            <div class="dataTables_paginate paging_simple">
+              {% if query['page']|int > 1 %}
+                <a href="?page={{query['page']|int - 1}}" class="button button--previous button--standard"></a>
+              {% endif %}
+                <a href="?page={{query['page']|int + 1}}" class="button button--next button--standard"></a>
+            </div>
+          </div>
+        </noscript>
       </div>
     </div>
 </section>

--- a/openfecwebapp/templates/datatable.html
+++ b/openfecwebapp/templates/datatable.html
@@ -38,6 +38,7 @@
           </noscript>
         </table>
         <noscript>
+          {% if query %}
           <div class="results-info">
             <div class="dataTables_paginate paging_simple">
               {% if query['page']|int > 1 %}
@@ -46,6 +47,7 @@
                 <a href="?page={{query['page']|int + 1}}" class="button button--next button--standard"></a>
             </div>
           </div>
+          {% endif %}
         </noscript>
       </div>
     </div>

--- a/openfecwebapp/templates/datatable.html
+++ b/openfecwebapp/templates/datatable.html
@@ -16,6 +16,9 @@
   {% include 'partials/' + slug + '-filter.html' %}
     <div class="data-container">
       <div class="data-container__widgets js-data-widgets">
+        <noscript>
+          <h1>{{ title }}</h1>
+        </noscript>        
         <div class="js-filter-tags data-container__tags">
         </div>
       </div>

--- a/openfecwebapp/templates/macros/datatables.html
+++ b/openfecwebapp/templates/macros/datatables.html
@@ -3,7 +3,7 @@
   <tr>
     <td><a href="{{ url_for('candidate_page', c_id=datum.candidate_id) }}">{{ datum.name}}</a></td>
     <td>{{ datum.office }}</td>
-    <td>{{ datum.election_years }}</td>
+    <td>{{ datum.election_years|join(', ') }}</td>
     <td>{{ datum.party_full }}</td>
     <td>{{ datum.state }}</td>
     <td>{{ datum.district }}</td>

--- a/openfecwebapp/templates/macros/datatables.html
+++ b/openfecwebapp/templates/macros/datatables.html
@@ -10,3 +10,14 @@
   </tr>
   {% endfor %}
 {% endmacro %}
+
+{% macro committees(data) %}
+  {% for datum in data %}
+  <tr>
+    <td><a href="{{ url_for('committee_page', c_id=datum.committee_id) }}">{{ datum.name }}</a></td>
+    <td>{{ datum.treasurer_name }}</td>
+    <td>{{ datum.committee_type_full }}</td>
+    <td>{{ datum.designation_full }}</td>
+  </tr>
+  {% endfor %}
+{% endmacro %}

--- a/openfecwebapp/templates/macros/datatables.html
+++ b/openfecwebapp/templates/macros/datatables.html
@@ -3,7 +3,7 @@
   <tr>
     <td><a href="{{ url_for('candidate_page', c_id=datum.candidate_id) }}">{{ datum.name}}</a></td>
     <td>{{ datum.office }}</td>
-    <td>{{ datum.cycles }}</td>
+    <td>{{ datum.election_years }}</td>
     <td>{{ datum.party_full }}</td>
     <td>{{ datum.state }}</td>
     <td>{{ datum.district }}</td>

--- a/openfecwebapp/templates/macros/datatables.html
+++ b/openfecwebapp/templates/macros/datatables.html
@@ -1,0 +1,12 @@
+{% macro candidates(data) %}
+  {% for datum in data %}
+  <tr>
+    <td><a href="{{ url_for('candidate_page', c_id=datum.candidate_id) }}">{{ datum.name}}</a></td>
+    <td>{{ datum.office }}</td>
+    <td>{{ datum.cycles }}</td>
+    <td>{{ datum.party_full }}</td>
+    <td>{{ datum.state }}</td>
+    <td>{{ datum.district }}</td>
+  </tr>
+  {% endfor %}
+{% endmacro %}

--- a/openfecwebapp/templates/partials/warnings.html
+++ b/openfecwebapp/templates/partials/warnings.html
@@ -1,13 +1,9 @@
 <noscript>
-  <div style="background-color: #DB4857; padding: 20px;">
-    <h2 style="color: #ffffff">Javascript Required</h2>
-    <p style="color: #ffffff"><a href="{{ url_for('search') }}">betaFEC</a> uses Javascript to provide the best possible user experience. Please enable Javascript in your browser or visit FEC.gov.</p>
-    <p style="color: #ffffff">
-      <a style="color: #ffffff; text-decoration: underline" target="_blank"
+  <div style="background-color: #212121; padding: 10px; font-family: sans-serif">
+    <p style="color: #ffffff"><strong>Javascript recommended:</strong> betaFEC uses Javascript to provide the best possible user experience. Please enable Javascript in your browser or visit FEC.gov. <a style="color: #ffffff; text-decoration: underline" target="_blank"
           href="http://enable-javascript.com/">
         Learn how to enable Javascript in your browser
-      </a>
-    </p>
+      </a></p>
   </div>
 </noscript>
 

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -170,7 +170,6 @@ var committees = [
   {data: 'treasurer_name', className: 'min-desktop hide-panel'},
   {data: 'committee_type_full', className: 'min-tablet hide-panel'},
   {data: 'designation_full', className: 'min-tablet hide-panel'},
-  dateColumn({data: 'first_file_date', className: 'min-tablet hide-panel column--med' }),
   modalTriggerColumn
 ];
 

--- a/static/js/pages/committees.js
+++ b/static/js/pages/committees.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
     columns: columns.committees,
     useFilters: true,
     useExport: true,
-    order: [[4, 'desc']],
+    order: [[0, 'asc']],
     rowCallback: tables.modalRenderRow,
     callbacks: {
       afterRender: tables.modalRenderFactory(committeesTemplate)


### PR DESCRIPTION
This is a proof of concept for adding basic server-side rendering of the candidate and committee data table pages, which can help with search engine indexing. 

![image](https://cloud.githubusercontent.com/assets/1696495/24432934/4d6e424e-13da-11e7-9202-d67321dfb4e0.png)

The idea is that for beta.fec.gov/data/candidates and beta.fec.gov/data/candidates , we generate a basic alphabetically ordered list of all candidates and committees server-side. If JS is enabled, the regular data table and filtering experience takes over. If not, the server-side data stays.

The only thing you can do is page through the results and click through to committee pages (so there's no filters), which _should_ be enough for a search spider to do it's the work of crawling through and indexing all the pages. 

A future step could be building this out to use this approach for the other pages and/or adding some simple filters, which would ensure these pages work in some minimal way for non-js users.

cc @xtine @onezerojeremy 