### PR TITLE
Use full_election for totals

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -233,7 +233,7 @@ def load_cmte_financials(committee_id, **filters):
 def load_candidate_totals(candidate_id, cycle, election_full=True):
     response = _call_api(
         'candidate', candidate_id, 'totals',
-        cycle=cycle, election_full=election_full,
+        cycle=cycle, full_election=election_full,
     )
 
     return response['results'][0] if response['results'] else None


### PR DESCRIPTION
What we initially thought was incorrect coverage dates for the full election totals on candidate pages turned out that it wasn't showing the full election totals at all. The API expects the parameter to be `full_election` but the app incorrectly was sending `election_full`. Fixing that fixes the totals and the coverage dates:

![image](https://cloud.githubusercontent.com/assets/1696495/25683658/1af34cfc-3012-11e7-825f-553d44adb8ce.png)

Resolves https://github.com/18F/openFEC-web-app/issues/2008