### PR TITLE
Passing cycle value to links to itemized data

### DIFF
--- a/openfecwebapp/templates/macros/tables.html
+++ b/openfecwebapp/templates/macros/tables.html
@@ -36,7 +36,7 @@
   </figure>
 {% endmacro %}
 
-{% macro summary(data, committee_id) %}
+{% macro summary(data, committee_id, cycle) %}
 <figure>
 <table class="simple-table">
   {% for item in data %}
@@ -50,7 +50,7 @@
       </td>
       <td class="simple-table__cell">
         {% if item[1]['link'] %}
-          <a href="{{ url_for(item[1]['link'], committee_id=committee_id) }}">
+          <a href="{{ url_for(item[1]['link'], committee_id=committee_id, two_year_transaction_period=cycle) }}">
             {{ item[0]|currency }}
           </a>
         {% else %}

--- a/openfecwebapp/templates/macros/tables.html
+++ b/openfecwebapp/templates/macros/tables.html
@@ -50,7 +50,7 @@
       </td>
       <td class="simple-table__cell">
         {% if item[1]['link'] %}
-          <a href="{{ url_for(item[1]['link'], committee_id=committee_id, two_year_transaction_period=cycle) }}">
+          <a href="{{ url_for(item[1]['link'], committee_id=committee_id, two_year_transaction_period=cycle, cycle=cycle) }}">
             {{ item[0]|currency }}
           </a>
         {% else %}

--- a/openfecwebapp/templates/partials/candidate/financial-summary.html
+++ b/openfecwebapp/templates/partials/candidate/financial-summary.html
@@ -34,7 +34,7 @@
               </a>
             </div>
         </div>
-        {{ tables.summary(raising_summary, committee_ids) }}
+        {{ tables.summary(raising_summary, committee_ids, cycle) }}
       </div>
       <div class="entity__figure entity__figure--narrow">
         <h3 class="u-no-margin">Spending</h3>
@@ -48,7 +48,7 @@
               </a>
             </div>
         </div>
-        {{ tables.summary(spending_summary, committee_ids) }}
+        {{ tables.summary(spending_summary, committee_ids, cycle) }}
       </div>
       <div class="entity__figure entity__figure--narrow">
         <h3 class="u-no-margin">Cash</h3>

--- a/openfecwebapp/templates/partials/committee/financial-summary.html
+++ b/openfecwebapp/templates/partials/committee/financial-summary.html
@@ -33,7 +33,7 @@
                   </a>
               </div>
           </div>
-          {{ tables.summary(raising_summary, committee_id) }}
+          {{ tables.summary(raising_summary, committee_id, cycle) }}
         </div>
         <div class="entity__figure">
           <h3 class="u-no-margin">Spending</h3>
@@ -53,7 +53,7 @@
                   </a>
               </div>
           </div>
-          {{ tables.summary(spending_summary, committee_id) }}
+          {{ tables.summary(spending_summary, committee_id, cycle) }}
         </div>
         <div class="entity__figure">
           <h3 class="u-no-margin">Cash summary</h3>


### PR DESCRIPTION
This passes through the value of the selected cycle to links to itemized receipts, disbursements and independent expenditures. It passes the value in as both `two_year_transaction_period` and `cycle` because receipts and disbursements use the former, and IEs use the latter, and there's not a problem passing a filter that isn't used.

Resolves https://github.com/18F/openFEC-web-app/issues/2077