### PR TITLE
Remove purpose of disbursement and add itemized tables

### DIFF
--- a/openfecwebapp/templates/partials/candidate/individual-contributions.html
+++ b/openfecwebapp/templates/partials/candidate/individual-contributions.html
@@ -48,11 +48,11 @@
 
           <label for="toggle-state">
             <input id="toggle-state" type="radio" class="panel-toggle-control" name="individual-contributions" value="contributor-state" checked />
-            <span class="button--alt">Contributor state</span>
+            <span class="button--alt">State</span>
           </label>
           <label for="toggle-size">
             <input id="toggle-size" type="radio" class="panel-toggle-control" name="individual-contributions" value="contribution-size" />
-            <span class="button--alt">Contribution size</span>
+            <span class="button--alt">Size</span>
           </label>
           <label for="toggle-all">
             <input id="toggle-all" type="radio" class="panel-toggle-control" name="individual-contributions" value="all-transactions" />

--- a/openfecwebapp/templates/partials/committee/disbursements.html
+++ b/openfecwebapp/templates/partials/committee/disbursements.html
@@ -9,13 +9,13 @@
       <div class="row">
         <fieldset class="toggles u-float-left">
           <legend class="label">Group by:</legend>
-          <label for="toggle-purpose">
-            <input id="toggle-purpose" type="radio" class="panel-toggle-control" name="disbursement-aggregate" value="by-purpose" checked />
-            <span class="button--alt">Purpose</span>
-          </label>
           <label for="toggle-recipient">
-            <input id="toggle-recipient" type="radio" class="panel-toggle-control" name="disbursement-aggregate" value="by-recipient" />
+            <input id="toggle-recipient" type="radio" class="panel-toggle-control" name="disbursements" value="by-recipient" checked>
             <span class="button--alt">Recipient</span>
+          </label>
+          <label for="toggle-all-disbursements">
+            <input id="toggle-all-disbursements" type="radio" class="panel-toggle-control" name="disbursements" value="itemized-disbursements">
+            <span class="button--alt">All transactions</span>
           </label>
         </fieldset>
         <a class="u-float-right button--alt button--browse"
@@ -29,26 +29,7 @@
         </a>
       </div>
 
-      <div id="by-purpose" class="panel-toggle-element" aria-hidden="false">
-        <div class="results-info results-info--simple">
-          <h3 class="results-info__title">Disbursements by purpose</h3>
-          <button type="button" class="js-export button button--cta button--export" data-export-for="disbursements-by-purpose">Export</button>
-        </div>
-        <table
-            class="data-table data-table--heading-borders"
-            data-type="disbursements-by-purpose"
-            data-committee="{{ committee.committee_id }}"
-            data-cycle="{{ cycle }}"
-          >
-          <thead>
-            <th scope="col">Purpose</th>
-            <th scope="col">Total</th>
-          </thead>
-        </table>
-        {{ disclaimer.disclaimer('disbursements', committee.committee_id, cycle) }}
-      </div>
-
-      <div id="by-recipient" class="panel-toggle-element" aria-hidden="true">
+      <div id="by-recipient" class="panel-toggle-element" aria-hidden="false">
         <div class="results-info results-info--simple">
           <h3 class="results-info__title">Disbursements by recipient</h3>
           <button type="button" class="js-export button button--cta button--export" data-export-for="disbursements-by-recipient">Export</button>
@@ -65,6 +46,41 @@
           </thead>
         </table>
         {{ disclaimer.disclaimer('disbursements', committee.committee_id, cycle) }}
+      </div>
+
+      <div id="itemized-disbursements" class="panel-toggle-element" aria-hidden="true">
+        <div class="results-info results-info--simple">
+          <ul class="u-float-left">
+            <li class="tag__category">
+              <div class="tag__item">Report year: {{cycle - 1}} to {{cycle}}</div>
+            </li>
+          </ul>
+
+          <div class="js-tooltip-container u-float-right">
+            <button type="button" class="js-export button button--cta button--export" data-export-for="itemized-disbursements">Export</button>
+            <div id="export-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--right tooltip__content" aria-hidden="true">
+            </div>
+          </div>
+
+        </div>
+
+        <table
+            class="data-table data-table--heading-borders"
+            data-type="itemized-disbursements"
+            data-committee-id="{{ committee.committee_id }}"
+            data-name="{{ name }}"
+            data-cycle="{{ cycle }}"
+          >
+          <thead>
+            <tr>
+              <th scope="col">Recipient</th>
+              <th scope="col">Recipient state</th>
+              <th scope="col">Description</th>
+              <th scope="col">Date</th>
+              <th scope="col">Amount</th>
+            </tr>
+          </thead>
+        </table>
       </div>
     </div>
   </div>

