### PR TITLE
Feature/ao panel icon

### DIFF
--- a/static/js/legal/LegalSearch.js
+++ b/static/js/legal/LegalSearch.js
@@ -91,7 +91,7 @@ class LegalSearch extends React.Component {
   render() {
     return <section className="main__content--full data-container__wrapper">
       <div id="filters" className="filters is-open">
-        <button className="filters__header js-filter-toggle" type="button">
+        <button className="filters__header filters__toggle js-filter-toggle" type="button">
           <span className="filters__title">Edit filters</span>
         </button>
         <div className="filters__content">

--- a/static/js/pages/legal.js
+++ b/static/js/pages/legal.js
@@ -1,14 +1,6 @@
 'use strict';
 
 /* global require */
-require('jquery.inputmask');
-require('jquery.inputmask/dist/inputmask/inputmask.date.extensions.js');
-
-var $ = require('jquery');
 var FilterPanel = require('fec-style/js/filter-panel').FilterPanel;
 
-$(function () {
-  new FilterPanel();
-
-  $('.js-date-mask').inputmask('mm/dd/yyyy');
-});
+new FilterPanel();


### PR DESCRIPTION
This just adds the class to get the open/close icon on the AO filter panel, and removes the unnecessary inputmask code from the legal js.

![image](https://cloud.githubusercontent.com/assets/1696495/26323170/acb34cbc-3ee2-11e7-9fb3-24f41f4648c4.png)

Resolves: https://github.com/18F/openFEC-web-app/issues/2043

cc @anthonygarvan or @xtine 