### PR TITLE
Feature/committee type filters

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -230,18 +230,16 @@ disbursement_categories = OrderedDict([
 ])
 
 pac_party_types = OrderedDict([
-    ('C', 'Communication cost'),
-    ('D', 'Delegate committee'),
-    ('E', 'Electioneering communication'),
-    ('Z', 'National party nonfederal account'),
     ('N', 'PAC - nonqualified'),
     ('Q', 'PAC - qualified'),
     ('V', 'PAC with non-contribution account - nonqualified'),
     ('W', 'PAC with non-contribution account - qualified'),
     ('P', 'Party - nonqualified'),
     ('Y', 'Party - qualified'),
+    ('Z', 'National party nonfederal account'),
     ('U', 'Single candidate independent expenditure'),
-    ('O', 'Super PAC (independent expenditure only')
+    ('O', 'Super PAC (independent expenditure only'),
+    ('I', 'Independent expenditor (person or group)')
 ])
 
 house_senate_types = OrderedDict([

--- a/openfecwebapp/templates/partials/reports-filter.html
+++ b/openfecwebapp/templates/partials/reports-filter.html
@@ -28,6 +28,25 @@ Filter reports
   <button type="button" class="js-accordion-trigger accordion__button">Filer</button>
   <div class="accordion__content">
     {{ typeahead.field('committee_id', 'Committee name or ID', '') }}
+    {% if table_context['form_type'] == 'presidential' %}
+      {{ typeahead.field('candidate_id', 'Authorizing candidate', dataset='candidates') }}
+    {% elif table_context['form_type'] == 'house-senate' %}
+      {{ typeahead.field('candidate_id', 'Authorizing candidate', dataset='candidates') }}
+      <fieldset class="filter js-filter" data-filter="checkbox">
+      <legend class="label">Committee type</legend>
+      <ul>
+        {% for value, label in constants.house_senate_types.items() %}
+        <li>
+          <input id="type-{{ value }}" name="type" type="checkbox" value="{{ value }}">
+          <label for="type-{{ value }}">{{ label }}</label>
+        </li>
+        {% endfor %}
+      </ul>
+    </fieldset>
+    {% elif table_context['form_type'] == 'pac-party' %}
+      {{ checkbox.checkbox_dropdown('type', 'Committee type', options=constants.pac_party_types) }}
+    </fieldset>
+    {% endif %}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Version</button>
   <div class="accordion__content">


### PR DESCRIPTION
This adds a couple filters to the reports pages that we always meant to add (from the master [column/filter spreadsheet](https://docs.google.com/spreadsheets/d/1-LjKQy3dOJI9FJmrhNEfgsr-uD7HzzH0qf1zpo3azTE/edit#gid=1983288278)). They were available on the API, so this was a 5 min. add.

It adds an authorizing candidate filter to presidential and house-senate pages:
![image](https://cloud.githubusercontent.com/assets/1696495/25915547/b1af819c-3576-11e7-81c1-f7d9f9d67dba.png)

And a committee type filter for house-senate and pac-party. On house-senate:
![image](https://cloud.githubusercontent.com/assets/1696495/25915566/c221e95c-3576-11e7-83bc-9e7313932cdf.png)

On pac-party:
![image](https://cloud.githubusercontent.com/assets/1696495/25915574/cab5131e-3576-11e7-8e51-667fc701622f.png)

Resolves https://github.com/18F/openFEC-web-app/issues/2024