### PR TITLE
Feature/unique fix

### DIFF
--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -102,7 +102,7 @@
             <h2>Raising</h2>
             <div class="post-feed">
               <div class="post">
-                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('receipts', is_individual=True) }}">All receipts</a></h3>
+                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('receipts') }}">All receipts</a></h3>
                 <p>Receipts are anything of value, like money, services or property. Search candidate and committee receipt data by contributor, amount and date.</p>
               </div>
               <div class="post post--child">
@@ -152,7 +152,7 @@
             <h2>Loans and debts</h2>
             <div class="post-feed">
               <div class="post">
-                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('loans', is_individual=True) }}">Loans</a></h3>
+                <h3><i class="icon i-all-files icon--inline--left"></i><a href="{{ url_for('loans') }}">Loans</a></h3>
               </div>
               <div class="post">
                 <h3 class="is-disabled"><i class="icon i-all-files icon--inline--left"></i>Debts (coming soon)</h3>

--- a/openfecwebapp/templates/partials/filters/unique-receipts.html
+++ b/openfecwebapp/templates/partials/filters/unique-receipts.html
@@ -11,9 +11,9 @@
     </legend>
     <ul>
       <li>
-        <input id="is-individual" name="is_individual" type="checkbox" value="true" class="tooltip-trigger" aria-describedby="unique-tooltip" checked>
+        <input id="is-individual" name="is_individual" type="checkbox" value="true" class="tooltip-trigger" aria-describedby="unique-tooltip">
         <label for="is-individual" class="t-inline-block">
-          Unique only
+          From unique individuals only
         </label>
       </li>
     </ul>

--- a/openfecwebapp/templates/partials/receipts-filter.html
+++ b/openfecwebapp/templates/partials/receipts-filter.html
@@ -47,6 +47,7 @@ Filter receipts
         </ul>
       </fieldset>
     </div>
+    {% include 'partials/filters/unique-receipts.html' %}    
     {{ typeahead.field('contributor_name', 'Contributor name or ID', dataset='committees', allow_text=True) }}
     {{ text.field('contributor_city', 'City') }}
     {{ states.field('contributor_state') }}
@@ -61,9 +62,6 @@ Filter receipts
     <div class="message message--info message--small">
       <span class="t-block">Receipts updated according to the filer's schedule. Processing time can vary.</span>
     </div>
-  </div>
-  <div class="filters__inner">
-    {% include 'partials/filters/unique-receipts.html' %}
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This relabels the "unique receipts" filter to be more descriptive and removes it from being set in links to receipts from the advanced data page.

![image](https://cloud.githubusercontent.com/assets/1696495/26170513/94c28608-3af6-11e7-956e-18c808b9fb37.png)

I also moved it to be under the "individual" vs "committee" filter, which feels like a more natural place for it. We had originally pulled it out because it was set by default and we wanted people to see it, but now that it's not checked by default I think it makes sense here. 

cc @LindsayYoung @PaulClark2 

Resolves https://github.com/18F/openFEC-web-app/issues/2044