### PR TITLE
Feature/ao entities

### DIFF
--- a/openfecwebapp/templates/legal-advisory-opinion.html
+++ b/openfecwebapp/templates/legal-advisory-opinion.html
@@ -32,17 +32,14 @@
       </div>
       <div class="main__content--right">
         <section id="summary" class="content__section">
-          <div id="advisory-opinion-summary" class="main__content">
-            <p>
-              {{ advisory_opinion.summary }}
-            </p>
-          </div>
+          <h2>Summary</h2>
+          <p>{{ advisory_opinion.summary }}</p>
         </section>
         <section id="documents" class="content__section">
           <h2>Documents</h2>
           {% if final_opinion %}
             <div class="content__section">
-              <a class="button button--cta button--document button--lg" href="{{ final_opinion.url }}">Final Opinion</a> <span class="t-sans">{{ final_opinion.date | date(fmt='%B %d, %Y') }}</span>
+              <a class="button button--cta button--document button--lg" href="{{ final_opinion.url }}">Final opinion</a> <span class="t-sans u-padding--left">{{ final_opinion.date | date(fmt='%B %d, %Y') }}</span>
             </div>
           {% endif %}
           <table class="data-table simple-table" style="table-layout: auto;">

--- a/openfecwebapp/templates/legal-advisory-opinion.html
+++ b/openfecwebapp/templates/legal-advisory-opinion.html
@@ -17,101 +17,117 @@
       <h1>AO {{ advisory_opinion.no }}</h1>
       <span class="heading__subtitle">{{ advisory_opinion.name }}</span>
     </header>
-    <section class="content__section">
-      <div id="advisory-opinion-summary" class="main__content">
-        <p>
-          {{ advisory_opinion.summary }}
-        </p>
-      </div>
-    </section>
-    <section class="content__section">
-      <h2>Documents</h2>
-      {% if final_opinion %}
-        <div class="content__section">
-          <a class="button button--cta button--document button--lg" href="{{ final_opinion.url }}">Final Opinion</a> <span class="t-sans">{{ final_opinion.date | date(fmt='%B %d, %Y') }}</span>
+    <div class="row" id="sections">
+      <div class="sidebar-container sidebar-container--left">
+        <div class="js-sticky-side" data-sticky-container="sections">
+          <nav class="sidebar sidebar--neutral sidebar--left side-nav js-toc">
+            <ul class="sidebar__content">
+              <li class="side-nav__item"><a class="side-nav__link" href="#summary">Summary</a></li>
+              <li class="side-nav__item"><a class="side-nav__link" href="#documents">Documents</a></li>
+              <li class="side-nav__item"><a class="side-nav__link" href="#entities">Entities</a></li>
+              <li class="side-nav__item"><a class="side-nav__link" href="#legal-citations">Legal citations</a></li>
+            </ul>
+          </nav>
         </div>
