### PR TITLE
[MERGE WITH GIT FLOW] Add dataType to ajax request

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
     "es6-weak-map": "2.0.1",
-    "fec-style": "7.7.2",
+    "fec-style": "7.7.3",
     "glossary-panel": "0.2.1",
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",

--- a/static/js/modules/download.js
+++ b/static/js/modules/download.js
@@ -134,7 +134,8 @@ DownloadItem.prototype.refresh = function() {
     method: 'POST',
     url: this.apiUrl,
     data: JSON.stringify({filename: this.filename}),
-    contentType: 'application/json'
+    contentType: 'application/json',
+    dataType: 'html'
   });
   this.promise.then(this.handleSuccess.bind(this));
   this.promise.fail(this.handleError.bind(this));

--- a/static/js/modules/election-lookup.js
+++ b/static/js/modules/election-lookup.js
@@ -314,7 +314,7 @@ ElectionLookup.prototype.drawZipWarning = function() {
  */
 ElectionLookup.prototype.updateLocations = function() {
   var self = this;
-  var svg = self.$svg || $.get('/static/img/i-map--primary.svg').then(function(document) {
+  var svg = self.$svg || $.get('/static/img/i-map--primary.svg', '', null, 'xml').then(function(document) {
     self.$svg = $(document.querySelector('svg'));
     return self.$svg;
   });

--- a/static/js/modules/reaction-box.js
+++ b/static/js/modules/reaction-box.js
@@ -69,7 +69,8 @@ ReactionBox.prototype.handleSubmit = function(e) {
     method: 'POST',
     url: this.url,
     data: JSON.stringify(data),
-    contentType: 'application/json'
+    contentType: 'application/json',
+    dataType: 'json'
   });
 
   promise.done(this.handleSuccess.bind(this));

--- a/tests/unit/modules/download.js
+++ b/tests/unit/modules/download.js
@@ -134,7 +134,8 @@ describe('DownloadItem', function() {
         method: 'POST',
         url: this.item.apiUrl,
         data: JSON.stringify({filename: this.item.filename}),
-        contentType: 'application/json'
+        contentType: 'application/json',
+        dataType: 'html'
       });
     });
 


### PR DESCRIPTION
**MERGE WITH GIT FLOW**

This changeset addresses the jQuery vulnerability we encountered a bit further by ensuring that a dataType parameter is set on our ajax requests.  We cannot do an upgrade to the 3.x series of jQuery just yet, so to help mitigate any potential threat we are ensuring our requests do not accept scripts to be executed.  We will update jQuery to the latest release in the near future after we have had a bit more time to test the changes and address any compatability issues.