### PR TITLE
Pass office to template to restore correct filters

### DIFF
--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -90,7 +90,7 @@ def candidate_page(c_id, cycle=None, election_full=True):
 
         # If the next_cycle is odd set it to whatever the cycle value was
         # and then set election_full to false
-        # This solves an issue with special elections 
+        # This solves an issue with special elections
         if next_cycle % 2 > 0:
             next_cycle = cycle
             election_full = False
@@ -151,6 +151,7 @@ def candidates_office(office):
         result_type='candidates',
         title='candidates for ' + office,
         slug='candidates-office',
+        office=office.lower(),
         table_context=OrderedDict([('office', office)]),
         columns=constants.table_columns['candidates-office-' + office.lower()]
     )

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -151,7 +151,6 @@ def candidates_office(office):
         result_type='candidates',
         title='candidates for ' + office,
         slug='candidates-office',
-        office=office.lower(),
         table_context=OrderedDict([('office', office)]),
         columns=constants.table_columns['candidates-office-' + office.lower()]
     )

--- a/openfecwebapp/templates/macros/filters/years.html
+++ b/openfecwebapp/templates/macros/filters/years.html
@@ -1,4 +1,4 @@
-{% macro years(name, label) %}
+{% macro cycles(name, label) %}
 <fieldset class="js-filter js-dropdown filter" data-filter="checkbox">
   <legend class="label">{{ label }}</legend>
   <ul class="dropdown__selected"></ul>
@@ -10,6 +10,26 @@
         <li class="dropdown__item">
           <input id="{{ name }}-checkbox-{{ year }}" name="{{ name }}" type="checkbox" value="{{ year }}" />
           <label class="dropdown__value" for="{{name}}-checkbox-{{ year }}">{{ year | fmt_year_range }}</label>
+        </li>
+      {% endfor %}
+      </ul>
+    </div>
+  </div>
+</fieldset>
+{% endmacro %}
+
+{% macro years(name, label) %}
+<fieldset class="js-filter js-dropdown filter" data-filter="checkbox">
+  <legend class="label">{{ label }}</legend>
+  <ul class="dropdown__selected"></ul>
+  <div class="dropdown">
+    <button type="button" class="dropdown__button button--alt" data-name="{{ name }}">More</button>
+    <div id="{{ name }}-dropdown" class="dropdown__panel" aria-hidden="true">
+      <ul class="dropdown__list">
+      {% for year in range(constants.END_YEAR, constants.START_YEAR, -1) %}
+        <li class="dropdown__item">
+          <input id="{{ name }}-checkbox-{{ year }}" name="{{ name }}" type="checkbox" value="{{ year }}" />
+          <label class="dropdown__value" for="{{name}}-checkbox-{{ year }}">{{ year }}</label>
         </li>
       {% endfor %}
       </ul>

--- a/openfecwebapp/templates/partials/candidates-filter.html
+++ b/openfecwebapp/templates/partials/candidates-filter.html
@@ -8,7 +8,7 @@
 {% block filters %}
 <div class="filters__inner">
   {{ typeahead.field('q', 'Candidate name or ID', '', dataset='candidates', allow_text=True) }}
-  {{ years.years('cycle', 'Election year') }}
+  {{ years.years('election_year', 'Election year') }}
   {% include 'partials/filters/office-sought.html' %}
   {% include 'partials/filters/parties.html' %}
   {{ states.field('state') }}

--- a/openfecwebapp/templates/partials/candidates-office-filter.html
+++ b/openfecwebapp/templates/partials/candidates-office-filter.html
@@ -5,13 +5,18 @@
 {% import 'macros/filters/typeahead-filter.html' as typeahead %}
 {% import 'macros/filters/election-filter.html' as election_filter %}
 {% import 'macros/filters/range.html' as range_filter %}
+{% import 'macros/filters/years.html' as years %}
 
 {% block filters %}
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
   <div class="filters__inner">
     {{ typeahead.field('q', 'Candidate name or ID', '', dataset='candidates', allow_text=True) }}
-    {{ election_filter.field('election_year', 'Election cycle', 'cycle', 'election_full', table_context['office']) }}
-    <input id="election_full" name="election_full" type="checkbox" value="true">
+    {% if table_context['office'] == 'house' %}
+      {{ years.cycles('cycle', 'Election cycle') }}
+    {% else %}
+      {{ election_filter.field('election_year', 'Election year', 'cycle', 'election_full', table_context['office']) }}
+      <input id="election_full" name="election_full" type="checkbox" value="true">
+    {% endif %}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Candidate information</button>
   <div class="accordion__content">

