### PR TITLE
Feature/fix candidate cycle logic

### DIFF
--- a/openfecwebapp/templates/partials/candidate/about-candidate.html
+++ b/openfecwebapp/templates/partials/candidate/about-candidate.html
@@ -61,12 +61,12 @@
       <div class="usa-width-one-fourth">
         <div class="card">
           {% if election_url(context(), cycle) %}
-          <a href="{{ election_url(context(), cycle) }}">
+          <a href="{{ election_url(context(), election_year) }}">
             <div class="card__image__container">
               <img class="icon--complex" src="/static/img/i-elections--primary.svg" alt="Icon representing elections">
             </div>
             <div class="card__content">
-              View all candidates in the {{ cycle }} {{ constants.states[state] }} {% if office == 'P' %}Presidential{% else %}{{ office_full }}{% endif %}{% if office_full == 'House' %} district {{ district }}{% endif %} election
+              View all candidates in the {{ election_year }} {{ constants.states[state] }} {% if office == 'P' %}Presidential{% else %}{{ office_full }}{% endif %}{% if office_full == 'House' %} district {{ district }}{% endif %} election
             </div>
           </a>
           {% endif %}

--- a/openfecwebapp/templates/partials/candidate/financial-summary.html
+++ b/openfecwebapp/templates/partials/candidate/financial-summary.html
@@ -30,7 +30,7 @@
             </div>
             <div class="u-float-right">
               <a class="heading__right button--alt button--browse"
-                  href="{{ url_for('receipts', committee_id=committee_ids, cycle=cycle) }}">Browse receipts
+                  href="{{ url_for('receipts', committee_id=committee_ids, two_year_transaction_period=max_cycle) }}">Browse receipts
               </a>
             </div>
         </div>
@@ -44,7 +44,7 @@
             </div>
             <div class="u-float-right">
               <a class="heading__right button--alt button--browse"
-                  href="{{ url_for('disbursements', committee_id=committee_ids, cycle=cycle) }}">Browse disbursements
+                  href="{{ url_for('disbursements', committee_id=committee_ids, two_year_transaction_period=max_cycle) }}">Browse disbursements
               </a>
             </div>
         </div>

--- a/openfecwebapp/templates/partials/candidate/individual-contributions.html
+++ b/openfecwebapp/templates/partials/candidate/individual-contributions.html
@@ -7,20 +7,20 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 
-    {{ select.candidate_cycle_select(cycles, cycle, id="cycle-5") }}
+    {{ select.candidate_cycle_select(cycles, max_cycle, id="cycle-5") }}
 
   <span class="t-sans t-bold">Data is included from these committees:</span>
 
   <ul class="list--bulleted">
     {% for committee in committee_groups['P'] | reverse %}
-    {% if committee.cycle == cycle %}
+    {% if committee.cycle == max_cycle %}
     <li>
       <a class="t-sans" href="{{ url_for('committee_page', c_id=committee.committee_id, cycle=committee.related_cycle) }}">{{ committee.name }}</a>
     </li>
     {% endif %}
     {% endfor %}
     {% for committee in committee_groups['A'] | reverse %}
-    {% if committee.cycle == cycle %}
+    {% if committee.cycle == max_cycle %}
     <li>
       <a class="t-sans" href="{{ url_for('committee_page', c_id=committee.committee_id, cycle=committee.related_cycle) }}">{{ committee.name }}</a>
     </li>
@@ -41,9 +41,9 @@
           <a class="u-float-right button--alt button--browse"
               href="{{ url_for(
                 'individual_contributions',
-                two_year_transaction_period=cycle,
-                min_date=cycle_start(cycle) | date(fmt='%m-%d-%Y'),
-                max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y')
+                two_year_transaction_period=max_cycle,
+                min_date=cycle_start(max_cycle) | date(fmt='%m-%d-%Y'),
+                max_date=cycle_end(max_cycle) | date(fmt='%m-%d-%Y')
               ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
 
           <label for="toggle-state">
