### PR TITLE
Fix/pending aos

### DIFF
--- a/openfecwebapp/templates/legal-advisory-opinions-landing.html
+++ b/openfecwebapp/templates/legal-advisory-opinions-landing.html
@@ -55,7 +55,7 @@
   <div class="post-feed">
     {% for ao in pending_aos %}
       <article class="post">
-        <h3 class="pending-ao__title"><a href="{{ url_for('advisory_opinion_page', ao_no=ao.no) }}">{{ ao.name }}</a></h3>
+        <h3 class="pending-ao__title"><a href="{{ url_for('advisory_opinion_page', ao_no=ao.no) }}">AO {{ ao.no }} {{ ao.name }}</a></h3>
         <p class="t-sans">{{ ao.summary }}</p>
         <!-- <p>Deadline for comments: {{ ao.deadline }}</p> -->
       </article>

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -79,13 +79,22 @@ def render_legal_mur(mur):
 def render_legal_ao_landing():
     today = datetime.date.today()
     ao_min_date = today - datetime.timedelta(weeks=26)
-    ao_results = api_caller.load_legal_search_results(query='', query_type='advisory_opinions', ao_min_date=ao_min_date)
-    pending_aos = api_caller.load_legal_search_results(query='', query_type='advisory_opinions', ao_is_pending=True)
+    recent_aos = api_caller.load_legal_search_results(
+        query='',
+        query_type='advisory_opinions',
+        ao_min_date=ao_min_date
+    )
+    pending_aos = api_caller.load_legal_search_results(
+        query='',
+        query_type='advisory_opinions',
+        ao_category='R',
+        ao_is_pending=True
+    )
     return render_template('legal-advisory-opinions-landing.html',
         parent='legal',
         result_type='advisory_opinions',
         display_name='advisory opinions',
-        recent_aos=ao_results['advisory_opinions'],
+        recent_aos=recent_aos['advisory_opinions'],
         pending_aos=pending_aos['advisory_opinions'])
 
 


### PR DESCRIPTION
Adds `ao_category` to the API call to show pending AOs on the AO landing page. 

![image](https://cloud.githubusercontent.com/assets/1696495/25027676/5e7728cc-2063-11e7-9a5d-9fe840733009.png)
