### PR TITLE
Changed URLs on Advanced Data page

### DIFF
--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -306,11 +306,11 @@
                 <div class="post">
                   <h4>Presidential campaign matching fund submissions</h4>
                   <p>
-                    <a href="{{ transition_url }}/finance/disclosure/2016MatchingFundSubmissions.shtml">2016</a> |
-                    <a href="{{ transition_url }}/finance/2012matching/2012matching.shtml">2012</a> |
-                    <a href="{{ transition_url }}/finance/2008matching/2008matching.shtml">2008</a> |
-                    <a href="{{ transition_url }}/finance/disclosure/2004MatchingFundSubmissions.shtml">2004</a> |
-                    <a href="{{ transition_url }}/finance/disclosure/submiss.shtml">2000</a>
+                    <a href="{{ classic_url }}/finance/disclosure/2016MatchingFundSubmissions.shtml">2016</a> |
+                    <a href="{{ classic_url }}/finance/2012matching/2012matching.shtml">2012</a> |
+                    <a href="{{ classic_url }}/finance/2008matching/2008matching.shtml">2008</a> |
+                    <a href="{{ classic_url }}/finance/disclosure/2004MatchingFundSubmissions.shtml">2004</a> |
+                    <a href="{{ classic_url }}/finance/disclosure/submiss.shtml">2000</a>
                   </p>
                   <p>You will find here the threshold files for Presidential candidates seeking matching funds.</p>
                   <p>In addition to regular quarterly or monthly disclosure reports, presidential candidates who seek matching funds must submit information about "matchable" contributions to the FEC for review. Contributions from individuals where the aggregate amount contributed by the individual is $250 or less are eligible to be matched on a dollar for dollar basis from the Presidential Election Campaign Fund. This Fund includes proceeds from the voluntary check-off of $3 per person from income tax returns of eligible taxpayers.</p>


### PR DESCRIPTION
The content owners agreed that we should change the presidential matching fund links from transition to classic. 