### PR TITLE
Fix/cycle range

### DIFF
--- a/openfecwebapp/templates/election-lookup.html
+++ b/openfecwebapp/templates/election-lookup.html
@@ -16,7 +16,7 @@
     <div class="search-controls">
       <form>
         <div class="search-controls__row">
-          {{ select.cycle_select(cycles, location='form') }}
+          {{ select.cycle_select(cycles, location='form', range=True) }}
         </div>
         <div class="search-controls__row">
           <div class="search-controls__either">

--- a/openfecwebapp/templates/elections.html
+++ b/openfecwebapp/templates/elections.html
@@ -30,7 +30,7 @@
         </div>
         <div class="entity__header__bottom row">
           <div class="entity__info">
-            {{ select.cycle_select(cycles, cycle, location='path', class='select--alt-primary') }}
+            {{ select.cycle_select(cycles, cycle, location='path', class='select--alt-primary', range=True) }}
           </div>
         </div>
       </div>

--- a/openfecwebapp/templates/macros/cycle-select.html
+++ b/openfecwebapp/templates/macros/cycle-select.html
@@ -1,4 +1,4 @@
-{% macro cycle_select(cycles, cycle=none, duration=2, location='query', id='cycle-select', class='') %}
+{% macro cycle_select(cycles, cycle=none, duration=2, location='query', id='cycle-select', class='', range=False) %}
 {% if cycles %}
   <div class="cycle-select">
     <label for="{{ id }}" class="cycle-select__label">Election</label>
@@ -14,7 +14,11 @@
           value="{{ each }}"
           {% if cycle and cycle <= each and cycle > (each - duration) %}selected{% endif %}
         >
-        {{ each|fmt_year_range }}
+        {% if range %}
+          {{ each|fmt_year_range }}
+        {% else %}
+          {{ each }}
+        {% endif %}
       </option>
     {% endfor %}
     </select>


### PR DESCRIPTION
This fixes an earlier change by making an optional parameter to the cycle select macro so that it can be told to display things as a range, rather than a single year:

![image](https://cloud.githubusercontent.com/assets/1696495/25456723/98493d18-2a88-11e7-991a-30080cc1c349.png)

On the election search and elections pages, it should be a range (in order to account for odd-year special elections) but on candidate pages, it should be a single year.

