### PR TITLE
Feature/partition field for reports

### DIFF
--- a/openfecwebapp/templates/macros/filters/date.html
+++ b/openfecwebapp/templates/macros/filters/date.html
@@ -20,16 +20,18 @@
 </div>
 {% endmacro %}
 
-{% macro partition_field(name, label, dates) %}
+{% macro partition_field(name, label, dates, show_tooltip=True) %}
 <div class="filter">
     <div class="js-filter js-filter-control" data-filter="select" data-validate="true" data-modifies-filter="{{ name }}" data-modifies-property="data-transaction-year" data-required-default="{{ constants.DEFAULT_TIME_PERIOD }}">
       <label class="label t-inline-block" for="two-year-transaction-period">Time period</label>
-      <div class="tooltip__container">
-        <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
-        <div id="year-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
-          <p class="tooltip__content">The two-year period in which the transaction was made. Due to the large number of itemized transactions, you can only access one period at a time.</p>
+      {% if show_tooltip %}
+        <div class="tooltip__container">
+          <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
+          <div id="year-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
+            <p class="tooltip__content">The two-year period in which the transaction was made. Due to the large number of itemized transactions, you can only access one period at a time.</p>
+          </div>
         </div>
-      </div>
+      {% endif %}
       <select id="two-year-transaction-period" name="two_year_transaction_period" aria-describedby="unique-tooltip">
           <option value="">Select a value</option>
         {% for year in range(constants.END_YEAR, constants.START_YEAR, -2) %}

--- a/openfecwebapp/templates/partials/reports-filter.html
+++ b/openfecwebapp/templates/partials/reports-filter.html
@@ -48,7 +48,11 @@ Filter reports
   <button type="button" class="js-accordion-trigger accordion__button">Date</button>
   <div class="accordion__content">
     {{ years.years('cycle', 'Years')  }}
-    {{ date.field('receipt_date', 'Receipt date', dates ) }}
+    {% if table_context['form_type'] == 'pac-party' %}
+      {{ date.field('receipt_date', 'Receipt date', dates ) }}
+    {% else %}
+      {{ date.partition_field('receipt_date', 'Receipt date', dates ) }}
+    {% endif %}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Report type</button>
   <div class="accordion__content">

--- a/openfecwebapp/templates/partials/reports-filter.html
+++ b/openfecwebapp/templates/partials/reports-filter.html
@@ -49,9 +49,9 @@ Filter reports
   <div class="accordion__content">
     {{ years.years('cycle', 'Years')  }}
     {% if table_context['form_type'] == 'pac-party' %}
-      {{ date.field('receipt_date', 'Receipt date', dates ) }}
-    {% else %}
       {{ date.partition_field('receipt_date', 'Receipt date', dates ) }}
+    {% else %}
+      {{ date.field('receipt_date', 'Receipt date', dates ) }}
     {% endif %}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Report type</button>

--- a/openfecwebapp/templates/partials/reports-filter.html
+++ b/openfecwebapp/templates/partials/reports-filter.html
@@ -49,7 +49,7 @@ Filter reports
   <div class="accordion__content">
     {{ years.years('cycle', 'Years')  }}
     {% if table_context['form_type'] == 'pac-party' %}
-      {{ date.partition_field('receipt_date', 'Receipt date', dates ) }}
+      {{ date.partition_field('receipt_date', 'Receipt date', dates, show_tooltip=False) }}
     {% else %}
       {{ date.field('receipt_date', 'Receipt date', dates ) }}
     {% endif %}


### PR DESCRIPTION
As suggested by @LindsayYoung in https://github.com/18F/openFEC/issues/2319 , this adds a mandatory two-year period restriction on the PAC and party reports page as a temporary fix for the very slow API responses because of the large amount of records.

![image](https://cloud.githubusercontent.com/assets/1696495/25363050/c4e48be8-290c-11e7-9502-bbd24538029c.png)