@@ -66,7 +66,7 @@
         <div class="results-info results-info--simple">
           <ul class="u-float-left">
             <li class="tag__category">
-              <div class="tag__item">Report year: {{cycle - 1}} to {{cycle}}</div>
+              <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
             </li>
           </ul>
 
@@ -77,7 +77,7 @@
           <table
               class="data-table data-table--heading-borders"
               data-type="contributor-state"
-              data-cycle="{{ cycle }}"
+              data-cycle="{{ max_cycle }}"
             >
             <thead>
               <th scope="col">State</th>
@@ -87,7 +87,7 @@
         </div>
 
         <div class="map-panel">
-          <div class="state-map" data-candidate-id="{{ candidate_id }}" data-cycle="{{ cycle }}">
+          <div class="state-map" data-candidate-id="{{ candidate_id }}" data-cycle="{{ max_cycle }}">
             <div class="legend-container">
               <span class="t-sans t-block">By state: total amount received</span>
               <svg></svg>
@@ -101,7 +101,7 @@
         <div class="results-info results-info--simple">
           <ul class="u-float-left">
             <li class="tag__category">
-              <div class="tag__item">Report year: {{cycle - 1}} to {{cycle}}</div>
+              <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
             </li>
           </ul>
 
@@ -111,7 +111,7 @@
         <table
            class="data-table data-table--heading-borders"
            data-type="contribution-size"
-           data-cycle="{{ cycle }}">
+           data-cycle="{{ max_cycle }}">
           <thead>
             <th scope="col">Contribution size</th>
             <th scope="col">Total contributed</th>
@@ -123,7 +123,7 @@
         <div class="results-info results-info--simple">
           <ul class="u-float-left">
             <li class="tag__category">
-              <div class="tag__item">Report year: {{cycle - 1}} to {{cycle}}</div>
+              <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
             </li>
           </ul>
 
@@ -141,7 +141,7 @@
             data-candidate-id="{{ candidate_id }}"
             data-committee-id="{% for c in committee_groups['P'] | reverse %}{{ c.committee_id }},{% endfor %}{% for c in committee_groups['A'] | reverse %}{{ c.committee_id }},{% endfor %}"
             data-name="{{ name }}"
-            data-cycle="{{ cycle }}"
+            data-cycle="{{ max_cycle }}"
           >
           <thead>
             <tr>

--- a/openfecwebapp/templates/partials/candidate/itemized-disbursements.html
+++ b/openfecwebapp/templates/partials/candidate/itemized-disbursements.html
@@ -9,20 +9,20 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 
-    {{ select.candidate_cycle_select(cycles, cycle, id="cycle-4") }}
+    {{ select.candidate_cycle_select(cycles, max_cycle, id="cycle-4") }}
 
     <span class="t-sans t-bold">Data is included from these committees:</span>
 
     <ul class="list--bulleted">
       {% for committee in committee_groups['P'] | reverse %}
-      {% if committee.cycle == cycle %}
+      {% if committee.cycle == max_cycle %}
       <li>
         <a class="t-sans" href="{{ url_for('committee_page', c_id=committee.committee_id, cycle=committee.related_cycle) }}">{{ committee.name }}</a>
       </li>
       {% endif %}
       {% endfor %}
       {% for committee in committee_groups['A'] | reverse %}
-      {% if committee.cycle == cycle %}
+      {% if committee.cycle == max_cycle %}
       <li>
         <a class="t-sans" href="{{ url_for('committee_page', c_id=committee.committee_id, cycle=committee.related_cycle) }}">{{ committee.name }}</a>
       </li>
@@ -39,14 +39,14 @@
           <a class="u-float-right button--alt button--browse"
               href="{{ url_for(
                 'disbursements',
