### PR TITLE
Fetch AO results on enter

### DIFF
--- a/static/js/legal/Filters.js
+++ b/static/js/legal/Filters.js
@@ -40,16 +40,16 @@ function Filters(props) {
   return <div>
             <div className="filters accordion__content">
               <TextFilter key="ao_no" name="ao_no" label="AO number" value={props.query.ao_no}
-                  handleChange={props.setQuery} getResults={props.getResults} />
+                  handleChange={props.setQuery} getResults={props.getResults} handleKeydown={props.handleKeydown} />
               <TextFilter key="ao_requestor" name="ao_requestor" label="Requestor Name (or AO Name)" value={props.query.ao_requestor}
-                    handleChange={props.setQuery} getResults={props.getResults} />
+                    handleChange={props.setQuery} getResults={props.getResults} handleKeydown={props.handleKeydown} />
               <Dropdown key="ao_requestor_type" name="ao_requestor_type" label="Requestor Type" value={props.query.ao_requestor_type}
                   options={requestorOptions} handleChange={props.instantQuery} />
             </div>
             <ul className="accordion--neutral" data-content-prefix="first">
               <FilterPanel id="first-content-0" header="Documents" startOpen={true}>
                 <TextFilter key="q" name="q" label="Keywords" value={props.query.q}
-                  handleChange={props.setQuery} getResults={props.getResults} />
+                  handleChange={props.setQuery} getResults={props.getResults} handleKeydown={props.handleKeydown} />
                 <CheckboxFilter key="ao_is_pending" name="ao_is_pending" label="Show only pending requests"
                   checked={props.query.ao_is_pending} handleChange={props.instantQuery} />
                 <CheckboxList key="ao_category" name="ao_category" label="Document Type" value={props.query.ao_category || ['F']}
@@ -77,7 +77,7 @@ function Filters(props) {
               </FilterPanel>
               <FilterPanel id="first-content-3" header="Other entities">
                 <TextFilter key="ao_entity_name" name="ao_entity_name" label="Entity name" value={props.query.ao_entity_name}
-                  handleChange={props.setQuery} getResults={props.getResults}
+                  handleChange={props.setQuery} getResults={props.getResults} handleKeydown={props.handleKeydown}
                   helpText="Search any individuals or groups involved in the opinion."/>
               </FilterPanel>
               </ul>

--- a/static/js/legal/LegalSearch.js
+++ b/static/js/legal/LegalSearch.js
@@ -19,6 +19,7 @@ class LegalSearch extends React.Component {
     this.getResults = this.getResults.bind(this);
     this.setQuery = this.setQuery.bind(this);
     this.instantQuery = this.instantQuery.bind(this);
+    this.handleKeydown = this.handleKeydown.bind(this);
     this.getResults();
   }
 
@@ -70,6 +71,12 @@ class LegalSearch extends React.Component {
                 });
   }
 
+  handleKeydown(e) {
+    if (e.keyCode === 13) {
+      this.getResults(e)
+    }
+  }
+
   render() {
     return <section className="main__content--full data-container__wrapper">
       <div id="filters" className="filters is-open">
@@ -78,7 +85,7 @@ class LegalSearch extends React.Component {
         </button>
         <div className="filters__content">
           <Filters query={this.state} setQuery={this.setQuery}
-                getResults={this.getResults} instantQuery={this.instantQuery} />
+                getResults={this.getResults} instantQuery={this.instantQuery} handleKeydown={this.handleKeydown}/>
         </div>
       </div>
       <div id="results-{{ result_type }}" className="content__section data-container__body">

--- a/static/js/legal/filters/TextFilter.js
+++ b/static/js/legal/filters/TextFilter.js
@@ -5,7 +5,7 @@ function TextFilter(props) {
       <label className="label" htmlFor={props.name + "-filter"}>{props.label}</label>
       <div className="combo combo--search--mini">
         <input id={props.name + "-filter"} type="text" name={props.name} className="combo__input"
-            value={props.value || ''} onChange={props.handleChange} />
+            value={props.value || ''} onChange={props.handleChange} onKeyDown={props.handleKeydown}/>
         <button className="combo__button button--search button--standard"
          onClick={props.getResults}>
           <span className="u-visually-hidden">Search</span>


### PR DESCRIPTION
This adds a keydown handler to search AOs when hitting enter in text filters to address an issue we've  noticed in [usability testing](https://github.com/18F/fec-testing/issues/43).