### PR TITLE
Feature/a11y improvements

### DIFF
--- a/openfecwebapp/templates/datatable.html
+++ b/openfecwebapp/templates/datatable.html
@@ -20,11 +20,11 @@
         </div>
       </div>
       <div id="{{slug}}" class="data-container__datatable">
-        <table id="results" class="data-table data-table--heading-borders" aria-live="polite">
-          <thead>
-            <tr>
+        <table id="results" class="data-table data-table--heading-borders" aria-live="polite" role="grid">
+          <thead role="rowgroup">
+            <tr role="row">
               {% for column in columns %}
-                <th scope="col">{{ column }}</th>
+                <th scope="col" role="columnheader">{{ column }}</th>
               {% endfor %}
               <th scope="col"></th>
             </tr>

--- a/openfecwebapp/templates/macros/filters/date.html
+++ b/openfecwebapp/templates/macros/filters/date.html
@@ -1,7 +1,7 @@
 {% macro field(name, label, dates, id_suffix='') %}
   <div class="filter js-filter" id="{{ name }}{{id_suffix}}" data-name="{{ name }}" data-filter="date">
   <fieldset>
-    <legend for="{{ name }}" class="label">{{ label }}</legend>
+    <legend class="label">{{ label }}</legend>
     <div class="range range--date js-date-range">
       <div class="range__input range__input--min" data-filter="range">
         <label for="min_{{ name }}{{id_suffix}}">Beginning</label>
@@ -22,80 +22,78 @@
 
 {% macro partition_field(name, label, dates, show_tooltip=True) %}
 <div class="filter">
-    <div class="js-filter js-filter-control" data-filter="select" data-validate="true" data-modifies-filter="{{ name }}" data-modifies-property="data-transaction-year" data-required-default="{{ constants.DEFAULT_TIME_PERIOD }}">
-      <label class="label t-inline-block" for="two-year-transaction-period">Time period</label>
-      {% if show_tooltip %}
-        <div class="tooltip__container">
-          <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
-          <div id="year-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
-            <p class="tooltip__content">The two-year period in which the transaction was made. Due to the large number of itemized transactions, you can only access one period at a time.</p>
-          </div>
+  <div class="js-filter js-filter-control" data-filter="select" data-validate="true" data-modifies-filter="{{ name }}" data-modifies-property="data-transaction-year" data-required-default="{{ constants.DEFAULT_TIME_PERIOD }}">
+    <label class="label t-inline-block" for="two-year-transaction-period">Time period</label>
+    {% if show_tooltip %}
+      <div class="tooltip__container">
+        <button class="tooltip__trigger" type="button"><span class="u-visually-hidden">Learn more</span></button>
+        <div id="year-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
+          <p class="tooltip__content">The two-year period in which the transaction was made. Due to the large number of itemized transactions, you can only access one period at a time.</p>
         </div>