-                two_year_transaction_period=cycle,
-                min_date=cycle_start(cycle) | date(fmt='%m-%d-%Y'),
-                max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y')
+                two_year_transaction_period=max_cycle,
+                min_date=cycle_start(max_cycle) | date(fmt='%m-%d-%Y'),
+                max_date=cycle_end(max_cycle) | date(fmt='%m-%d-%Y')
               ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
 
           <ul>
             <li class="tag__category">
-              <div class="tag__item">Report year: {{cycle - 1}} to {{cycle}}</div>
+              <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
             </li>
           </ul>
 
@@ -62,7 +62,7 @@
             data-type="itemized-disbursements"
             data-committee-id="{% for id in committee_ids %}{{ id }}{% if not loop.last %},{% endif %}{% endfor %}"
             data-name="{{ name }}"
-            data-cycle="{{ cycle }}"
+            data-cycle="{{ max_cycle }}"
           >
           <thead>
             <tr>

--- a/openfecwebapp/templates/partials/candidate/other-spending-tab.html
+++ b/openfecwebapp/templates/partials/candidate/other-spending-tab.html
@@ -1,83 +1,84 @@
 {% import 'macros/cycle-select.html' as select %}
 
 <section id="section-3" role="tabpanel" aria-hidden="true" aria-labelledby="section-3-heading">
+  <div class="heading--section">
+    <h2 id="section-3-heading">Spending by others to oppose/support</h2>
+  </div>
   <div class="content__section">
-    <div class="heading--section">
-      <h2 id="section-3-heading">Spending by others to oppose/support</h2>
-    </div>
+    <p class="usa-width-two-thirds">This tab shows spending that opposes or supports this candidate. None of the funds are directly given to or spent by the candidate.</p>
+  </div>
 
+  <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     <div class="content__section">
       {{ select.cycle_select(election_years, cycle, duration=duration, id="cycle-3") }}
     </div>
 
-    <p class="usa-width-two-thirds">This tab shows spending that opposes or supports this candidate. None of the funds are directly given to or spent by the candidate.</p>
-  </div>
+    <div class="entity__figure row">
+      <div class="results-info results-info--simple">
+        <h3 class="results-info__title">Independent expenditures</h3>
+      </div>
+      <table
+          class="data-table data-table--heading-borders"
+          data-type="independent-expenditures"
+          data-candidate="{{ candidate_id }}"
+          data-cycle="{{ max_cycle }}"
+          data-election-full="{{ show_full_election }}"
+        >
+        <thead>
+          <tr>
+            <th scope="col">Aggregate amount</th>
+            <th scope="col">Spent by</th>
+            <th scope="col">Support/Oppose</th>
+          </tr>
+        </thead>
+      </table>
+      <div class="datatable__note">
+        <p class="t-note">These totals are drawn from quarterly, monthly and semi-annual reports. 24- and 48-Hour Reports of independent expenditures aren't included.</p>
+      </div>
+    </div>
 
-  <div class="content__section">
-    <div class="results-info results-info--simple">
-      <h3 class="results-info__title">Independent expenditures</h3>
+    <div class="entity__figure row">
+      <div class="results-info results-info--simple">
+        <h3 class="results-info__title">Communication costs</h3>
+      </div>
+      <table
+          class="data-table data-table--heading-borders"
+          data-type="communication-costs"
+          data-candidate="{{ candidate_id }}"
+          data-cycle="{{ max_cycle }}"
+          data-election-full="{{ show_full_election }}"
+        >
+        <thead>
+          <tr>
+            <th scope="col">Aggregate amount</th>
+            <th scope="col">Spent by</th>
+            <th scope="col">Support/Oppose</th>
+          </tr>
+        </thead>
+      </table>
     </div>
-    <table
-        class="data-table data-table--heading-borders"
-        data-type="independent-expenditures"
-        data-candidate="{{ candidate_id }}"
-        data-cycle="{{ cycle }}"
-        data-election-full="{{ election_full }}"
-      >
-      <thead>
-        <tr>
-          <th scope="col">Aggregate amount</th>
-          <th scope="col">Spent by</th>
-          <th scope="col">Support/Oppose</th>
-        </tr>
-      </thead>
-    </table>
-    <div class="datatable__note">
-      <p class="t-note">These totals are drawn from quarterly, monthly and semi-annual reports. 24- and 48-Hour Reports of independent expenditures aren't included.</p>
-    </div>
-  </div>
 
