### PR TITLE
Feature/remove export

### DIFF
--- a/openfecwebapp/templates/partials/candidate/individual-contributions.html
+++ b/openfecwebapp/templates/partials/candidate/individual-contributions.html
@@ -69,7 +69,6 @@
               <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
             </li>
           </ul>
-          <button type="button" class="js-export button button--cta button--export" data-export-for="contributor-state">Export</button>
         </div>
 
         <div class="map-table">
@@ -103,8 +102,6 @@
               <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
             </li>
           </ul>
-
-          <button type="button" class="js-export button button--cta button--export" data-export-for="contribution-size">Export</button>
         </div>
 
         <table

--- a/static/js/pages/candidate-single.js
+++ b/static/js/pages/candidate-single.js
@@ -403,7 +403,6 @@ function initContributionsTables() {
         )
       }],
     callbacks: aggregateCallbacks,
-    aggregateExport: true,
     dom: 't',
     order: [[1, 'desc']],
     paging: false,
@@ -447,7 +446,6 @@ function initContributionsTables() {
     pagingType: 'simple',
     lengthChange: false,
     pageLength: 10,
-    aggregateExport: true,
     hideEmpty: true,
     hideEmptyOpts: {
       dataType: 'individual contributions',

--- a/tests/unit/modules/download.js
+++ b/tests/unit/modules/download.js
@@ -120,12 +120,14 @@ describe('DownloadItem', function() {
       sinon.stub($, 'ajax').returns(this.promise);
       sinon.stub(download.DownloadItem.prototype, 'schedule');
       sinon.stub(download.DownloadItem.prototype, 'finish');
+      sinon.stub(download.DownloadItem.prototype, 'handleServerError');
     });
 
     afterEach(function() {
       $.ajax.restore();
       download.DownloadItem.prototype.schedule.restore();
       download.DownloadItem.prototype.finish.restore();
+      download.DownloadItem.prototype.handleServerError.restore();
     });
 
     it('sends an ajax request', function() {
@@ -151,9 +153,15 @@ describe('DownloadItem', function() {
       expect(this.item.finish).to.have.been.calledWith('/download');
     });
 
-    it('handles an error', function() {
+    it('handles a 500 server error', function() {
       this.item.refresh();
       this.promise.reject({}, 'error');
+      expect(this.item.handleServerError).to.have.been.called;
+    });
+
+    it('handles other server errors', function() {
+      this.item.refresh();
+      this.promise.reject({}, 'fake');
       expect(this.item.schedule).to.have.been.called;
     });
 


### PR DESCRIPTION
This removes the export button from the candidate contributions by state and contributions by size tables and adds support for handling 500 server errors.

Now if a user gets an error with text status of `error` you will see this message:

![image](https://cloud.githubusercontent.com/assets/1696495/26609632/120bc6fa-4557-11e7-8f4c-e3af137fff8e.png)

Resolves https://github.com/18F/openFEC-web-app/issues/2038
Resolves https://github.com/18F/openFEC-web-app/issues/2089

cc @LindsayYoung 