-      {% endif %}
-      <select id="two-year-transaction-period" name="two_year_transaction_period" aria-describedby="unique-tooltip">
-          <option value="">Select a value</option>
-        {% for year in range(constants.END_YEAR, constants.START_YEAR, -2) %}
-          <option value="{{year}}">{{ year | fmt_year_range }}</option>
-        {% endfor %}
-      </select>
+      </div>
+    {% endif %}
+    <select id="two-year-transaction-period" name="two_year_transaction_period">
+        <option value="">Select a value</option>
+      {% for year in range(constants.END_YEAR, constants.START_YEAR, -2) %}
+        <option value="{{year}}">{{ year | fmt_year_range }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="js-filter" id="{{ name }}" data-filter="date" data-name="{{ name }}" data-validate="true">
+    <div class="range range--date js-date-range">
+      <div class="range__input range__input--min" data-filter="range">
+        <label for="min_{{ name }}">Beginning</label>
+        <input type="text" id="min_{{ name }}" name="min_{{ name }}" data-range="min" class="js-min-date" data-prefix="Beginning">
+      </div>
+      <div class="range__hyphen">-</div>
+      <div class="range__input range__input--max" data-filter="range">
+        <label for="max_{{ name }}">Ending</label>
+        <input type="text" id="max_{{ name }}" name="max_{{ name }}" data-range="max" class="js-max-date" data-prefix="Ending">
+      </div>
+      <button class="button--go button--standard" type="button">
+        <span class="u-visually-hidden">Search</span>
+      </button>
     </div>
-    <div class="js-filter" id="{{ name }}" data-filter="date" data-name="{{ name }}" data-validate="true">
-      <fieldset>
-      <div class="range range--date js-date-range">
-        <div class="range__input range__input--min" data-filter="range">
-          <label for="min_{{ name }}">Beginning</label>
-          <input type="text" id="min_{{ name }}" name="min_{{ name }}" data-range="min" class="js-min-date" data-prefix="Beginning">
+    <div class="date-range__grid js-date-grid">
+      <div class="date-range__row">
+        <div class="date-range__year">
+        {{ constants.DEFAULT_TIME_PERIOD|int - 1 }}
         </div>
-        <div class="range__hyphen">-</div>
-        <div class="range__input range__input--max" data-filter="range">
-          <label for="max_{{ name }}">Ending</label>
-          <input type="text" id="max_{{ name }}" name="max_{{ name }}" data-range="max" class="js-max-date" data-prefix="Ending">
-        </div>
-        <button class="button--go button--standard" type="button">
-          <span class="u-visually-hidden">Search</span>
-        </button>
+        <ul data-year="{{ constants.DEFAULT_TIME_PERIOD|int - 1 }}" class="date-range__months">
+          <li data-month="01"><div>Jan</div></li>
+          <li data-month="02"><div>Feb</div></li>
+          <li data-month="03"><div>Mar</div></li>
+          <li data-month="04"><div>Apr</div></li>
+          <li data-month="05"><div>May</div></li>
+          <li data-month="06"><div>Jun</div></li>
+          <li data-month="07"><div>Jul</div></li>
+          <li data-month="08"><div>Aug</div></li>
+          <li data-month="09"><div>Sep</div></li>
+          <li data-month="10"><div>Oct</div></li>
+          <li data-month="11"><div>Nov</div></li>
+          <li data-month="12"><div>Dec</div></li>
+        </ul>
       </div>
-      <div class="date-range__grid js-date-grid">
-        <div class="date-range__row">
-          <div class="date-range__year">
-          {{ constants.DEFAULT_TIME_PERIOD|int - 1 }}
-          </div>
-          <ul data-year="{{ constants.DEFAULT_TIME_PERIOD|int - 1 }}" class="date-range__months">
-            <li data-month="01"><div>Jan</div></li>
-            <li data-month="02"><div>Feb</div></li>
-            <li data-month="03"><div>Mar</div></li>
-            <li data-month="04"><div>Apr</div></li>
-            <li data-month="05"><div>May</div></li>
-            <li data-month="06"><div>Jun</div></li>
-            <li data-month="07"><div>Jul</div></li>
-            <li data-month="08"><div>Aug</div></li>
-            <li data-month="09"><div>Sep</div></li>
-            <li data-month="10"><div>Oct</div></li>
-            <li data-month="11"><div>Nov</div></li>
-            <li data-month="12"><div>Dec</div></li>
-          </ul>
+      <div class="date-range__row">
+        <div class="date-range__year">
+          {{ constants.DEFAULT_TIME_PERIOD }}
         </div>
-        <div class="date-range__row">
-          <div class="date-range__year">
-            {{ constants.DEFAULT_TIME_PERIOD }}
-          </div>
-          <ul data-year="{{ constants.DEFAULT_TIME_PERIOD }}" class="date-range__months">
-            <li data-month="01"><div>Jan</div></li>
-            <li data-month="02"><div>Feb</div></li>
-            <li data-month="03"><div>Mar</div></li>
-            <li data-month="04"><div>Apr</div></li>
-            <li data-month="05"><div>May</div></li>
-            <li data-month="06"><div>Jun</div></li>
-            <li data-month="07"><div>Jul</div></li>
-            <li data-month="08"><div>Aug</div></li>
-            <li data-month="09"><div>Sep</div></li>
-            <li data-month="10"><div>Oct</div></li>
-            <li data-month="11"><div>Nov</div></li>
-            <li data-month="12"><div>Dec</div></li>
-          </ul>
-        </div>
+        <ul data-year="{{ constants.DEFAULT_TIME_PERIOD }}" class="date-range__months">
+          <li data-month="01"><div>Jan</div></li>
+          <li data-month="02"><div>Feb</div></li>
+          <li data-month="03"><div>Mar</div></li>
+          <li data-month="04"><div>Apr</div></li>
+          <li data-month="05"><div>May</div></li>
+          <li data-month="06"><div>Jun</div></li>
+          <li data-month="07"><div>Jul</div></li>
+          <li data-month="08"><div>Aug</div></li>
+          <li data-month="09"><div>Sep</div></li>
+          <li data-month="10"><div>Oct</div></li>
+          <li data-month="11"><div>Nov</div></li>
+          <li data-month="12"><div>Dec</div></li>
+        </ul>
       </div>
-    </fieldset>
+    </div>
   </div>
 </div>
 

--- a/openfecwebapp/templates/partials/candidate/individual-contributions.html
+++ b/openfecwebapp/templates/partials/candidate/individual-contributions.html
@@ -35,7 +35,7 @@
       <h3>Individual contributions by transaction</h3>
 
       <div class="row">
-        <fieldset class="toggles">
+        <fieldset class="toggles js-toggles">
           <legend class="label">View by:</legend>
 
           <a class="u-float-right button--alt button--browse"
@@ -47,15 +47,15 @@
               ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
 
           <label for="toggle-state">
-            <input id="toggle-state" type="radio" class="panel-toggle-control" name="individual-contributions" value="contributor-state" checked />
+            <input id="toggle-state" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="contributor-state" checked />
             <span class="button--alt">State</span>
           </label>
           <label for="toggle-size">
-            <input id="toggle-size" type="radio" class="panel-toggle-control" name="individual-contributions" value="contribution-size" />
+            <input id="toggle-size" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="contribution-size" />
             <span class="button--alt">Size</span>
           </label>
           <label for="toggle-all">
-            <input id="toggle-all" type="radio" class="panel-toggle-control" name="individual-contributions" value="all-transactions" />
+            <input id="toggle-all" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="all-transactions" />
             <span class="button--alt">All transactions</span>
           </label>
         </fieldset>

--- a/openfecwebapp/templates/partials/committee/between-committees.html
+++ b/openfecwebapp/templates/partials/committee/between-committees.html
@@ -6,14 +6,14 @@
     {{ select.committee_cycle_select(cycles, cycle, 'between-committees')}}
     <div class="entity__figure">
       <div class="row">
-        <fieldset class="toggles u-float-left">
+        <fieldset class="toggles js-toggles u-float-left">
           <legend class="label" for="transfers">Group by:</legend>
           <label for="toggle-from">
-            <input id="toggle-from" type="radio" class="panel-toggle-control" name="transfers" value="from-committees" checked>
+            <input id="toggle-from" type="radio" class="js-panel-toggle-control" name="transfers" value="from-committees" checked>
             <span class="button--alt">Disbursements received from committees</span>
           </label>
           <label for="toggle-to">
-            <input id="toggle-to" type="radio" class="panel-toggle-control" name="transfers" value="to-committees">
+            <input id="toggle-to" type="radio" class="js-panel-toggle-control" name="transfers" value="to-committees">
             <span class="button--alt">Disbursements to committees</span>
           </label>
         </fieldset>

--- a/openfecwebapp/templates/partials/committee/disbursements.html
+++ b/openfecwebapp/templates/partials/committee/disbursements.html
@@ -7,18 +7,18 @@
     {{ select.committee_cycle_select(cycles, cycle, 'disbursements')}}
     <div class="entity__figure">
       <div class="row">
-        <fieldset class="toggles u-float-left">
+        <fieldset class="toggles js-toggles u-float-left">
           <legend class="label">Group by:</legend>
           <label for="toggle-recipient">
-            <input id="toggle-recipient" type="radio" class="panel-toggle-control" name="disbursements" value="by-recipient" checked>
+            <input id="toggle-recipient" type="radio" class="js-panel-toggle-control" name="disbursements" value="by-recipient" checked>
             <span class="button--alt">Recipient name</span>
           </label>
           <label for="toggle-to">
-            <input id="toggle-to" type="radio" class="panel-toggle-control" name="disbursements" value="to-committees">
+            <input id="toggle-to" type="radio" class="js-panel-toggle-control" name="disbursements" value="to-committees">
             <span class="button--alt">Recipient committee ID</span>
           </label>
           <label for="toggle-all-disbursements">
-            <input id="toggle-all-disbursements" type="radio" class="panel-toggle-control" name="disbursements" value="itemized-disbursements">
+            <input id="toggle-all-disbursements" type="radio" class="js-panel-toggle-control" name="disbursements" value="itemized-disbursements">
             <span class="button--alt">All transactions</span>
           </label>
         </fieldset>

--- a/openfecwebapp/templates/partials/committee/receipts.html
+++ b/openfecwebapp/templates/partials/committee/receipts.html
@@ -8,26 +8,26 @@
     {{ select.committee_cycle_select(cycles, cycle, 'receipts')}}
     <div class="entity__figure">
       <div class="row">
-        <fieldset class="toggles u-float-left">
+        <fieldset class="toggles js-toggles u-float-left">
           <legend class="label">Group by:</legend>
           <label for="toggle-state">
-            <input id="toggle-state" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-state" checked>
+            <input id="toggle-state" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-state" checked>
             <span class="button--alt">State</span>
           </label>
           <label for="toggle-contribution-size">
-            <input id="toggle-contribution-size" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-contribution-size">
+            <input id="toggle-contribution-size" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-contribution-size">
             <span class="button--alt">Size</span>
           </label>
           <label for="toggle-employer">
-            <input id="toggle-employer" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-employer">
+            <input id="toggle-employer" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-employer">
             <span class="button--alt">Employer</span>
           </label>
           <label for="toggle-occupation">
-            <input id="toggle-occupation" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="by-occupation">
+            <input id="toggle-occupation" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-occupation">
             <span class="button--alt">Occupation</span>
           </label>
           <label for="toggle-itemized">
-            <input id="toggle-itemized" type="radio" class="panel-toggle-control" name="receipt-aggregate" value="itemized-contributions">
+            <input id="toggle-itemized" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="itemized-contributions">
             <span class="button--alt">All transactions</span>
           </label>
         </fieldset>

--- a/openfecwebapp/templates/partials/elections/candidate-comparison-tab.html
+++ b/openfecwebapp/templates/partials/elections/candidate-comparison-tab.html
@@ -36,14 +36,14 @@
       </div>
       <div id="comparison" class="filters--horizontal">
         <div class="row">
-          <fieldset class="toggles">
+          <fieldset class="toggles js-toggles">
             <legend class="label">Group by:</legend>
             <label for="toggle-size">
-              <input id="toggle-size" type="radio" class="panel-toggle-control" name="election-aggregate" value="by-size" checked>
+              <input id="toggle-size" type="radio" class="js-panel-toggle-control" name="election-aggregate" value="by-size" checked>
               <span class="button--alt">Contribution size</span>
             </label>
             <label for="toggle-state">
-              <input id="toggle-state" type="radio" class="panel-toggle-control" name="election-aggregate" value="by-state">
+              <input id="toggle-state" type="radio" class="js-panel-toggle-control" name="election-aggregate" value="by-state">
               <span class="button--alt">Contributor state</span>
             </label>
           </fieldset>

--- a/openfecwebapp/templates/partials/loans-filter.html
+++ b/openfecwebapp/templates/partials/loans-filter.html
@@ -13,7 +13,7 @@
       {{ typeahead.field('committee_id', 'Committee Name or ID') }}
       {{ text.field('loaner_name', 'Loaner name') }}
       {{ date.field('incurred_date', 'Incurred date', dates, id_suffix='_raw') }}
-      {{ range.amount('amount', 'Payment to date') }}
+      {{ range.amount('payment_to_date', 'Payment to date') }}
       {{ range.amount('amount', 'Original loan amount') }}
    </div>
  </div>

--- a/openfecwebapp/templates/partials/reports-filter.html
+++ b/openfecwebapp/templates/partials/reports-filter.html
@@ -57,6 +57,7 @@ Filter reports
   <button type="button" class="js-accordion-trigger accordion__button">Report type</button>
   <div class="accordion__content">
     <fieldset class="js-filter" data-filter="checkbox">
+      <legend class="u-visually-hidden">Report type</legend>
       {{ report_types.year_end() }}
       {% if table_context['form_type'] == 'presidential' %}
         {{ report_types.monthly() }}

--- a/static/js/modules/column-helpers.js
+++ b/static/js/modules/column-helpers.js
@@ -80,7 +80,6 @@ function buildEntityLink(data, url, category, opts) {
   anchor.setAttribute('href', url);
   anchor.setAttribute('title', data);
   anchor.setAttribute('data-category', category);
-  anchor.classList.add('single-link');
 
   if (opts.isIncumbent) {
     anchor.classList.add('is-incumbent');

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -50,6 +50,7 @@ var messageTimer;
 
 // Only show table after draw
 $(document.body).on('draw.dt', function() {
+  $('.dataTable tbody').attr('role', 'rowgroup');
   $('.dataTable tbody td:first-child').attr('scope','row');
 });
 

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -454,6 +454,11 @@ DataTable.prototype.initTable = function() {
 
   this.$body.css('width', '100%');
   this.$body.find('tbody').addClass('js-panel-toggle');
+  // If there's a length select, add the id to the label
+  if ($('#results_length').length) {
+    $('#results_length label').attr('for', 'results-length');
+    $('#results_length select').attr('id', 'results-length');
+  }
 };
 
 DataTable.prototype.initFilters = function() {

--- a/static/js/modules/toggle.js
+++ b/static/js/modules/toggle.js
@@ -1,16 +1,16 @@
 'use strict';
 
-/* global require, module, document */ 
+/* global require, module, document */
 var $ = require('jquery');
 
 module.exports = {
   init: function() {
     $(document).ready(function() {
-      $('.toggles input').each(function(){
+      $('.js-toggles input').each(function(){
         $(this).attr('aria-controls', $(this).attr('value'));
       });
 
-      $('.panel-toggle-control').on('change', function(e) {
+      $('.js-panel-toggle-control').on('change', function(e) {
         var $elm = $(e.target);
         $('[name="' + $elm.attr('name') + '"]').each(function(idx, input) {
           var $input = $(input);


### PR DESCRIPTION
This addresses nearly all of the a11y issues around datatables from https://github.com/18F/openFEC-web-app/issues/1935 .

Chrome Auditor is still showing an error for `Elements with ARIA roles must ensure required owned elements are present`, which as best I can tell was from the `<tr role="row">` elements not being contained within an element with `role="rowgroup"`. I added this and [according to this](https://www.w3.org/TR/wai-aria/roles#rowgroup) it seems like it should pass, so I'm not sure why it's not.