### PR TITLE
Adding support for accordion library v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "a11y-dialog": "2.3.1",
-    "aria-accordion": "0.1.1",
+    "aria-accordion": "1.0.0",
     "babel-eslint": "^7.1.1",
     "babel-preset-latest": "^6.24.0",
     "babelify": "^7.3.0",
@@ -105,7 +105,7 @@
     "datatables.net-responsive": "2.0.1",
     "es6-weak-map": "2.0.1",
     "fec-style": "10.0.0",
-    "glossary-panel": "0.2.1",
+    "glossary-panel": "1.0.0",
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",
     "intl": "1.0.0-rc-4",

--- a/static/js/init.js
+++ b/static/js/init.js
@@ -91,14 +91,13 @@ $(document).ready(function() {
     var contentPrefix = $(this).data('content-prefix') || 'accordion';
     var openFirst = $(this).data('open-first');
     var selectors = {
-      body: '.js-accordion',
       trigger: '.js-accordion-trigger'
     };
     var opts = {
       contentPrefix: contentPrefix,
       openFirst: openFirst
     };
-    new Accordion(selectors, opts);
+    new Accordion(this, selectors, opts);
   });
 
   // Initialize search


### PR DESCRIPTION
This takes advantage of a small change in the accordion library in order to allow multiple accordions on the same page. It just updates the version number (did it for the glossary, too, which I just bumped to 1.0.0), and now passes in an element as the first arg of the accordion constructor.