--- a/openfecwebapp/templates/partials/committee/receipts.html
+++ b/openfecwebapp/templates/partials/committee/receipts.html
@@ -12,19 +12,23 @@
           <legend class="label">Group by:</legend>
           <label for="toggle-state">
             <input id="toggle-state" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-state" checked>
-            <span class="button--alt">Contributor state</span>
+            <span class="button--alt">State</span>
           </label>
           <label for="toggle-contribution-size">
             <input id="toggle-contribution-size" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-contribution-size">
-            <span class="button--alt">Contribution size</span>
+            <span class="button--alt">Size</span>
           </label>
           <label for="toggle-employer">
             <input id="toggle-employer" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-employer">
-            <span class="button--alt">Contributor employer</span>
+            <span class="button--alt">Employer</span>
           </label>
           <label for="toggle-occupation">
             <input id="toggle-occupation" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-occupation">
-            <span class="button--alt">Contributor occupation</span>
+            <span class="button--alt">Occupation</span>
+          </label>
+          <label for="toggle-itemized">
+            <input id="toggle-itemized" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="itemized-contributions">
+            <span class="button--alt">All transactions</span>
           </label>
         </fieldset>
         <a class="u-float-right button--alt button--browse"
@@ -114,6 +118,27 @@
             <thead>
               <th scope="col">Occupation</th>
               <th scope="col">Total contributed</th>
+            </thead>
+          </table>
+          {{ disclaimer.disclaimer('receipts', committee.committee_id, cycle) }}
+        </div>
+
+        <div id="itemized-contributions" class="panel-toggle-element" aria-hidden="true">
+          <div class="results-info results-info--simple">
+            <h3 class="results-info__title">All transactions</h3>
+            <button type="button" class="js-export button button--cta button--export" data-export-for="itemized-receipts">Export</button>
+          </div>
+          <table
+              class="data-table data-table--heading-borders"
+              data-type="itemized-receipts"
+              data-committee="{{ committee.committee_id }}"
+              data-cycle="{{ cycle }}"
+            >
+            <thead>
+              <th scope="col">Contributor name</th>
+              <th scope="col">Contributor state</th>
+              <th scope="col">Receipt date</th>
+              <th scope="col">Amount</th>
             </thead>
           </table>
           {{ disclaimer.disclaimer('receipts', committee.committee_id, cycle) }}

--- a/openfecwebapp/templates/partials/committee/receipts.html
+++ b/openfecwebapp/templates/partials/committee/receipts.html
@@ -141,7 +141,6 @@
               <th scope="col">Amount</th>
             </thead>
           </table>
-          {{ disclaimer.disclaimer('receipts', committee.committee_id, cycle) }}
         </div>
       </div>
     </div>

--- a/static/js/pages/candidate-single.js
+++ b/static/js/pages/candidate-single.js
@@ -322,6 +322,7 @@ function initContributionsTables() {
     path: ['schedules', 'schedule_a'],
     query: {
       committee_id: opts.committee_id,
+      is_individual: true,
       two_year_transaction_period: opts.cycle
     },
     columns: individualContributionsColumns,

--- a/static/js/pages/candidate-single.js
+++ b/static/js/pages/candidate-single.js
@@ -22,7 +22,10 @@ var filingsColumns = [
     orderable: false
   }),
   columns.amendmentIndicatorColumn,
-  columns.dateColumn({data: 'receipt_date', className: 'min-tablet'}),
+  columns.dateColumn({
+    data: 'receipt_date',
+    className: 'min-tablet'
+  }),
 ];
 
 var expenditureColumns = [
@@ -32,13 +35,16 @@ var expenditureColumns = [
     orderable: true,
     orderSequence: ['desc', 'asc'],
     render: columnHelpers.buildTotalLink(['independent-expenditures'], function(data, type, row) {
-        return {
-          support_oppose_indicator: row.support_oppose_indicator,
-          candidate_id: row.candidate_id,
-        };
+      return {
+        support_oppose_indicator: row.support_oppose_indicator,
+        candidate_id: row.candidate_id,
+      };
     })
   },
-  columns.committeeColumn({data: 'committee', className: 'all'}),
+  columns.committeeColumn({
+    data: 'committee',
+    className: 'all'
+  }),
   columns.supportOpposeColumn
 ];
 
