### PR TITLE
Hotfix/restore coverage dates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ after_success:
   - codecov
 before_deploy:
   - export PATH=$HOME:$PATH
+  - export FEC_WEB_ENVIRONMENT=prod  # for minifying assets
   - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.25.0"
   - tar xzvf $HOME/cf.tgz -C $HOME
   - travis_retry cf install-plugin autopilot -f -r CF-Community

--- a/openfecwebapp/app.py
+++ b/openfecwebapp/app.py
@@ -40,7 +40,7 @@ def get_absolute_url():
 
 def get_canonical_url():
     path = furl.furl(request.url).path
-    return '{}/data{}'.format(config.canonical_base, path)
+    return '{}{}'.format(config.canonical_base, path)
 
 
 def _get_default_cycles():

--- a/openfecwebapp/templates/partials/candidate/financial-summary.html
+++ b/openfecwebapp/templates/partials/candidate/financial-summary.html
@@ -25,9 +25,9 @@
       <div class="entity__figure entity__figure--narrow">
         <h3 class="u-no-margin">Raising</h3>
         <div class="row">
-            <!-- <div class="u-float-left tag__category u-no-margin">
+            <div class="u-float-left tag__category u-no-margin">
               <div class="tag__item">Coverage dates: {{aggregate.coverage_start_date|date}} to {{aggregate.coverage_end_date|date}}</div>
-            </div> -->
+            </div>
             <div class="u-float-right">
               <a class="heading__right button--alt button--browse"
                   href="{{ url_for('receipts', committee_id=committee_ids, two_year_transaction_period=max_cycle) }}">Browse receipts
@@ -39,9 +39,9 @@
       <div class="entity__figure entity__figure--narrow">
         <h3 class="u-no-margin">Spending</h3>
         <div class="row">
-            <!-- <div class="u-float-left tag__category u-no-margin">
+            <div class="u-float-left tag__category u-no-margin">
               <div class="tag__item">Coverage dates: {{aggregate.coverage_start_date|date}} to {{aggregate.coverage_end_date|date}}</div>
-            </div> -->
+            </div>
             <div class="u-float-right">
               <a class="heading__right button--alt button--browse"
                   href="{{ url_for('disbursements', committee_id=committee_ids, two_year_transaction_period=max_cycle) }}">Browse disbursements
@@ -53,9 +53,9 @@
       <div class="entity__figure entity__figure--narrow">
         <h3 class="u-no-margin">Cash</h3>
         <div class="row">
-          <!-- <div class="u-float-left tag__category u-no-margin">
+          <div class="u-float-left tag__category u-no-margin">
             <div class="tag__item">Coverage dates: {{aggregate.coverage_start_date|date}} to {{aggregate.coverage_end_date|date}}</div>
-          </div> -->
+          </div>
         </div>
         {{ tables.summary(cash_summary) }}
       </div>

--- a/openfecwebapp/templates/partials/committee/financial-summary.html
+++ b/openfecwebapp/templates/partials/committee/financial-summary.html
@@ -18,9 +18,9 @@
         <div class="entity__figure">
           <h3 class="u-no-margin">Raising</h3>
           <div class="row">
-              <!-- <div class="u-float-left tag__category u-no-margin">
+              <div class="u-float-left tag__category u-no-margin">
                 <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
-              </div> -->
+              </div>
               <div class="u-float-right">
                 <a class="heading__right button--alt button--browse"
                     href="{{ url_for(
@@ -38,9 +38,9 @@
         <div class="entity__figure">
           <h3 class="u-no-margin">Spending</h3>
           <div class="row">
-              <!-- <div class="u-float-left tag__category u-no-margin">
+              <div class="u-float-left tag__category u-no-margin">
                 <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
-              </div> -->
+              </div>
               <div class="u-float-right">
                 <a class="heading__right button--alt button--browse"
                     href="{{ url_for(
@@ -57,9 +57,9 @@
         </div>
         <div class="entity__figure">
           <h3 class="u-no-margin">Cash summary</h3>
-          <!-- <div class="tag__category u-no-margin">
+          <div class="tag__category u-no-margin">
             <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
-          </div> -->
+          </div>
           {{ tables.summary(cash_summary, committee_id) }}
         </div>
       {% endif %}

--- a/openfecwebapp/templates/search-results.html
+++ b/openfecwebapp/templates/search-results.html
@@ -13,7 +13,7 @@
     <header>
       <h1 class="heading--main">Candidate and committee profiles</h1>
     </header>
-    <form action="/" method="GET" class="slab slab--inline slab--neutral">
+    <form action="" method="GET" class="slab slab--inline slab--neutral">
       <div class="container combo combo--search">
         <label for="search" class="label">Search candidate and committee profiles</label>
         <input id="search"


### PR DESCRIPTION
Once the API fix for coverage dates is in (https://github.com/18F/openFEC/pull/2418) this can be merged to restore them to the frontend. I also rolled in the 1 character change from https://github.com/18F/openFEC-web-app/pull/2073.