--- a/openfecwebapp/templates/partials/candidates-office-filter.html
+++ b/openfecwebapp/templates/partials/candidates-office-filter.html
@@ -16,10 +16,10 @@
   <button type="button" class="js-accordion-trigger accordion__button">Candidate information</button>
   <div class="accordion__content">
     {% include 'partials/filters/parties.html' %}
-    {% if office in ['senate', 'house'] %}
+    {% if table_context['office'] in ['senate', 'house'] %}
       {{ states.field('state') }}
     {% endif %}
-    {% if office == 'house' %}
+    {% if table_context['office'] == 'house' %}
       {% include 'partials/filters/districts.html' %}
     {% endif %}
   </div>
@@ -29,7 +29,7 @@
     {{ range_filter.amount('disbursements', 'Total disbursements') }}
     {{ range_filter.amount('cash_on_hand_end_period', 'Cash on hand') }}
     {{ range_filter.amount('debts_owed_by_committee', 'Debts owed by committee') }}
-    {% if office == 'president' %}
+    {% if table_context['office'] == 'president' %}
       <div class="js-filter">
         <input id="federal-funds-flag" name="federal_funds_flag" type="checkbox" value="true">
         <label class="dropdown__value" for="federal-funds-flag">Has accepted presidential public funds</label>

--- a/openfecwebapp/templates/partials/committees-filter.html
+++ b/openfecwebapp/templates/partials/committees-filter.html
@@ -9,7 +9,7 @@
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
   <div class="filters__inner">
     {{ typeahead.field('q', 'Committee name or ID', False, dataset='committees', allow_text=True) }}
-    {{ years.years('cycle', 'Years active') }}
+    {{ years.cycles('cycle', 'Years active') }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Committee details</button>
   <div class="accordion__content">

--- a/openfecwebapp/templates/partials/filings-filter.html
+++ b/openfecwebapp/templates/partials/filings-filter.html
@@ -32,7 +32,7 @@ Filter reports
 
   <button type="button" class="js-accordion-trigger accordion__button">Filing date</button>
   <div class="accordion__content">
-    {{ years.years('cycle', 'Years')  }}
+    {{ years.cycles('cycle', 'Years')  }}
     {{ date.field('receipt_date', 'Receipt date', dates ) }}
   </div>
 

--- a/openfecwebapp/templates/partials/independent-expenditures-filter.html
+++ b/openfecwebapp/templates/partials/independent-expenditures-filter.html
@@ -29,7 +29,7 @@ Filter independent expenditures
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
   <div class="filters__inner">
     {{ typeahead.field('committee_id', 'Spender name or ID') }}
-    {{ years.years('cycle', 'Years') }}
+    {{ years.cycles('cycle', 'Years') }}
     {{ reports.type()}}
     {{ reports.form()}}
   </div>

--- a/openfecwebapp/templates/partials/reports-filter.html
+++ b/openfecwebapp/templates/partials/reports-filter.html
@@ -47,7 +47,7 @@ Filter reports
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Date</button>
   <div class="accordion__content">
-    {{ years.years('cycle', 'Years')  }}
+    {{ years.cycles('cycle', 'Years')  }}
     {% if table_context['form_type'] == 'pac-party' %}
       {{ date.partition_field('receipt_date', 'Receipt date', dates, show_tooltip=False) }}
     {% else %}

--- a/static/templates/receipts.hbs
+++ b/static/templates/receipts.hbs
@@ -50,9 +50,11 @@
     {{#panelRow "Memo"}}
       {{memo_text}}
     {{/panelRow}}
-    {{#panelRow "Reported on"}}
-      Form {{formNumber filing_form }} on line {{line_number}}
-    {{/panelRow}}
+    {{#if filing_form}}
+      {{#panelRow "Reported on"}}
+        Form {{formNumber filing_form }} on line {{line_number}}
+      {{/panelRow}}
+    {{/if}}
     {{#panelRow "Election type"}}
       {{fec_election_type_desc}}
     {{/panelRow}}


### PR DESCRIPTION
As reported in https://github.com/18F/FEC/issues/4032, the [House Candidates](https://beta.fec.gov/data/candidates/house/) page is missing the state (and district) filter. I looked into it and the template code was already there, but it was using the wrong variable to check the office. So this is just a small fix to restore the original designed functionality:

![image](https://cloud.githubusercontent.com/assets/1696495/25586061/781cbab0-2e52-11e7-8419-f0235377c5b8.png)

Resolves https://github.com/18F/FEC/issues/4032

This also includes a small fix to restore the details panels when looking at raw receipts data.
