### PR TITLE
Adding conditionals for cases when candidates don't have totals

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -236,8 +236,8 @@ def load_candidate_totals(candidate_id, cycle, election_full=True):
         'candidate', candidate_id, 'totals',
         cycle=cycle, election_full=election_full,
     )
-    
-    return response['results'][0] if 'results' in response else None
+
+    return response['results'][0] if response['results'] else None
 
 
 def load_candidate_statement_of_candidacy(candidate_id, cycle):

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -234,9 +234,10 @@ def render_candidate(candidate, committees, cycle, election_full=True):
 
     tmpl_vars['cycles'] = [cycle for cycle in candidate['cycles'] if cycle <= max(candidate['election_years'])]
 
-    tmpl_vars['raising_summary'] = utils.process_raising_data(aggregate)
-    tmpl_vars['spending_summary'] = utils.process_spending_data(aggregate)
-    tmpl_vars['cash_summary'] = utils.process_cash_data(aggregate)
+    if aggregate:
+        tmpl_vars['raising_summary'] = utils.process_raising_data(aggregate)
+        tmpl_vars['spending_summary'] = utils.process_spending_data(aggregate)
+        tmpl_vars['cash_summary'] = utils.process_cash_data(aggregate)
 
     return render_template('candidates-single.html', **tmpl_vars)
 


### PR DESCRIPTION
This fixes the conditional logic when rendering candidate pages so the pages don't break if the candidate doesn't have financial totals for the selected cycle.

To verify, make sure this page works: http://localhost:3000/candidate/P80001571/?election_full=true&cycle=2020