### PR TITLE
Feature/fix election lookup dates

### DIFF
--- a/openfecwebapp/templates/macros/cycle-select.html
+++ b/openfecwebapp/templates/macros/cycle-select.html
@@ -14,7 +14,7 @@
           value="{{ each }}"
           {% if cycle and cycle <= each and cycle > (each - duration) %}selected{% endif %}
         >
-        {{ each }}
+        {{ each|fmt_year_range }}
       </option>
     {% endfor %}
     </select>

--- a/static/js/modules/election-lookup.js
+++ b/static/js/modules/election-lookup.js
@@ -371,7 +371,8 @@ ElectionLookup.prototype.drawLocations = function($svg) {
 
 ElectionLookup.prototype.getTitle = function() {
   var params = this.serialized;
-  var title = params.cycle + ' candidates';
+  var minYear = Number(params.cycle) - 1;
+  var title = minYear + '–' + params.cycle + ' candidates';
   if (params.zip) {
     title += ' in ZIP code ' + params.zip;
   } else {

--- a/static/js/modules/election-lookup.js
+++ b/static/js/modules/election-lookup.js
@@ -60,20 +60,6 @@ function formatName(result) {
   return parts.join(' ');
 }
 
-function formatElectionDateUrl(result) {
-  var now = new Date();
-  var month = now.getMonth() + 1;
-  var today = now.getFullYear() + '-' + month + '-' + now.getDate();
-  var query = {
-    'election_state': result.state,
-    'election_district': result.district,
-    'office_sought': result.office,
-    'sort': 'election_date',
-    'min_election_date': today
-  };
-  return helpers.buildUrl(['election-dates'], query);
-}
-
 function formatGenericElectionDate(result) {
   var date = moment()
     .year(result.cycle)

--- a/static/templates/electionResult.hbs
+++ b/static/templates/electionResult.hbs
@@ -1,26 +1,16 @@
-<div>
-  {{#each this}}
-  <div class="result" data-office="{{this.office}}">
-    <h3>
-      {{#if this.district}}
-      <span data-color="{{this.color}}"></span>
-      {{/if}}
-      <a href="{{this.url}}">{{this.electionName}}</a>
-    </h3>
-    <div class="row">
-      <span class="result__term">Next general election:</span>
-      <span class="result__definition">{{this.electionDate}}</span>
-    </div>
-    {{#if this.incumbent}}
-    <div class="row">
-      <span class="result__term">Current officeholder:</span>
-      <a class="result__definition" href="{{this.incumbent.url}}">{{this.incumbent.name}}</a>
-      </div>
+<div class="result" data-office="{{office}}">
+  <h3>
+    {{#if district}}
+    <span data-color="{{color}}"></span>
     {{/if}}
-    <div class="row">
-      <span class="result__term">Current candidates:</span>
-      <a class="result__definition" href="{{this.url}}">Show all &raquo;</a>
-    </div>
+    <a href="{{url}}">{{electionName}}</a>
+  </h3>
+  <div class="row">
+    <span class="result__term">{{electionType}}:</span>
+    <span class="result__definition">{{electionDate}}</span>
   </div>
-  {{/each}}
+  <div class="row">
+    <span class="result__term">Current candidates:</span>
+    <a class="result__definition" href="{{url}}">Show all &raquo;</a>
+  </div>
 </div>

--- a/tests/unit/modules/election-lookup.js
+++ b/tests/unit/modules/election-lookup.js
@@ -97,19 +97,25 @@ describe('election lookup', function() {
     expect(this.el.serialize()).to.deep.equal({cycle: '2016', state: 'VA', district: '01'});
   });
 
-  it('should draw search results', function() {
-    var results = [
-      {cycle: 2016, office: 'P', state: 'US'},
-      {cycle: 2016, office: 'S', state: 'NJ'},
-      {cycle: 2016, office: 'H', state: 'NJ', district: '09'}
-    ];
-    this.el.serialized = {cycle: '2016', state: 'NJ', district: '09'};
-    this.el.draw(results);
-    var $rendered = this.el.$resultsItems.find('.result');
-    var titles = $rendered.map(function(idx, elm) {
-      return $(elm).find('h3').text().trim();
-    }).get();
-    expect(titles).to.deep.equal(['US President', 'NJ Senate', 'NJ House District 09']);
+  describe('drawing search results', function() {
+    beforeEach(function() {
+      this.drawItem = sinon.spy(lookup.ElectionLookup.prototype, 'drawItem');
+      this.results = [
+        {cycle: 2016, office: 'P', state: 'US'},
+        {cycle: 2016, office: 'S', state: 'NJ'},
+        {cycle: 2016, office: 'H', state: 'NJ', district: '09'}
+      ];
+      this.el.serialized = {cycle: '2016', state: 'NJ', district: '09'};
+    });
+
+    afterEach(function() {
+      this.drawItem.restore();
+    });
+
+    it('should call drawItem', function() {
+      this.el.draw(this.results);
+      expect(this.drawItem).to.have.been.called;
+    });
   });
 
   it('should show no results warning on no results by zip', function() {

--- a/tests/unit/modules/election-lookup.js
+++ b/tests/unit/modules/election-lookup.js
@@ -99,7 +99,7 @@ describe('election lookup', function() {
 
   describe('drawing search results', function() {
     beforeEach(function() {
-      this.drawItem = sinon.spy(lookup.ElectionLookup.prototype, 'drawItem');
+      this.drawItem = sinon.spy(lookup.ElectionLookup.prototype, 'drawResult');
       this.results = [
         {cycle: 2016, office: 'P', state: 'US'},
         {cycle: 2016, office: 'S', state: 'NJ'},
@@ -112,7 +112,7 @@ describe('election lookup', function() {
       this.drawItem.restore();
     });
 
-    it('should call drawItem', function() {
+    it('should call drawResult', function() {
       this.el.draw(this.results);
       expect(this.drawItem).to.have.been.called;
     });


### PR DESCRIPTION
This adds a call to the `/election-dates/` endpoint to check for upcoming elections for districts, such as special elections. If it finds one, it uses that date. Otherwise, it uses the date of the next general election. 

![image](https://cloud.githubusercontent.com/assets/1696495/25296836/1de1ba38-269f-11e7-8ba8-00e312c36bb8.png)

It also makes a few minor UI tweaks for greater clarity. Because the election may be in either of the years of a two-year period, I changed single years to be year ranges, a la:
![image](https://cloud.githubusercontent.com/assets/1696495/25295335/ec433daa-2697-11e7-80b0-b58b830d2f3b.png)

Also, as someone noted the other day, the "current officeholder" doesn't make sense for historic elections, and also seems to be inaccurate for cases like special elections, so I just removed it.