@@ -49,13 +55,16 @@ var communicationCostColumns = [
     orderable: true,
     orderSequence: ['desc', 'asc'],
     render: columnHelpers.buildTotalLink(['communication-costs'], function(data, type, row) {
-        return {
-          support_oppose_indicator: row.support_oppose_indicator,
-          candidate_id: row.candidate_id,
-        };
+      return {
+        support_oppose_indicator: row.support_oppose_indicator,
+        candidate_id: row.candidate_id,
+      };
     })
   },
-  columns.committeeColumn({data: 'committee', className: 'all'}),
+  columns.committeeColumn({
+    data: 'committee',
+    className: 'all'
+  }),
   columns.supportOpposeColumn
 ];
 
@@ -67,10 +76,15 @@ var electioneeringColumns = [
     orderSequence: ['desc', 'asc'],
     render: columnHelpers.buildTotalLink(['electioneering-communications'],
       function(data, type, row) {
-        return {candidate_id: row.candidate_id};
-    })
+        return {
+          candidate_id: row.candidate_id
+        };
+      })
   },
-  columns.committeeColumn({data: 'committee', className: 'all'})
+  columns.committeeColumn({
+    data: 'committee',
+    className: 'all'
+  })
 ];
 
 var otherDocumentsColumns = [
@@ -87,9 +101,8 @@ var otherDocumentsColumns = [
       var version = helpers.amendmentVersion(data);
       if (version === 'Version unknown') {
         return '<i class="icon-blank"></i>Version unknown<br>' +
-               '<i class="icon-blank"></i>' + row.fec_file_id;
-      }
-      else {
+          '<i class="icon-blank"></i>' + row.fec_file_id;
+      } else {
         if (row.fec_file_id !== null) {
           version = version + '<br><i class="icon-blank"></i>' + row.fec_file_id;
         }
@@ -97,7 +110,10 @@ var otherDocumentsColumns = [
       }
     }
   },
-  columns.dateColumn({data: 'receipt_date', className: 'min-tablet'})
+  columns.dateColumn({
+    data: 'receipt_date',
+    className: 'min-tablet'
+  })
 ];
 
 var itemizedDisbursementColumns = [
@@ -129,7 +145,10 @@ var itemizedDisbursementColumns = [
     orderable: false,
     defaultContent: 'NOT REPORTED'
   },
-  columns.dateColumn({data: 'disbursement_date', className: 'min-tablet'}),
+  columns.dateColumn({
+    data: 'disbursement_date',
+    className: 'min-tablet'
+  }),
   columns.currencyColumn({
     data: 'disbursement_amount',
     className: 'column--number'
@@ -154,7 +173,10 @@ var individualContributionsColumns = [
       );
     }
   },
-  columns.dateColumn({data: 'contribution_receipt_date', className: 'min-tablet'}),
+  columns.dateColumn({
+    data: 'contribution_receipt_date',
+    className: 'min-tablet'
+  }),
   columns.currencyColumn({
     data: 'contribution_receipt_amount',
     className: 'column--number'
@@ -360,20 +382,20 @@ function initContributionsTables() {
         return span.outerHTML;
       }
     },
-    {
-      data: 'total',
-      width: '50%',
-      className: 'all',
-      orderSequence: ['desc', 'asc'],
-      render: columnHelpers.buildTotalLink(['receipts', 'individual-contributions'],
-        function(data, type, row) {
-          return {
-            contributor_state: row.state,
-            committee_id: opts.committee_id
-          };
-        }
-      )
-    }],
+      {
+        data: 'total',
+        width: '50%',
+        className: 'all',
+        orderSequence: ['desc', 'asc'],
+        render: columnHelpers.buildTotalLink(['receipts', 'individual-contributions'],
+          function(data, type, row) {
+            return {
+              contributor_state: row.state,
+              committee_id: opts.committee_id
+            };
+          }
+        )
+      }],
     callbacks: aggregateCallbacks,
     aggregateExport: true,
     dom: 't',
@@ -399,20 +421,20 @@ function initContributionsTables() {
         return columnHelpers.sizeInfo[data].label;
       }
     },