-  <div class="content__section">
-    <div class="results-info results-info--simple">
-      <h3 class="results-info__title">Communication costs</h3>
-    </div>
-    <table
-        class="data-table data-table--heading-borders"
-        data-type="communication-costs"
-        data-candidate="{{ candidate_id }}"
-        data-cycle="{{ cycle }}"
-        data-election-full="{{ election_full }}"
-      >
-      <thead>
-        <tr>
-          <th scope="col">Aggregate amount</th>
-          <th scope="col">Spent by</th>
-          <th scope="col">Support/Oppose</th>
-        </tr>
-      </thead>
-    </table>
-  </div>
-
-  <div class="content__section">
-    <div class="results-info results-info--simple">
-      <h3 class="results-info__title">Electioneering communications</h3>
-    </div>
-    <table
-        class="data-table data-table--heading-borders"
-        data-type="electioneering"
-        data-candidate="{{ candidate_id }}"
-        data-cycle="{{ cycle }}"
-        data-election-full="{{ election_full }}"
-      >
-      <thead>
-        <tr>
-          <th scope="col">Aggregate amount</th>
-          <th scope="col">Spent by</th>
-        </tr>
-      </thead>
-    </table>
-    <div class="datatable__note">
-      <p class="t-note">To help users work with this data, we divide each itemized disbursement amount by the number of federal candidates named in connection with that disbursement. The resulting amount is listed here.</p>
+    <div class="entity__figure row">
+      <div class="results-info results-info--simple">
+        <h3 class="results-info__title">Electioneering communications</h3>
+      </div>
+      <table
+          class="data-table data-table--heading-borders"
+          data-type="electioneering"
+          data-candidate="{{ candidate_id }}"
+          data-cycle="{{ max_cycle }}"
+          data-election-full="{{ show_full_election }}"
+        >
+        <thead>
+          <tr>
+            <th scope="col">Aggregate amount</th>
+            <th scope="col">Spent by</th>
+          </tr>
+        </thead>
+      </table>
+      <div class="datatable__note">
+        <p class="t-note">To help users work with this data, we divide each itemized disbursement amount by the number of federal candidates named in connection with that disbursement. The resulting amount is listed here.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/openfecwebapp/templates/partials/candidate/other-spending-tab.html
+++ b/openfecwebapp/templates/partials/candidate/other-spending-tab.html
@@ -1,8 +1,8 @@
 {% import 'macros/cycle-select.html' as select %}
 
-<section id="section-3" role="tabpanel" aria-hidden="true" aria-labelledby="section-3-heading">
+<section id="section-5" role="tabpanel" aria-hidden="true" aria-labelledby="section-5-heading">
   <div class="heading--section">
-    <h2 id="section-3-heading">Spending by others to oppose/support</h2>
+    <h2 id="section-5-heading">Spending by others to oppose/support</h2>
   </div>
   <div class="content__section">
     <p class="usa-width-two-thirds">This tab shows spending that opposes or supports this candidate. None of the funds are directly given to or spent by the candidate.</p>

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -187,6 +187,10 @@ def render_candidate(candidate, committees, cycle, election_full=True):
     tmpl_vars = candidate
     tmpl_vars['parent'] = 'data'
     tmpl_vars['cycle'] = cycle
+    tmpl_vars['election_year'] = next(
+        (year for year in sorted(candidate['election_years']) if year >= cycle),
+        None,
+    )
     tmpl_vars['result_type'] = 'candidates'
     tmpl_vars['duration'] = election_durations.get(candidate['office'], 2)
     tmpl_vars['election_full'] = election_full
