### PR TITLE
Feature/remove disabled components

### DIFF
--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -69,6 +69,23 @@
         </div>
         {{ overviews.overview('raised', 'landing')}}
          <a class="breakdown-link" href="{{ url_for('raising_breakdown') }}">Raising breakdown &raquo;</a>
+         <ul class="grid grid--4-wide t-sans">
+           <li class="grid__item">
+             <a href="{{ url_for('raising_breakdown') }}#top-raisers" class="icon-heading--graph-circle">
+               <span>Who's raising the most</span>
+             </a>
+           </li>
+           <li class="grid__item is-disabled">
+             <span class="icon-heading--map-circle" title="Coming soon">
+               <span>Where contributions come from</span>
+             </span>
+           </li>
+           <li class="grid__item is-disabled">
+             <span class="icon-heading--graph-unordered-circle" title="Coming soon">
+               <span>The size of contributions</span>
+             </span>
+           </li>
+         </ul>
       </div>
     </section>
     <section class="content__section content__section--ruled" id="spending">
@@ -86,6 +103,23 @@
         </div>
         {{ overviews.overview('spent', 'landing')}}
         <a class="breakdown-link" href="{{ url_for('spending_breakdown') }}">Spending breakdown &raquo;</a>
+        <ul class="grid grid--4-wide t-sans">
+          <li class="grid__item">
+            <a href="{{ url_for('spending_breakdown') }}#top-spenders" class="icon-heading--graph-circle">
+              <span>Who's spending the most</span>
+            </a>
+          </li>
+          <li class="grid__item is-disabled">
+            <span class="icon-heading--graph-unordered-circle" title="Coming soon">
+              <span>What's spent on day-to-day activities</span>
+            </span>
+          </li>
+          <li class="grid__item is-disabled">
+            <span class="icon-heading--map-circle" title="Coming soon">
+              <span>Where money is spent to support and oppose candidates</span>
+            </span>
+          </li>
+        </ul>
       </div>
     </section>
     <section class="content__section--extra">

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -64,7 +64,6 @@
               <li><a class="button button--standard button--table" href="{{ url_for('receipts') }}">Explore data</a></li>
               <li><button class="button button--standard js-ga-event"  data-a11y-dialog-show="raised-modal" data-ga-event="Raised methodology modal clicked" aria-controls="raised-modal">
               Methodology</button></li>
-              <li><button class="button button--standard button--share is-disabled">Share</button></li>
             </ul>
           </div>
         </div>
@@ -82,7 +81,6 @@
             <ul class="list--buttons">
               <li><a class="button button--standard button--table" href="{{ url_for('disbursements') }}">Explore data</a></li>
               <li><button class="button button--standard js-ga-event"  data-a11y-dialog-show="spending-modal" data-ga-event="Spending methodology modal clicked" aria-controls="spending-modal">Methodology</button></li>
-              <li><button class="button button--standard button--share is-disabled">Share</button></li>
             </ul>
           </div>
         </div>

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -72,18 +72,18 @@
          <ul class="grid grid--4-wide t-sans">
            <li class="grid__item">
              <a href="{{ url_for('raising_breakdown') }}#top-raisers" class="icon-heading--graph-circle">
-               <span>Who's raising the most</span>
+               <div class="icon-heading__text"><span>Who's raising the most</span></div>
              </a>
            </li>
            <li class="grid__item is-disabled">
-             <span class="icon-heading--map-circle" title="Coming soon">
-               <span>Where contributions come from</span>
-             </span>
+             <div class="icon-heading--map-circle" title="Coming soon">
+               <div class="icon-heading__text"><span>Where contributions come from</span></div>
+             </div>
            </li>
            <li class="grid__item is-disabled">
-             <span class="icon-heading--graph-unordered-circle" title="Coming soon">
-               <span>The size of contributions</span>
-             </span>
+             <div class="icon-heading--graph-unordered-circle" title="Coming soon">
+               <div class="icon-heading__text"><span>The size of contributions</span></div>
+             </div>
            </li>
          </ul>
       </div>
@@ -106,18 +106,18 @@
         <ul class="grid grid--4-wide t-sans">
           <li class="grid__item">
             <a href="{{ url_for('spending_breakdown') }}#top-spenders" class="icon-heading--graph-circle">
-              <span>Who's spending the most</span>
+              <div class="icon-heading__text"><span>Who's spending the most</span></div>
             </a>
           </li>
           <li class="grid__item is-disabled">
-            <span class="icon-heading--graph-unordered-circle" title="Coming soon">
-              <span>What's spent on day-to-day activities</span>
-            </span>
+            <div class="icon-heading--graph-unordered-circle" title="Coming soon">
+              <div class="icon-heading__text"><span>What's spent on day-to-day activities</span></div>
+            </div>
           </li>
           <li class="grid__item is-disabled">
-            <span class="icon-heading--map-circle" title="Coming soon">
-              <span>Where money is spent to support and oppose candidates</span>
-            </span>
+            <div class="icon-heading--map-circle" title="Coming soon">
+              <div class="icon-heading__text"><span>Where money is spent to support and oppose candidates</span></div>
+            </div>
           </li>
         </ul>
       </div>

