### PR TITLE
[MERGE WITH GITFLOW] Hotfix/ie aos

### DIFF
--- a/static/js/legal/LegalSearch.js
+++ b/static/js/legal/LegalSearch.js
@@ -71,6 +71,7 @@ class LegalSearch extends React.Component {
                   this.setState({ advisory_opinions: results.advisory_opinions,
                   resultCount: results.total_advisory_opinions,
                   lastResultCount }, () => {
+                    queryPath = queryPath.removeSearch('api_key');
                     window.history.pushState(URI.parseQuery(queryPath.query()),
                       null, queryPath.search().toString());
                   });

--- a/static/js/legal/LegalSearch.js
+++ b/static/js/legal/LegalSearch.js
@@ -1,4 +1,5 @@
 const $ = require('jquery');
+const _ = require('underscore');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const URI = require('urijs');
@@ -56,7 +57,7 @@ class LegalSearch extends React.Component {
                 .addQuery('api_key', window.API_KEY)
                 .addQuery('type', 'advisory_opinions');
 
-    const queryState = Object.assign({}, this.state);
+    const queryState = _.extend({}, this.state);
     queryState.search = queryState.q;
     Object.keys(queryState).forEach((queryParam) => {
       if(['advisory_opinions', 'resultCount', 'lastResultCount', 'lastFilter'].indexOf(queryParam) === -1


### PR DESCRIPTION
This fixes the AO search in Internet Explorer by replacing an unsupported ES6 method (`Object.assign()`) with Underscore's `_.extend()` which for this purpose does the same thing. 

It also removes the API key from being included in the browser query string for prettier URLs (and similar to how we handle it on other parts of the site). 

cc @anthonygarvan 