-    {
-      data: 'total',
-      width: '50%',
-      className: 'all',
-      orderSequence: ['desc', 'asc'],
-      orderable: false,
-      render: columnHelpers.buildTotalLink(['receipts', 'individual-contributions'],
-        function(data, type, row) {
-          var params = columnHelpers.getSizeParams(row.size);
-          params.committee_id = opts.committee_id;
-          return params;
-        }
-      )
-    }],
+      {
+        data: 'total',
+        width: '50%',
+        className: 'all',
+        orderSequence: ['desc', 'asc'],
+        orderable: false,
+        render: columnHelpers.buildTotalLink(['receipts', 'individual-contributions'],
+          function(data, type, row) {
+            var params = columnHelpers.getSizeParams(row.size);
+            params.committee_id = opts.committee_id;
+            return params;
+          }
+        )
+      }],
     callbacks: aggregateCallbacks,
     dom: 't',
     order: false,

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -100,7 +100,12 @@ var stateColumns = [
 ];
 
 var employerColumns = [
-  {data: 'employer', className: 'all', orderable: false, defaultContent: 'NOT REPORTED'},
+  {
+    data: 'employer',
+    className: 'all',
+    orderable: false,
+    defaultContent: 'NOT REPORTED'
+  },
   {
     data: 'total',
     className: 'all',
@@ -119,7 +124,12 @@ var employerColumns = [
 ];
 
 var occupationColumns = [
-  {data: 'occupation', className: 'all', orderable: false, defaultContent: 'NOT REPORTED'},
+  {
+    data: 'occupation',
+    className: 'all',
+    orderable: false,
+    defaultContent: 'NOT REPORTED'
+  },
   {
     data: 'total',
     className: 'all',
@@ -137,28 +147,21 @@ var occupationColumns = [
   }
 ];
 
-var disbursementPurposeColumns = [
-  {data: 'purpose', className: 'all', orderable: false},
-  {
-    data: 'total',
-    className: 'all',
-    orderable: false,
-    orderSequence: ['desc', 'asc'],
-    render: columnHelpers.buildTotalLink(['disbursements'], function(data, type, row, meta) {
-      return {disbursement_purpose_categories: row.purpose.toLowerCase()};
-    })
-  }
-];
-
 var disbursementRecipientColumns = [
-  {data: 'recipient_name', className: 'all', orderable: false},
+  {
+    data: 'recipient_name',
+    className: 'all',
+    orderable: false
+  },
   {
     data: 'total',
     className: 'all',
     orderable: false,
     orderSequence: ['desc', 'asc'],
     render: columnHelpers.buildTotalLink(['disbursements'], function(data, type, row, meta) {
-      return {recipient_name: row.recipient_name};
+      return {
+        recipient_name: row.recipient_name
+      };
     })
   }
 ];
@@ -182,7 +185,9 @@ var disbursementRecipientIDColumns = [
     orderable: false,
     orderSequence: ['desc', 'asc'],
     render: columnHelpers.buildTotalLink(['disbursements'], function(data, type, row, meta) {
-      return {recipient_name: row.recipient_id};
+      return {
+        recipient_name: row.recipient_id
+      };
     })
   }
 ];
@@ -197,12 +202,15 @@ var expendituresColumns = [
       return {
         support_oppose_indicator: row.support_oppose_indicator,
         candidate_id: row.candidate_id,
-        // is_notice: false,
+      // is_notice: false,
       };
     })
   },
   columns.supportOpposeColumn,
-  columns.candidateColumn({data: 'candidate', className: 'all'})
+  columns.candidateColumn({
+    data: 'candidate',
+    className: 'all'
+  })
 ];
 
 var electioneeringColumns = [
@@ -218,7 +226,10 @@ var electioneeringColumns = [
       };
     })
   },
-  columns.candidateColumn({data: 'candidate', className: 'all'})
+  columns.candidateColumn({
+    data: 'candidate',
+    className: 'all'
+  })
 ];
 
 var communicationCostColumns = [
@@ -235,8 +246,60 @@ var communicationCostColumns = [
     })
   },
   columns.supportOpposeColumn,
-  columns.candidateColumn({data: 'candidate', className: 'all'})
+  columns.candidateColumn({
+    data: 'candidate',
+    className: 'all'
+  })
 ];