@@ -258,10 +262,6 @@ def render_candidate(candidate, committees, cycle, election_full=True):
         zip(candidate['election_years'], candidate['election_districts']),
         key=lambda pair: pair[0],
         reverse=True,
-    )
-    tmpl_vars['election_year'] = next(
-        (year for year in sorted(candidate['election_years']) if year >= cycle),
-        None,
     )
 
     return render_template('candidates-single.html', **tmpl_vars)

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -185,19 +185,31 @@ report_types = {
 def render_candidate(candidate, committees, cycle, election_full=True):
     # candidate fields will be top-level in the template
     tmpl_vars = candidate
-
     tmpl_vars['parent'] = 'data'
     tmpl_vars['cycle'] = cycle
     tmpl_vars['result_type'] = 'candidates'
     tmpl_vars['duration'] = election_durations.get(candidate['office'], 2)
     tmpl_vars['election_full'] = election_full
+    tmpl_vars['report_type'] = report_types.get(candidate['office'])
+    tmpl_vars['context_vars'] = {'cycles': candidate['cycles'], 'name': candidate['name']}
+
+    # In the case of when a presidential or senate candidate has filed
+    # for a future year that's beyond the current cycle,
+    # set a max_cycle var to the current cycle we're in
+    # and when calling the API for totals, set election_full to False.
+    # The max_cycle value is also referenced in the templates for setting
+    # the cycle for itemized tables. Because these are only in 2-year chunks,
+    # the cycle should never be beyond the one we're in.
+    tmpl_vars['cycles'] = [cycle for cycle in candidate['cycles'] if cycle <= utils.current_cycle()]
+    tmpl_vars['max_cycle'] = cycle if cycle <= utils.current_cycle() else utils.current_cycle()
+    tmpl_vars['show_full_election'] = election_full if cycle <= utils.current_cycle() else False
+
+    # Annotate committees with most recent available cycle
     tmpl_vars['aggregate_cycles'] = (
         list(range(cycle, cycle - tmpl_vars['duration'], -2))
         if election_full
         else [cycle]
     )
-
-    # Annotate committees with most recent available cycle
     for committee in committees:
         committee['related_cycle'] = (
             max(cycle for cycle in tmpl_vars['aggregate_cycles'] if cycle in committee['cycles'])
@@ -205,15 +217,29 @@ def render_candidate(candidate, committees, cycle, election_full=True):
             else candidate['two_year_period']
         )
 
+    # Group the committees by designation
     committee_groups = groupby(committees, lambda each: each['designation'])
     committees_authorized = committee_groups.get('P', []) + committee_groups.get('A', [])
 
+    tmpl_vars['committee_groups'] = committee_groups
+    tmpl_vars['committees_authorized'] = committees_authorized
+    tmpl_vars['committee_ids'] = [committee['committee_id'] for committee in committees_authorized]
+
+    # Get aggregate totals for the financial summary
+    # And pass through the data processing utils
     aggregate = api_caller.load_candidate_totals(
         candidate['candidate_id'],
-        cycle=cycle,
-        election_full=election_full,
+        cycle=tmpl_vars['max_cycle'],
+        election_full=tmpl_vars['show_full_election'],
     )
+    if aggregate:
+        tmpl_vars['raising_summary'] = utils.process_raising_data(aggregate)
+        tmpl_vars['spending_summary'] = utils.process_spending_data(aggregate)
+        tmpl_vars['cash_summary'] = utils.process_cash_data(aggregate)
 
+    tmpl_vars['aggregate'] = aggregate
+
+    # Get the statements of candidacy
     statement_of_candidacy = api_caller.load_candidate_statement_of_candidacy(
         candidate['candidate_id'],
         cycle=cycle
@@ -227,11 +253,7 @@ def render_candidate(candidate, committees, cycle, election_full=True):
 
     tmpl_vars['statement_of_candidacy'] = statement_of_candidacy
 
-    tmpl_vars['committee_groups'] = committee_groups
-    tmpl_vars['committees_authorized'] = committees_authorized
-    tmpl_vars['committee_ids'] = [committee['committee_id'] for committee in committees_authorized]
-    tmpl_vars['aggregate'] = aggregate
-
+    # Get all the elections
     tmpl_vars['elections'] = sorted(
         zip(candidate['election_years'], candidate['election_districts']),
         key=lambda pair: pair[0],
@@ -241,16 +263,6 @@ def render_candidate(candidate, committees, cycle, election_full=True):
         (year for year in sorted(candidate['election_years']) if year >= cycle),
         None,
     )
-
-    tmpl_vars['report_type'] = report_types.get(candidate['office'])
-    tmpl_vars['context_vars'] = {'cycles': candidate['cycles'], 'name': candidate['name']}
-
-    tmpl_vars['cycles'] = [cycle for cycle in candidate['cycles'] if cycle <= max(candidate['election_years'])]
-
-    if aggregate:
-        tmpl_vars['raising_summary'] = utils.process_raising_data(aggregate)
-        tmpl_vars['spending_summary'] = utils.process_spending_data(aggregate)
-        tmpl_vars['cash_summary'] = utils.process_cash_data(aggregate)
 
     return render_template('candidates-single.html', **tmpl_vars)
 


### PR DESCRIPTION
This fixes a few interrelated snags on the candidate pages having to do with the logic around cycles / election years / full 4 and 6 year time periods.

**The problem:** So you're going to a presidential candidate who ran in 2016. The current behavior when going to a candidate page is to load it with `cycle=2016` and `election_full=true`, and then the page will show aggregated data for the 2014 and 2016 cycles. This works fine. 

But the problem is with future dates. Senate and presidential candidates often file to run for office for a year that's 4 or 6 years in the future. The current behavior in this cases is to load the candidate page with `cycle=2020` and `election_full=true`. This causes three problems:

1. Behind the scenes, we use the 2020 value for all API queries for totals and itemized data; e.g. `/schedule_a/?two_year_transaction_period=2020`. While there might be data for the 2018 cycle, which we're in, there will never be data for the 2020 cycle until we're in the year 2019. This results in empty contribution and disbursement tables when looking at the default time period for a candidate currently running for president or senate (https://github.com/18F/openFEC-web-app/issues/1985).

2. When calling the `/totals/` endpoint with `full_election=true`, it currently returns no results because the time period requested includes a time period that hasn't happened yet. That's why when you go to [Schumer's profile](https://beta.fec.gov/data/candidate/S8NY00082/?cycle=2022&election_full=True) there are no results, but if you toggle to 2017-2018, the data shows up.

3. As @jontours uncovered in https://github.com/18F/openFEC/issues/2364, passing a future cycle to the `schedule_e` aggregates also results in null data.

**The solution:** Rather than use the regular `cycle` value for all of the logic explained above, I added logic to set a `max_cycle`. If the `cycle` is before or equal to the current cycle we're in, it stays the same. If it's in the future (i.e. 2020 or later), `max_cycle` will be our current cycle. All of the API calls then use `max_cycle` to get data. 

Similarly, if the request was for `election_full=true` but the `cycle` is in the future, it sets `show_full_election` to `false` so that we're not trying to aggregate data that doesn't yet exist.

**However!** In doing this, I uncovered what seems to be an API bug. #2000 fixed the `/totals/` call by using the correct `full_election` param instead of `election_full`. However, there seems to be a bug in the case of a candidate who only has financial info for _part_ of a full cycle ([like this](https://fec-dev-proxy.app.cloud.gov/data/candidate/P80001571/?cycle=2016&election_full=true)), the API returns nothing. This isn't visible on production because the API call is passing the wrong param, so it's just being ignored, but you can see on dev.

Resolves https://github.com/18F/openFEC-web-app/issues/1985
Resolves https://github.com/18F/openFEC/issues/2364