### PR TITLE
HOTFIX: Pass committee ID through for itemized disbursements

### DIFF
--- a/openfecwebapp/templates/partials/committee/disbursements.html
+++ b/openfecwebapp/templates/partials/committee/disbursements.html
@@ -71,7 +71,7 @@
         <table
             class="data-table data-table--heading-borders"
             data-type="itemized-disbursements"
-            data-committee-id="{{ committee.committee_id }}"
+            data-committee="{{ committee.committee_id }}"
             data-name="{{ name }}"
             data-cycle="{{ cycle }}"
           >


### PR DESCRIPTION
This is a small but important hotfix to fix the display of itemized disbursements on committee pages. I initially misunderstood [this issue](https://github.com/18F/FEC/issues/4051), but what it was flagging is the fact that _all_ committee disbursements for _all_ committees are currently showing up on committee pages. This was because the javascript that makes the API call was looking for `data-committee` rather than `data-committee-id`. So this just fixes the data attribute and now the committee ID is passed through.