### PR TITLE
Update "Start the tour" button

### DIFF
--- a/openfecwebapp/templates/partials/site-orientation.html
+++ b/openfecwebapp/templates/partials/site-orientation.html
@@ -4,7 +4,7 @@
       {% if canonical_base == 'https://www.fec.gov' %}
         <span class="t-bold">We’ve updated FEC.gov</span> | You can still access an archive of the old FEC.gov at <a href="http://classic.fec.gov">classic.fec.gov</a>
         <div class="toggle" aria-hidden="false">
-          <div class="tour__start"><button class="tour__start__button">Start a tour</button> of the new features</div>
+          <button class="tour__start__button">Start the tour</button>
           <span class="t-block">Questions or comments? Use our <button class="js-feedback">anonymous feedback tool</button> or email <a href="mailto:webmanager@fec.gov">webmanager@fec.gov</a></span>
         </div>
         <div class="toggle-text" aria-expanded="true">
@@ -16,7 +16,7 @@
         <div class="toggle" aria-hidden="false">
           <span class="t-block">After that, the <a href="http://www.fec.gov">current FEC.gov</a> will be archived and made available at classic.fec.gov</span>
           <span class="t-block">Questions or comments? Use our <button class="js-feedback">anonymous feedback tool</button> or email <a href="mailto:webmanager@fec.gov">webmanager@fec.gov</a></span>
-          <div class="tour__start"><button class="tour__start__button">Start a tour</button> of the new features</div>
+          <button class="tour__start__button">Start the tour</button>
         </div>
         <div class="toggle-text">
           <button class="less" aria-hidden="false" tabindex="0">Show less <i class="icon-small--arrow-up-border"></i></button>

--- a/openfecwebapp/templates/partials/site-orientation.html
+++ b/openfecwebapp/templates/partials/site-orientation.html
@@ -1,28 +1,15 @@
 <div class="js-new-site-orientation site-orientation">
   <div class="banner" role="banner" aria-hidden="false">
     <div class="container">
-      {% if canonical_base == 'https://www.fec.gov' %}
-        <span class="t-bold">We’ve updated FEC.gov</span> | You can still access an archive of the old FEC.gov at <a href="http://classic.fec.gov">classic.fec.gov</a>
-        <div class="toggle" aria-hidden="false">
-          <button class="tour__start__button">Start the tour</button>
-          <span class="t-block">Questions or comments? Use our <button class="js-feedback">anonymous feedback tool</button> or email <a href="mailto:webmanager@fec.gov">webmanager@fec.gov</a></span>
-        </div>
-        <div class="toggle-text" aria-expanded="true">
-          <button class="less" aria-hidden="false" tabindex="0">Show less <i class="icon-small--arrow-up-border"></i></button>
-          <button class="more" aria-hidden="true" tabindex="0">Show more <i class="icon-small--arrow-down-border"></i></button>
-        </div>
-      {% else %}
-        <span class="t-bold">In May, this site will become the new FEC.gov</span>
-        <div class="toggle" aria-hidden="false">
-          <span class="t-block">After that, the <a href="http://www.fec.gov">current FEC.gov</a> will be archived and made available at classic.fec.gov</span>
-          <span class="t-block">Questions or comments? Use our <button class="js-feedback">anonymous feedback tool</button> or email <a href="mailto:webmanager@fec.gov">webmanager@fec.gov</a></span>
-          <button class="tour__start__button">Start the tour</button>
-        </div>
-        <div class="toggle-text">
-          <button class="less" aria-hidden="false" tabindex="0">Show less <i class="icon-small--arrow-up-border"></i></button>
-          <button class="more" aria-hidden="true" tabindex="0">Show more <i class="icon-small--arrow-down-border"></i></button>
-        </div>
-      {% endif %}
+      <span class="t-bold">We’ve updated FEC.gov</span> | You can still access an archive of the old FEC.gov at <a href="http://classic.fec.gov">classic.fec.gov</a>
+      <div class="toggle" aria-hidden="false">
+        <button class="tour__start__button">Start the tour</button>
+        <span class="t-block">Questions or comments? Use our <button class="js-feedback">anonymous feedback tool</button> or email <a href="mailto:webmanager@fec.gov">webmanager@fec.gov</a></span>
+      </div>
+      <div class="toggle-text" aria-expanded="true">
+        <button class="less" aria-hidden="false" tabindex="0">Show less <i class="icon-small--arrow-up-border"></i></button>
+        <button class="more" aria-hidden="true" tabindex="0">Show more <i class="icon-small--arrow-down-border"></i></button>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
Update the "Start the tour" button for post-flip.
<img width="613" alt="screen shot 2017-05-31 at 10 01 12 am" src="https://cloud.githubusercontent.com/assets/24054/26644081/6ce4df44-45e8-11e7-8c86-22e51dd80668.png">

Relies on https://github.com/18F/fec-style/pull/720
https://github.com/18F/fec-cms/issues/1081