### PR TITLE
Election year filter

### DIFF
--- a/openfecwebapp/templates/macros/filters/election-filter.html
+++ b/openfecwebapp/templates/macros/filters/election-filter.html
@@ -1,13 +1,10 @@
-{% macro field(name, title, cycle_name, full_name, office) %}
+{% macro full_cycle(name, title, cycle_name, full_name, office) %}
   {% if office == 'president' %}
     {% set duration = 4 %}
     {% set years = range(2020, 1976, -4) %}
   {% elif office == 'senate' %}
     {% set duration = 6 %}
-    {% set years = range(2020, 1976, -2) %}
-  {% else %}
-    {% set duration = 2 %}
-    {% set years = range(2020, 1976, -2) %}
+    {% set years = range(2022, 1976, -2) %}
   {% endif %}
   <div
       id="{{ name }}-field"
@@ -19,7 +16,6 @@
       data-duration="{{ duration }}"
     >
   <label class="label" for="{{ name }}">{{ title }}</label>
-  <ul class="dropdown__selected"></ul>
   <select id="{{name}}" name="{{ name }}" class="js-election select--full">
     {% for year in years %}
       <option value="{{ year }}">{{ year }}</option>
@@ -34,4 +30,13 @@
   <input type="hidden" name="{{ full_name }}" />
   {% endif %}
 </div>
+{% endmacro %}
+
+{% macro single_cycle(name, title) %}
+  <label class="label" for="{{ name }}">{{ title }}</label>
+  <select id="{{name}}" name="{{ name }}" class="js-election select--full">
+    {% for year in range(2020, 1976, -2) %}
+      <option value="{{ year }}" {% if year == constants.DEFAULT_TIME_PERIOD %}selected{% endif %}>{{ year|fmt_year_range }}</option>
+    {% endfor %}
+  </select>
 {% endmacro %}

--- a/openfecwebapp/templates/partials/candidates-office-filter.html
+++ b/openfecwebapp/templates/partials/candidates-office-filter.html
@@ -12,9 +12,9 @@
   <div class="filters__inner">
     {{ typeahead.field('q', 'Candidate name or ID', '', dataset='candidates', allow_text=True) }}
     {% if table_context['office'] == 'house' %}
-      {{ years.cycles('cycle', 'Election cycle') }}
+      {{ election_filter.single_cycle('cycle', 'Election cycle') }}
     {% else %}
-      {{ election_filter.field('election_year', 'Election year', 'cycle', 'election_full', table_context['office']) }}
+      {{ election_filter.full_cycle('election_year', 'Election year', 'cycle', 'election_full', table_context['office']) }}
       <input id="election_full" name="election_full" type="checkbox" value="true">
     {% endif %}
   </div>

--- a/openfecwebapp/templates/partials/candidates-office-filter.html
+++ b/openfecwebapp/templates/partials/candidates-office-filter.html
@@ -35,7 +35,7 @@
     {{ range_filter.amount('cash_on_hand_end_period', 'Cash on hand') }}
     {{ range_filter.amount('debts_owed_by_committee', 'Debts owed by committee') }}
     {% if table_context['office'] == 'president' %}
-      <div class="js-filter">
+      <div class="js-filter" data-filter="checkbox">
         <input id="federal-funds-flag" name="federal_funds_flag" type="checkbox" value="true">
         <label class="dropdown__value" for="federal-funds-flag">Has accepted presidential public funds</label>
       </div>


### PR DESCRIPTION
In https://github.com/18F/openFEC-web-app/pull/2000/commits/2d98e0e5220ed64024244159488fc99eb203e360 I changed the cycle filter on the House candidates data page to be a multi-select dropdown. But that was a mistake; it should only be a single-select dropdown, because we only want to look at one period of data at a time. Allowing multiple leads to duplicate results.

![image](https://cloud.githubusercontent.com/assets/1696495/25923976/2f04f190-3595-11e7-9a36-4e486c83974e.png)


