### PR TITLE
Updates footer links

### DIFF
--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -129,6 +129,9 @@
             <li>
               <a href="{{ cms_url }}/about/no-fear-act/">No FEAR Act</a>
             </li>
+            <li>
+              <a href="/about/reports-about-fec/strategy-budget-and-performance/">Strategy, budget and performance</a>
+            </li>
           </ul>
         </div>
 
@@ -152,13 +155,13 @@
               <a href="https://www.data.gov/open-gov/">Open government</a>
             </li>
             <li>
-              <a href="https://www.foia.gov/">FOIA</a>
-            </li>
-            <li>
               <a href="https://www.usa.gov/">USA.gov</a>
             </li>
             <li>
               <a href="{{ transition_url }}/fecig/fecig.shtml">Inspector General</a>
+            </li>
+            <li>
+              <a href="/freedom-information-act/">FOIA</a>
             </li>
           </ul>
         </div>

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -130,7 +130,7 @@
               <a href="{{ cms_url }}/about/no-fear-act/">No FEAR Act</a>
             </li>
             <li>
-              <a href="/about/reports-about-fec/strategy-budget-and-performance/">Strategy, budget and performance</a>
+              <a href="{{ cms_url }}/about/reports-about-fec/strategy-budget-and-performance/">Strategy, budget and performance</a>
             </li>
           </ul>
         </div>
@@ -161,7 +161,7 @@
               <a href="{{ transition_url }}/fecig/fecig.shtml">Inspector General</a>
             </li>
             <li>
-              <a href="/freedom-information-act/">FOIA</a>
+              <a href="{{ cms_url }}/freedom-information-act/">FOIA</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
- Links to FOIA page
- Makes FOIA bottom link (so it's on the same latitude as Press; makes it easier to scan across)
- Links to strategy and budget page

These changes are also incorporated in fec-cms: https://github.com/18F/fec-cms/pull/1037

cc @noahmanger 