### PR TITLE
Adding tabindex to nav links

### DIFF
--- a/openfecwebapp/templates/partials/navigation.html
+++ b/openfecwebapp/templates/partials/navigation.html
@@ -8,17 +8,17 @@
         </a>
       </li>
       <li class="site-nav__item" data-submenu="data">
-        <a href="{{ url_for('search') }}" class="site-nav__link {% if parent == 'data' %}is-parent{% endif %}">
+        <a href="{{ url_for('search') }}" tabindex="0" class="site-nav__link {% if parent == 'data' %}is-parent{% endif %}">
           <span class="site-nav__link__title">Campaign finance data</span>
         </a>
       </li>
       <li class="site-nav__item site-nav__item--secondary" data-submenu="help">
-        <a href="{{ cms_url }}/help-candidates-committees/" class="site-nav__link">
+        <a href="{{ cms_url }}/help-candidates-committees/" tabindex="0" class="site-nav__link">
           <span class="site-nav__link__title">Help for candidates and committees</span>
         </a>
       </li>
       <li class="site-nav__item" data-submenu="legal">
-        <a href="{{ cms_url }}/legal-resources" class="site-nav__link {% if parent == 'legal' %}is-parent{% endif %}">
+        <a href="{{ cms_url }}/legal-resources" tabindex="0" class="site-nav__link {% if parent == 'legal' %}is-parent{% endif %}">
           <span class="site-nav__link__title">Legal resources</span>
         </a>
       </li>


### PR DESCRIPTION
This fixes the mega menu in Safari by adding tabindex to the links. 

The issue is that the mega menu calls the click handler when the triggering element has focus. Chrome automatically adds focus to an element when you click it, but Safari doesn't unless there's a tabindex. 

Also requires https://github.com/18F/fec-style/pull/688