### PR TITLE
Fixes an issue for candidates who ran in odd years

### DIFF
--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -87,8 +87,16 @@ def candidate_page(c_id, cycle=None, election_full=True):
             ),
             max(candidate['election_years']),
         )
+
+        # If the next_cycle is odd set it to whatever the cycle value was
+        # and then set election_full to false
+        # This solves an issue with special elections 
+        if next_cycle % 2 > 0:
+            next_cycle = cycle
+            election_full = False
+
         return redirect(
-            url_for('candidate_page', c_id=c_id, cycle=next_cycle, election_full='true')
+            url_for('candidate_page', c_id=c_id, cycle=next_cycle, election_full=election_full)
         )
 
     return views.render_candidate(candidate, committees, cycle, election_full)


### PR DESCRIPTION
This fixes the issue of 404s for candidates who ran for special elections in odd years. It adds a check for trying to set `next_cycle` to an odd value, and if so, falls back to the `cycle`, which corresponds to the two-year period for which the committee has financial activity. It then also sets `election_full` to false. 

This makes sense in these cases and fixes the reported bugs with Ossof and Halvorsen, but paging @LindsayYoung to double-check my logic here. 