### PR TITLE
Add missing transition URL env var

### DIFF
--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -10,5 +10,6 @@ env:
   NPM_CONFIG_PRODUCTION: false
   NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
   NEW_RELIC_LOG: stdout
+  FEC_TRANSITION_URL: https://transition.fec.gov
 applications:
 - name: web


### PR DESCRIPTION
This changeset adds a missing env var to our base manifest to ensure that the transition site URL does not get lost on subsequent deploys.