+
+var itemizedDisbursementColumns = [
+  {
+    data: 'recipient_name',
+    className: 'all',
+    orderable: false,
+  },
+  {
+    data: 'recipient_state',
+    className: 'min-tablet hide-panel',
+    orderable: false,
+  },
+  {
+    data: 'disbursement_description',
+    className: 'all',
+    orderable: false,
+    defaultContent: 'NOT REPORTED'
+  },
+  columns.dateColumn({
+    data: 'disbursement_date',
+    className: 'min-tablet'
+  }),
+  columns.currencyColumn({
+    data: 'disbursement_amount',
+    className: 'column--number'
+  }),
+];
+
+var individualContributionsColumns = [
+  {
+    data: 'contributor_name',
+    className: 'all',
+    orderable: false,
+  },
+  {
+    data: 'contributor_state',
+    className: 'all',
+    orderable: false,
+  },
+  columns.dateColumn({
+    data: 'contribution_receipt_date',
+    className: 'min-tablet'
+  }),
+  columns.currencyColumn({
+    data: 'contribution_receipt_amount',
+    className: 'column--number'
+  }),
+];
+
 
 var aggregateCallbacks = {
   afterRender: tables.barsAfterRender.bind(undefined, undefined),
@@ -262,7 +325,9 @@ $(document).ready(function() {
     var $table = $(table);
     var committeeId = $table.attr('data-committee');
     var cycle = $table.attr('data-cycle');
-    var query = {cycle: cycle};
+    var query = {
+      cycle: cycle
+    };
     var path;
     var opts;
     var filingsOpts = {
@@ -271,257 +336,294 @@ $(document).ready(function() {
       dom: '<"panel__main"t><"results-info"frlpi>',
       pagingType: 'simple',
       lengthMenu: [100, 10],
-      drawCallback: function () {
+      drawCallback: function() {
         this.dropdowns = $table.find('.dropdown').map(function(idx, elm) {
-          return new dropdown.Dropdown($(elm), {checkboxes: false});
+          return new dropdown.Dropdown($(elm), {
+            checkboxes: false
+          });
         });
       }
     };
     switch ($table.attr('data-type')) {
-    case 'committee-contributor':
-      path = ['schedules', 'schedule_b', 'by_recipient_id'];
-      tables.DataTable.defer($table, {
-        path: path,
-        query: _.extend({recipient_id: committeeId}, query),
-        columns: committeeColumns,
-        callbacks: aggregateCallbacks,
-        dom: tables.simpleDOM,
-        order: [[1, 'desc']],
-        pagingType: 'simple',
-        lengthChange: true,
-        pageLength: 10,
-        lengthMenu: [10, 50, 100],
-        aggregateExport: true,
-        hideEmpty: true,
-        hideEmptyOpts: {
-          dataType: 'disbursements received from other committees',
-          name: context.name,
-          timePeriod: context.timePeriod
-        }
-      });
-      break;
-    case 'contribution-size':
-      path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_size'];
-      tables.DataTable.defer($table, {
-        path: path,
-        query: query,
-        columns: sizeColumns,
-        callbacks: aggregateCallbacks,
-        dom: 't',
-        order: false,
-        pagingType: 'simple',
-        lengthChange: false,
-        pageLength: 10,
-        aggregateExport: true,
-        hideEmpty: true,
-        hideEmptyOpts: {
-          dataType: 'individual contributions',
-          name: context.name,
-          timePeriod: context.timePeriod
-        }
-      });
-      break;
-    case 'receipts-by-state':
-      path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_state'];
-      query = _.extend(query, {per_page: 99});
-      tables.DataTable.defer($table, {
-        path: path,
-        query: query,
-        columns: stateColumns,
-        callbacks: aggregateCallbacks,
-        aggregateExport: true,
-        dom: 't',
-        order: [[1, 'desc']],
-        paging: false,
-        scrollY: 400,
-        scrollCollapse: true
-      });
-
-      $mapTable = $table;
-
-      break;
-    case 'receipts-by-employer':
-      path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_employer'];
-      tables.DataTable.defer(
-        $table,
-        _.extend({}, tableOpts, {
+      case 'committee-contributor':
+        path = ['schedules', 'schedule_b', 'by_recipient_id'];
+        tables.DataTable.defer($table, {
+          path: path,
+          query: _.extend({
+            recipient_id: committeeId
+          }, query),
+          columns: committeeColumns,
+          callbacks: aggregateCallbacks,
+          dom: tables.simpleDOM,
+          order: [[1, 'desc']],
+          pagingType: 'simple',
+          lengthChange: true,
+          pageLength: 10,
+          lengthMenu: [10, 50, 100],
+          aggregateExport: true,
+          hideEmpty: true,
+          hideEmptyOpts: {
+            dataType: 'disbursements received from other committees',
+            name: context.name,
+            timePeriod: context.timePeriod
+          }
+        });
+        break;
+      case 'contribution-size':
+        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_size'];
+        tables.DataTable.defer($table, {
           path: path,
           query: query,
-          columns: employerColumns,
+          columns: sizeColumns,
           callbacks: aggregateCallbacks,
-          order: [[1, 'desc']],
+          dom: 't',
+          order: false,
+          pagingType: 'simple',
+          lengthChange: false,
+          pageLength: 10,
+          aggregateExport: true,
+          hideEmpty: true,
           hideEmptyOpts: {
             dataType: 'individual contributions',
             name: context.name,
             timePeriod: context.timePeriod
-          },
-        })
-      );
-      break;
-    case 'receipts-by-occupation':
-      path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_occupation'];
-      tables.DataTable.defer(
-        $table,
-        _.extend({}, tableOpts, {
+          }
+        });
+        break;
+      case 'receipts-by-state':
+        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_state'];
+        query = _.extend(query, {
+          per_page: 99
+        });
+        tables.DataTable.defer($table, {
           path: path,
           query: query,
-          columns: occupationColumns,
+          columns: stateColumns,
           callbacks: aggregateCallbacks,
+          aggregateExport: true,
+          dom: 't',
           order: [[1, 'desc']],
+          paging: false,
+          scrollY: 400,
+          scrollCollapse: true
+        });
+
+        $mapTable = $table;
+
+        break;
+      case 'receipts-by-employer':
+        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_employer'];
+        tables.DataTable.defer(
+          $table,
+          _.extend({}, tableOpts, {
+            path: path,
+            query: query,
+            columns: employerColumns,
+            callbacks: aggregateCallbacks,
+            order: [[1, 'desc']],
+            hideEmptyOpts: {
+              dataType: 'individual contributions',
+              name: context.name,
+              timePeriod: context.timePeriod
+            },
+          })
+        );
+        break;
+      case 'receipts-by-occupation':
+        path = ['committee', committeeId, 'schedules', 'schedule_a', 'by_occupation'];
+        tables.DataTable.defer(
+          $table,
+          _.extend({}, tableOpts, {
+            path: path,
+            query: query,
+            columns: occupationColumns,
+            callbacks: aggregateCallbacks,
+            order: [[1, 'desc']],
+            hideEmptyOpts: {
+              dataType: 'individual contributions',
+              name: context.name,
+              timePeriod: context.timePeriod
+            },
+          })
+        );
+        break;
+      case 'itemized-receipts':
+        path = ['schedules', 'schedule_a'];
+        tables.DataTable.defer(
+          $table,
+          _.extend({}, tableOpts, {
+            path: path,
+            query: {
+              committee_id: committeeId,
+              two_year_transaction_period: cycle,
+              is_individual: true,
+            },
+            columns: individualContributionsColumns,
+            callbacks: aggregateCallbacks,
+            order: [[2, 'desc']],
+            hideEmptyOpts: {
+              dataType: 'disbursements to committees',
+              name: context.name,
+              timePeriod: context.timePeriod
+            },
+          })
+        );
+        break;
+      case 'disbursements-by-recipient':
+        path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_recipient'];
+        tables.DataTable.defer(
+          $table,
+          _.extend({}, tableOpts, {
+            path: path,
+            query: query,
+            columns: disbursementRecipientColumns,
+            callbacks: aggregateCallbacks,
+            order: [[1, 'desc']],
+            hideEmptyOpts: {
+              dataType: 'disbursements',
+              name: context.name,
+              timePeriod: context.timePeriod
+            },
+          })
+        );
+        break;
+      case 'itemized-disbursements':
+        path = ['schedules', 'schedule_b'];
+        tables.DataTable.defer(
+          $table,
+          _.extend({}, tableOpts, {
+            path: path,
+            query: {
+              committee_id: committeeId,
+              two_year_transaction_period: cycle
+            },
+            columns: itemizedDisbursementColumns,
+            callbacks: aggregateCallbacks,
+            order: [[3, 'desc']],
+            hideEmptyOpts: {
+              dataType: 'disbursements to committees',
+              name: context.name,
+              timePeriod: context.timePeriod
+            },
+          })
+        );
+        break;
+      case 'disbursements-by-recipient-id':
+        path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_recipient_id'];
+        tables.DataTable.defer(
+          $table,
+          _.extend({}, tableOpts, {
+            path: path,
+            query: query,
+            columns: disbursementRecipientIDColumns,
+            callbacks: aggregateCallbacks,
+            order: [[1, 'desc']],
+            hideEmptyOpts: {
+              dataType: 'disbursements to committees',
+              name: context.name,
+              timePeriod: context.timePeriod
+            },
+          })
+        );
+        break;
+      case 'independent-expenditure-committee':
+        path = ['committee', committeeId, 'schedules', 'schedule_e', 'by_candidate'];
+        tables.DataTable.defer($table, {
+          path: path,
+          query: query,
+          columns: expendituresColumns,
+          order: [[0, 'desc']],
+          dom: tables.simpleDOM,
+          pagingType: 'simple',
+          hideEmpty: true,
           hideEmptyOpts: {
-            dataType: 'individual contributions',
+            dataType: 'independent expenditures',
             name: context.name,
             timePeriod: context.timePeriod
           },
-        })
-      );
-      break;
-    case 'disbursements-by-purpose':
-      path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_purpose'];
-      tables.DataTable.defer(
-        $table,
-        _.extend({}, tableOpts, {
+        });
+        break;
+      case 'electioneering-committee':
+        path = ['committee', committeeId, 'electioneering', 'by_candidate'];
+        tables.DataTable.defer($table, {
           path: path,
           query: query,
-          columns: disbursementPurposeColumns,
-          callbacks: aggregateCallbacks,
-          order: [[1, 'desc']],
+          columns: electioneeringColumns,
+          order: [[0, 'desc']],
+          dom: tables.simpleDOM,
+          pagingType: 'simple',
+          hideEmpty: true,
           hideEmptyOpts: {
-            dataType: 'disbursements',
+            dataType: 'electioneering communications',
             name: context.name,
             timePeriod: context.timePeriod
           },
-        })
-      );
-      break;
-    case 'disbursements-by-recipient':
-      path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_recipient'];
-      tables.DataTable.defer(
-        $table,
-        _.extend({}, tableOpts, {
+        });
+        break;
+      case 'communication-cost-committee':
+        path = ['committee', committeeId, 'communication_costs', 'by_candidate'];
+        tables.DataTable.defer($table, {
           path: path,
           query: query,
-          columns: disbursementRecipientColumns,
-          callbacks: aggregateCallbacks,
-          order: [[1, 'desc']],
+          columns: communicationCostColumns,
+          order: [[0, 'desc']],
+          dom: tables.simpleDOM,
+          pagingType: 'simple',
+          hideEmpty: true,
           hideEmptyOpts: {
-            dataType: 'disbursements',
+            dataType: 'communication costs',
             name: context.name,
             timePeriod: context.timePeriod
           },
-        })
-      );
-      break;
-    case 'disbursements-by-recipient-id':
-      path = ['committee', committeeId, 'schedules', 'schedule_b', 'by_recipient_id'];
-      tables.DataTable.defer(
-        $table,
-        _.extend({}, tableOpts, {
-          path: path,
-          query: query,
-          columns: disbursementRecipientIDColumns,
-          callbacks: aggregateCallbacks,
-          order: [[1, 'desc']],
-          hideEmptyOpts: {
-            dataType: 'disbursements to committees',
-            name: context.name,
-            timePeriod: context.timePeriod
-          },
-        })
-      );
-      break;
-    case 'independent-expenditure-committee':
-      path = ['committee', committeeId, 'schedules', 'schedule_e', 'by_candidate'];
-      tables.DataTable.defer($table, {
-        path: path,
-        query: query,
-        columns: expendituresColumns,
-        order: [[0, 'desc']],
-        dom: tables.simpleDOM,
-        pagingType: 'simple',
-        hideEmpty: true,
-        hideEmptyOpts: {
-          dataType: 'independent expenditures',
-          name: context.name,
-          timePeriod: context.timePeriod
-        },
-      });
-      break;
-    case 'electioneering-committee':
-      path = ['committee', committeeId, 'electioneering', 'by_candidate'];
-      tables.DataTable.defer($table, {
-        path: path,
-        query: query,
-        columns: electioneeringColumns,
-        order: [[0, 'desc']],
-        dom: tables.simpleDOM,
-        pagingType: 'simple',
-        hideEmpty: true,
-        hideEmptyOpts: {
-          dataType: 'electioneering communications',
-          name: context.name,
-          timePeriod: context.timePeriod
-        },
-      });
-      break;
-    case 'communication-cost-committee':
-      path = ['committee', committeeId, 'communication_costs', 'by_candidate'];
-      tables.DataTable.defer($table, {
-        path: path,
-        query: query,
-        columns: communicationCostColumns,
-        order: [[0, 'desc']],
-        dom: tables.simpleDOM,
-        pagingType: 'simple',
-        hideEmpty: true,
-        hideEmptyOpts: {
-          dataType: 'communication costs',
-          name: context.name,
-          timePeriod: context.timePeriod
-        },
-      });
-      break;
-    case 'filings-reports':
-      opts = _.extend({
-        columns: filingsReportsColumns,
-        path: ['committee', committeeId, 'filings'],
-        query: _.extend({
+        });
+        break;
+      case 'filings-reports':
+        opts = _.extend({
+          columns: filingsReportsColumns,
+          path: ['committee', committeeId, 'filings'],
+          query: _.extend({
             form_type: ['F3', 'F3X', 'F3P', 'F3L', 'F4', 'F7', 'F13', 'RFAI'],
             sort: ['-coverage_end_date', 'report_type_full', '-beginning_image_number']
           }, query),
-        callbacks: {
-          afterRender: filings.renderModal
-        }
-      }, filingsOpts);
-      tables.DataTable.defer($table, opts);
-      break;
-    case 'filings-notices':
-      opts = _.extend({
-        columns: filingsColumns,
-        order: [[2, 'desc']],
-        path: ['committee', committeeId, 'filings'],
-        query: _.extend({form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11']}, query),
-      }, filingsOpts);
-      tables.DataTable.defer($table, opts);
-      break;
-    case 'filings-statements':
-      opts = _.extend({
-        columns: filingsColumns,
-        order: [[2, 'desc']],
-        path: ['committee', committeeId, 'filings'],
-        query: _.extend({form_type: ['F1']}, query),
-      }, filingsOpts);
-      tables.DataTable.defer($table, opts);
-      break;
-    case 'filings-other':
-      opts = _.extend({
-        columns: filingsColumns,
-        order: [[2, 'desc']],
-        path: ['committee', committeeId, 'filings'],
-        query: _.extend({form_type: ['F1M', 'F8', 'F99', 'F12']}, query),
-      }, filingsOpts);
-      tables.DataTable.defer($table, opts);
-      break;
+          callbacks: {
+            afterRender: filings.renderModal
+          }
+        }, filingsOpts);
+        tables.DataTable.defer($table, opts);
+        break;
+      case 'filings-notices':
+        opts = _.extend({
+          columns: filingsColumns,
+          order: [[2, 'desc']],
+          path: ['committee', committeeId, 'filings'],
+          query: _.extend({
+            form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11']
+          }, query),
+        }, filingsOpts);
+        tables.DataTable.defer($table, opts);
+        break;
+      case 'filings-statements':
+        opts = _.extend({
+          columns: filingsColumns,
+          order: [[2, 'desc']],
+          path: ['committee', committeeId, 'filings'],
+          query: _.extend({
+            form_type: ['F1']
+          }, query),
+        }, filingsOpts);
+        tables.DataTable.defer($table, opts);
+        break;
+      case 'filings-other':
+        opts = _.extend({
+          columns: filingsColumns,
+          order: [[2, 'desc']],
+          path: ['committee', committeeId, 'filings'],
+          query: _.extend({
+            form_type: ['F1M', 'F8', 'F99', 'F12']
+          }, query),
+        }, filingsOpts);
+        tables.DataTable.defer($table, opts);
+        break;
     }
   });
 


### PR DESCRIPTION
Because the "purpose of disbursement" aggregate logic is unreliable, @PaulClark2 [requested](https://github.com/18F/openFEC/issues/1833#issuecomment-291473162) disabling those tables on committee pages for now, so this PR does that.

I also took the opportunity to add a feature from the original designs that we just hadn't gotten to yet: adding the tables of itemized contributions and disbursements:

![image](https://cloud.githubusercontent.com/assets/1696495/24669985/46e6af32-1921-11e7-9d6c-3384e26b3596.png)

![image](https://cloud.githubusercontent.com/assets/1696495/24669977/3ea71640-1921-11e7-8ace-5f5a9a1b90b9.png)
