### PR TITLE
jQuery 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",
     "intl": "1.0.0-rc-4",
-    "jquery": "2.2.4",
+    "jquery": "3.2.1",
     "jquery.inputmask": "3.2.7",
     "keyboardjs": "0.4.2",
     "leaflet": "0.7.7",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
     "es6-weak-map": "2.0.1",
-    "fec-style": "10.0.0",
+    "fec-style": "11.0.0",
     "glossary-panel": "1.0.0",
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",

--- a/static/js/modules/download.js
+++ b/static/js/modules/download.js
@@ -137,7 +137,7 @@ DownloadItem.prototype.refresh = function() {
     contentType: 'application/json',
     dataType: 'json'
   });
-  this.promise.then(this.handleSuccess.bind(this));
+  this.promise.done(this.handleSuccess.bind(this));
   this.promise.fail(this.handleError.bind(this));
 };
 


### PR DESCRIPTION
This updates jQuery to the latest version. I clicked through the site and everything seems to be working. I also ready through the [upgrade guide](https://jquery.com/upgrade-guide/3.0/#overview) and checked for instances of the things they warned about and I didn't find anything concerning.

~The one snag is that a single test is failing, which seems to perhaps relate to the change in the `$.Deferred()` implementation.~

~But I'm stumped, so I'd appreciate if someone else could take a look.~

Update: the test issue is resolved.