### PR TITLE
Submit the data search form to the current page

### DIFF
--- a/openfecwebapp/templates/search-results.html
+++ b/openfecwebapp/templates/search-results.html
@@ -13,7 +13,7 @@
     <header>
       <h1 class="heading--main">Candidate and committee profiles</h1>
     </header>
-    <form action="/" method="GET" class="slab slab--inline slab--neutral">
+    <form action="" method="GET" class="slab slab--inline slab--neutral">
       <div class="container combo combo--search">
         <label for="search" class="label">Search candidate and committee profiles</label>
         <input id="search"


### PR DESCRIPTION
This resolves the issue where entering another search term from the data search results page sends users to the home page, as reported in https://github.com/18F/FEC/issues/4084