-      {% endif %}
-      <table class="data-table simple-table">
-        <thead>
-          <tr>
-            <th scope="col" class="cell--20">Date</th>
-            <th scope="col">Name</th>
-            <th scope="col">Document type</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for document in advisory_opinion.documents %}
-            <tr>
-              <td>{{ document.date | date }}</td>
-              <td><a href="{{ document.url }}">{{ document.description }}</a></td>
-              <td>{{ document.category }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </section>
-    <section class="content__section">
-      <h2>Entities</h2>
-      <table class="data-table simple-table">
-        <thead>
-          <tr>
-            <th scope="col" class="cell--20">Role</th>
-            <th scope="col">Name</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for entity in advisory_opinion.requestor_names %}
-            <tr>
-              <td>Requestor</td>
-              <td>{{ entity }}</td>
-            </tr>
-          {% endfor %}
-          {% for entity in advisory_opinion.representative_names %}
-            <tr>
-              <td>Counsel/representative</td>
-              <td>{{ entity }}</td>
-            </tr>
-          {% endfor %}
-          {% for entity in advisory_opinion.commenter_names %}
-            <tr>
-              <td>Commenter</td>
-              <td>{{ entity }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </section>
-    <section class="content__section">
-      <aside id="legal-citations" class="sidebar sidebar--primary">
-          <h4 class="sidebar__title">Legal citations</h4>
-          <div class="sidebar__content">
-            <div class="grid grid--2-wide">
-                <div class="grid__item">
-                  <p class="t-bold">This opinion cites these earlier opinions</p>
-                  <div class="rich-text">
-                    {% if advisory_opinion.ao_citations %}
-                    {% for citation in advisory_opinion.ao_citations %}
+      </div>
+      <div class="main__content--right">
+        <section id="summary" class="content__section">
+          <div id="advisory-opinion-summary" class="main__content">
+            <p>
+              {{ advisory_opinion.summary }}
+            </p>
+          </div>
+        </section>
+        <section id="documents" class="content__section">
+          <h2>Documents</h2>
+          {% if final_opinion %}
+            <div class="content__section">
+              <a class="button button--cta button--document button--lg" href="{{ final_opinion.url }}">Final Opinion</a> <span class="t-sans">{{ final_opinion.date | date(fmt='%B %d, %Y') }}</span>
+            </div>
+          {% endif %}
+          <table class="data-table simple-table" style="table-layout: auto;">
+            <thead>
+              <tr>
+                <th scope="col">Date</th>
+                <th scope="col">Name</th>
+                <th scope="col">Document type</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for document in advisory_opinion.documents %}
+                <tr>
+                  <td>{{ document.date | date }}</td>
+                  <td><a href="{{ document.url }}">{{ document.description }}</a></td>
+                  <td>{{ document.category }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </section>
+        <section id="entities" class="content__section">
+          <h2>Entities</h2>
+          <table class="data-table simple-table" style="table-layout: auto;">
+            <thead>
+              <tr>
+                <th scope="col">Role</th>
+                <th scope="col">Name</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for entity in advisory_opinion.requestor_names %}
+                <tr>
+                  <td>Requestor</td>
+                  <td>{{ entity }}</td>
+                </tr>
+              {% endfor %}
+              {% for entity in advisory_opinion.representative_names %}
+                <tr>
+                  <td>Counsel/representative</td>
+                  <td>{{ entity }}</td>
+                </tr>
+              {% endfor %}
+              {% for entity in advisory_opinion.commenter_names %}
+                <tr>
+                  <td>Commenter</td>
+                  <td>{{ entity }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </section>
+        <section id="legal-citations" class="content__section">
+          <div class="sidebar--primary t-sans">
+            <h4 class="sidebar__title">Legal citations</h4>
+            <div class="sidebar__content">
+              <div class="grid grid--2-wide">
+                  <div class="grid__item">
+                    <p class="t-bold">This opinion cites these earlier opinions</p>
+                    <div class="rich-text">
+                      {% if advisory_opinion.ao_citations %}
+                      {% for citation in advisory_opinion.ao_citations %}
+                        <p><a href="{{ url_for('advisory_opinion_page', ao_no=citation.no) }}">AO {{ citation.no }}</a><br><i>{{ citation.name }}</i></p>
+                      {% endfor %}
+                      {% else %}
+                        <p><em>Doesn't cite earlier opinions</em></p>
+                      {% endif %}
+                    </div>
+                  </div>
+                  <div class="grid__item">
+                    <p class="t-bold">This opinion is cited by these later opinions</p>
+                    {% if advisory_opinion.aos_cited_by %}
+                    {% for citation in advisory_opinion.aos_cited_by %}
                       <p><a href="{{ url_for('advisory_opinion_page', ao_no=citation.no) }}">AO {{ citation.no }}</a><br><i>{{ citation.name }}</i></p>
                     {% endfor %}
                     {% else %}
-                      <p><em>Doesn't cite earlier opinions</em></p>
+                      <p><em>Isn't cited by later opinions</em></p>
                     {% endif %}
                   </div>
-                </div>
-                <div class="grid__item">
-                  <p class="t-bold">This opinion is cited by these later opinions</p>
-                  {% if advisory_opinion.aos_cited_by %}
-                  {% for citation in advisory_opinion.aos_cited_by %}
-                    <p><a href="{{ url_for('advisory_opinion_page', ao_no=citation.no) }}">AO {{ citation.no }}</a><br><i>{{ citation.name }}</i></p>
-                  {% endfor %}
-                  {% else %}
-                    <p><em>Isn't cited by later opinions</em></p>
-                  {% endif %}
-                </div>
+              </div>
             </div>
-        </div>
-        </aside>
-    </section>
+          </div>
+        </section>
+      </div>
+    </div>
   </div>
 </div>
 </div>

--- a/openfecwebapp/templates/legal-advisory-opinion.html
+++ b/openfecwebapp/templates/legal-advisory-opinion.html
@@ -25,18 +25,18 @@
       </div>
     </section>
     <section class="content__section">
-      <h2 class="t-ruled--bold t-ruled--bottom">Documents</h2>
-      <div class="content__section">
-      {% if advisory_opinion.category == "Final Opinion" %}
-        <a class="button button--cta button--document button--lg" href="{{ advisory_opinion.url }}">{{ advisory_opinion.category | lower | capitalize }}</a>
+      <h2>Documents</h2>
+      {% if final_opinion %}
+        <div class="content__section">
+          <a class="button button--cta button--document button--lg" href="{{ final_opinion.url }}">Final Opinion</a> <span class="t-sans">{{ final_opinion.date | date(fmt='%B %d, %Y') }}</span>
+        </div>
       {% endif %}
-      </div>
-      <table class="data-table data-table--text">
+      <table class="data-table simple-table">
         <thead>
           <tr>
-            <th class="cell--20">Date</th>
-            <th>Name</th>
-            <th>Document type</th>
+            <th scope="col" class="cell--20">Date</th>
+            <th scope="col">Name</th>
+            <th scope="col">Document type</th>
           </tr>
         </thead>
         <tbody>
@@ -50,9 +50,36 @@
         </tbody>
       </table>
     </section>
-    <section class="content__section is-disabled">
-      <h2 class="t-ruled--bold t-ruled--bottom">Entities</h2>
-      Coming soon.
+    <section class="content__section">
+      <h2>Entities</h2>
+      <table class="data-table simple-table">
+        <thead>
+          <tr>
+            <th scope="col" class="cell--20">Role</th>
+            <th scope="col">Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for entity in advisory_opinion.requestor_names %}
+            <tr>
+              <td>Requestor</td>
+              <td>{{ entity }}</td>
+            </tr>
+          {% endfor %}
+          {% for entity in advisory_opinion.representative_names %}
+            <tr>
+              <td>Counsel/representative</td>
+              <td>{{ entity }}</td>
+            </tr>
+          {% endfor %}
+          {% for entity in advisory_opinion.commenter_names %}
+            <tr>
+              <td>Commenter</td>
+              <td>{{ entity }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </section>
     <section class="content__section">
       <aside id="legal-citations" class="sidebar sidebar--primary">

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -62,9 +62,11 @@ def render_legal_doc_search_results(results, query, result_type, ao_no, ao_name,
 
 
 def render_legal_advisory_opinion(advisory_opinion):
+    final_opinion = [doc for doc in advisory_opinion['documents'] if doc['category'] == 'Final Opinion']
     return render_template(
         'legal-advisory-opinion.html',
         advisory_opinion=advisory_opinion,
+        final_opinion=final_opinion[0],
         parent='legal'
     )
 


### PR DESCRIPTION
Now that we have the entity filters as implemented in #1955 , I realized we could also add the entity table to the AO page to show requestor, counsel and commenters. 

While I was in there, I noticed that since we refactored the AO schema a while ago, the big final opinion button was also missing, so I fixed that.

And last, I went ahead and added the side nav layout from [the design](https://gsa.invisionapp.com/share/QCA404INT#/229485601_AO_Canonical-Collapsed-Demo).

So here's nicer AO pages:
![ao 2013-06 - fec](https://cloud.githubusercontent.com/assets/1696495/25155003/fc2b5c86-2460-11e7-8a57-dc492c68ad29.png)

cc @jenniferthibault @nickykrause 