--- a/openfecwebapp/templates/macros/breakdowns.html
+++ b/openfecwebapp/templates/macros/breakdowns.html
@@ -8,8 +8,6 @@
   page_info
 ) %}
 
-{% import 'macros/reaction-box.html' as reaction_box %}
-
 {% if category in ['P', 'S', 'H'] %}
   {% set name_field='name' %}
   {% set id_field='candidate_id' %}
@@ -82,5 +80,4 @@
     <li><button class="button button--alt js-ga-event"  data-a11y-dialog-show="{{ action }}-modal" data-ga-event="{{ action }} methodology modal clicked" aria-controls="{{ action }}-modal">Methodology</button></li>
   </ul>
 </div>
-{{ reaction_box.reaction_box('top-entities', action + '-breakdown')}}
 {% endmacro %}

--- a/openfecwebapp/templates/macros/breakdowns.html
+++ b/openfecwebapp/templates/macros/breakdowns.html
@@ -75,7 +75,6 @@
 </div>
 <div class="content__section row">
   <ul class="list--buttons u-float-right">
-    <li><button class="button button--standard button--share is-disabled">Share</button></li>
     <li><a class="button button--standard button--table" href="{{ url_for(value_field) }}">Browse {{value_field}}</a></li>
     <li><button class="button button--alt js-ga-event"  data-a11y-dialog-show="{{ action }}-modal" data-ga-event="{{ action }} methodology modal clicked" aria-controls="{{ action }}-modal">Methodology</button></li>
   </ul>

--- a/openfecwebapp/templates/macros/overviews.html
+++ b/openfecwebapp/templates/macros/overviews.html
@@ -1,5 +1,3 @@
-{% import 'macros/reaction-box.html' as reaction_box %}
-
 {% macro overview(verb, location) %}
   <div class="overview js-{{verb}}-overview">
     <div class="overview__chart js-chart">
@@ -49,9 +47,6 @@
         </span>
       </div>
     </div>
-  </div>
-  <div class="overview__feedback">
-    {{ reaction_box.reaction_box(verb, location)}}
   </div>
 {% endmacro %}
 

--- a/static/js/pages/breakdowns.js
+++ b/static/js/pages/breakdowns.js
@@ -4,14 +4,9 @@
 
 var $ = require('jquery');
 var analytics = require('fec-style/js/analytics');
-var ReactionBox = require('../modules/reaction-box').ReactionBox;
 var TopEntities = require('../modules/top-entities').TopEntities;
 
 new TopEntities('.js-top-entities', context.type);
-
-$('.js-reaction-box').each(function() {
-  new ReactionBox(this);
-});
 
 $('.js-ga-event').each(function() {
   var eventName = $(this).data('ga-event');

--- a/static/js/pages/landing.js
+++ b/static/js/pages/landing.js
@@ -6,7 +6,6 @@ var $ = require('jquery');
 
 var LineChart = require('../modules/line-chart').LineChart;
 var TopList = require('../modules/top-list').TopList;
-var ReactionBox = require('../modules/reaction-box').ReactionBox;
 var helpers = require('../modules/helpers');
 var analytics = require('fec-style/js/analytics');
 
@@ -17,7 +16,6 @@ function Overview(selector, type, index) {
   this.index = index;
 
   this.totals = this.$element.find('.js-total');
-  this.reactionBox = this.$element.find('.js-reaction-box');
 
   this.zeroPadTotals();
 
@@ -32,11 +30,6 @@ Overview.prototype.zeroPadTotals = function() {
 
 new Overview('.js-raised-overview', 'raised', 1);
 new Overview('.js-spent-overview', 'spent', 2);
-
-
-$('.js-reaction-box').each(function() {
-  new ReactionBox(this);
-});
 
 var maxHeight = 0;
 var $topLists = $('.js-top-list');

--- a/static/templates/tables/exportWidget.hbs
+++ b/static/templates/tables/exportWidget.hbs
@@ -1,7 +1,6 @@
 <div class="data-container__head">
   <h1 class="data-container__title">{{this.title}} data</h1>
   <div class="data-container__action">
-    <button class="data-container__share button--standard button--share is-disabled" type="button">Share</button>
     <div class="data-container__export js-tooltip-container">
       <button type="button"
         class="js-export button button--cta button--export">


### PR DESCRIPTION
This removes the reaction boxes and disabled share buttons in preparation for the flip.

It also adds the active and pending links to the breakdown pages below the overview charts:

![image](https://cloud.githubusercontent.com/assets/1696495/25729723/132c5ccc-30ec-11e7-8023-ea88bb4e45cf.png)

![image](https://cloud.githubusercontent.com/assets/1696495/25729734/269a96e8-30ec-11e7-90ba-e83ade5f04ee.png)

Resolves https://github.com/18F/openFEC-web-app/issues/1994
Resolves https://github.com/18F/fec-cms/issues/1034