### PR TITLE
Fixing sort problems on committee filing tables

### DIFF
--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -307,7 +307,7 @@ var filings = {
   pages: pagesColumn,
   version: versionColumn,
   receipt_date: receiptDateColumn,
-  receipt_date_unordable: {
+  receipt_date_unorderable: {
     data: 'receipt_date',
     className: 'min-tablet hide-panel column--small',
     orderable: false,

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -127,23 +127,23 @@ var renderCommitteeColumn = function(data, type, row, meta) {
 };
 
 var candidates = [
-  {data: 'name', className: 'all column--large', render: renderCandidateColumn},
-  {data: 'office_full', className: 'min-tablet hide-panel-tablet column--med'},
+  {data: 'name', className: 'all', render: renderCandidateColumn},
+  {data: 'office_full', className: 'min-tablet hide-panel-tablet'},
   {
     data: 'election_years',
-    className: 'min-tablet hide-panel column--med',
+    className: 'min-tablet hide-panel',
     render: function(data, type, row, meta) {
       return tables.yearRange(_.first(data), _.last(data));
     }
   },
-  {data: 'party_full', className: 'min-tablet column--med hide-panel'},
+  {data: 'party_full', className: 'min-tablet hide-panel'},
   {data: 'state', className: 'min-desktop hide-panel column--state'},
   {data: 'district', className: 'min-desktop hide-panel column--small'},
   modalTriggerColumn
 ];
 
 var candidateOffice = {
-  name:   {data: 'name', className: 'all column--xl', render: renderCandidateColumn},
+  name:   {data: 'name', className: 'all', render: renderCandidateColumn},
   party: {data: 'party_full', className: 'min-desktop'},
   state: {data: 'state', className: 'min-tablet column--state hide-panel'},
   district: {data: 'district', className: 'min-desktop column--small hide-panel'},
@@ -155,7 +155,7 @@ var candidateOffice = {
 var committees = [
   {
     data: 'name',
-    className: 'all column--xl',
+    className: 'all',
     render: function(data, type, row, meta) {
       if (data) {
         return columnHelpers.buildEntityLink(
@@ -177,18 +177,18 @@ var communicationCosts = [
   {
     data: 'committee_name',
     orderable: false,
-    className: 'all column--xl',
+    className: 'all',
     render: renderCommitteeColumn,
   },
-  _.extend({}, supportOpposeColumn, {className: 'min-tablet hide-panel-tablet column--med'}),
+  _.extend({}, supportOpposeColumn, {className: 'min-tablet hide-panel-tablet'}),
   {
     data: 'candidate_name',
     orderable: false,
-    className: 'min-tablet hide-panel-tablet column--large',
+    className: 'min-tablet hide-panel-tablet',
     render: renderCandidateColumn
   },
-  currencyColumn({data: 'transaction_amount', className: 'min-tablet hide-panel column--med column--number'}),
-  dateColumn({data: 'transaction_date', className: 'min-tablet hide-panel column--med'}),
+  currencyColumn({data: 'transaction_amount', className: 'min-tablet hide-panel column--number'}),
+  dateColumn({data: 'transaction_date', className: 'min-tablet hide-panel column--small'}),
   modalTriggerColumn
 ];
 
@@ -196,7 +196,7 @@ var disbursements = [
   {
     data: 'committee',
     orderable: false,
-    className: 'all column--large',
+    className: 'all',
     render: function(data, type, row, meta) {
       if (data) {
         return columnHelpers.buildEntityLink(
@@ -212,7 +212,7 @@ var disbursements = [
   {
     data: 'recipient_name',
     orderable: false,
-    className: 'all column--large',
+    className: 'all',
     render: function(data, type, row, meta) {
       var committee = row.recipient_committee;
       if (committee) {
@@ -228,8 +228,8 @@ var disbursements = [
   },
   {data: 'recipient_state', orderable: false, className: 'min-desktop column--state hide-panel'},
   {data: 'disbursement_description', className: 'min-desktop hide-panel', orderable: false},
-  dateColumn({data: 'disbursement_date', className: 'min-tablet hide-panel column--med'}),
-  currencyColumn({data: 'disbursement_amount', className: 'min-tablet hide-panel column--number column--med'}),
+  dateColumn({data: 'disbursement_date', className: 'min-tablet hide-panel column--small'}),
+  currencyColumn({data: 'disbursement_amount', className: 'min-tablet hide-panel column--number'}),
   modalTriggerColumn
 ];
 
@@ -237,7 +237,7 @@ var electioneeringCommunications = [
   {
     data: 'committee_name',
     orderable: false,
-    className: 'all column--xl',
+    className: 'all',
     render: renderCommitteeColumn
   },
   {
@@ -250,16 +250,16 @@ var electioneeringCommunications = [
     data: 'number_of_candidates',
     className: 'min-desktop hide-panel column--small column--number',
   },
-  currencyColumn({data: 'calculated_candidate_share', className: 'min-desktop hide-panel column--number column--med'}),
-  dateColumn({data: 'disbursement_date', className: 'min-tablet hide-panel column--med'}),
-  currencyColumn({data: 'disbursement_amount', className: 'min-tablet hide-panel column--number column--med'}),
+  currencyColumn({data: 'calculated_candidate_share', className: 'min-desktop hide-panel column--number'}),
+  dateColumn({data: 'disbursement_date', className: 'min-tablet hide-panel column--small'}),
+  currencyColumn({data: 'disbursement_amount', className: 'min-tablet hide-panel column--number'}),
   modalTriggerColumn
 ];
 
 var filings = {
   filer_name: {
     data: 'committee_id',
-    className: 'all column--large',
+    className: 'all',
     orderable: false,
     render: function(data, type, row, meta) {
       var cycle = tables.getCycle([row.cycle], meta);
@@ -284,12 +284,12 @@ var filings = {
     // This is just used by the committee pages because those tables
     // are too narrow to support the combo button
     data: 'document_description',
-    className: 'all column--medium',
+    className: 'all',
     orderable: false
   }),
   document_type: {
     data: 'document_description',
-    className: 'all column--doc-download column--large',
+    className: 'all column--doc-download',
     orderable: false,
     render: function(data, type, row) {
       var doc_description = row.document_description ? row.document_description : row.form_type;
@@ -324,8 +324,8 @@ var filings = {
       return parsed.isValid() ? parsed.format('MM/DD/YYYY') : 'Invalid date';
     }
   },
-  coverage_start_date: dateColumn({data: 'coverage_start_date', className: 'min-tablet hide-panel column--med', orderable: false}),
-  coverage_end_date: dateColumn({data: 'coverage_end_date', className: 'min-tablet hide-panel column--med', orderable: false}),
+  coverage_start_date: dateColumn({data: 'coverage_start_date', className: 'min-tablet hide-panel column--small', orderable: false}),
+  coverage_end_date: dateColumn({data: 'coverage_end_date', className: 'min-tablet hide-panel column--small', orderable: false}),
   total_receipts: currencyColumn({data: 'total_receipts', className: 'min-desktop hide-panel column--number'}),
   total_disbursements: currencyColumn({data: 'total_disbursements', className: 'min-desktop hide-panel column--number'}),
   total_independent_expenditures: currencyColumn({data: 'total_independent_expenditures', className: 'min-desktop hide-panel column--number'}),
@@ -346,7 +346,7 @@ var independentExpenditures = [
   {
     data: 'committee',
     orderable: false,
-    className: 'all column--large',
+    className: 'all',
     render: function(data, type, row, meta) {
       if (data) {
         return columnHelpers.buildEntityLink(
@@ -359,11 +359,11 @@ var independentExpenditures = [
       }
     }
   },
-  _.extend({}, supportOpposeColumn, {className: 'min-tablet hide-panel-tablet column--med'}),
+  _.extend({}, supportOpposeColumn, {className: 'min-tablet hide-panel-tablet'}),
   {
     data: 'candidate_name',
     orderable: false,
-    className: 'min-tablet hide-panel-tablet column--large',
+    className: 'min-tablet hide-panel-table',
     render: function(data, type, row, meta) {
       if (row.candidate_id) {
         return columnHelpers.buildEntityLink(
@@ -380,10 +380,10 @@ var independentExpenditures = [
   {
     data: 'payee_name',
     orderable: false,
-    className: 'min-desktop hide-panel column--medium'
+    className: 'min-desktop hide-panel'
   },
-  dateColumn({data: 'expenditure_date', className: 'min-tablet hide-panel column--med'}),
-  currencyColumn({data: 'expenditure_amount', className: 'min-tablet hide-panel column--number column--med'}),
+  dateColumn({data: 'expenditure_date', className: 'min-tablet hide-panel column--small'}),
+  currencyColumn({data: 'expenditure_amount', className: 'min-tablet hide-panel column--number'}),
   modalTriggerColumn
 ];
 
@@ -391,7 +391,7 @@ var individualContributions = [
   {
     data: 'contributor',
     orderable: false,
-    className: 'all hide-panel-tablet column--large',
+    className: 'all hide-panel-tablet',
     render: function(data, type, row, meta) {
       if (data && row.receipt_type !== helpers.globals.EARMARKED_CODE) {
         return columnHelpers.buildEntityLink(
@@ -407,7 +407,7 @@ var individualContributions = [
   {
     data: 'committee',
     orderable: false,
-    className: 'all column--xl',
+    className: 'all',
     render: function(data, type, row, meta) {
       if (data) {
         return columnHelpers.buildEntityLink(
@@ -422,8 +422,8 @@ var individualContributions = [
   },
   {data: 'contributor_state', orderable: false, className: 'min-desktop hide-panel column--state '},
   {data: 'contributor_employer', orderable: false, className: 'min-desktop hide-panel'},
-  dateColumn({data: 'contribution_receipt_date', className: 'min-tablet hide-panel column--med'}),
-  currencyColumn({data: 'contribution_receipt_amount', className: 'min-tablet hide-panel column--number column--med'}),
+  dateColumn({data: 'contribution_receipt_date', className: 'min-tablet hide-panel column--small'}),
+  currencyColumn({data: 'contribution_receipt_amount', className: 'min-tablet hide-panel column--number'}),
   modalTriggerColumn
 ];
 
@@ -431,7 +431,7 @@ var partyCoordinatedExpenditures = [
   {
     data: 'committee',
     orderable: false,
-    className: 'all column--xl',
+    className: 'all',
     render: function(data, type, row) {
       if (data) {
         return columnHelpers.buildEntityLink(
@@ -447,7 +447,7 @@ var partyCoordinatedExpenditures = [
   {
     data: 'candidate_name',
     orderable: false,
-    className: 'min-tablet hide-panel-tablet column--large',
+    className: 'min-tablet hide-panel-tablet',
     render: function(data, type, row) {
       if (row.candidate_id) {
         return columnHelpers.buildEntityLink(
@@ -463,10 +463,10 @@ var partyCoordinatedExpenditures = [
   {
     data: 'payee_name',
     orderable: false,
-    className: 'min-desktop hide-panel column--medium'
+    className: 'min-desktop hide-panel'
   },
-  dateColumn({data: 'expenditure_date', className: 'min-tablet hide-panel column--med'}),
-  currencyColumn({data: 'expenditure_amount', className: 'min-tablet hide-panel column--number column--med'}),
+  dateColumn({data: 'expenditure_date', className: 'min-tablet hide-panel column--small'}),
+  currencyColumn({data: 'expenditure_amount', className: 'min-tablet hide-panel column--number'}),
   modalTriggerColumn
 ];
 
@@ -474,7 +474,7 @@ var receipts = [
   {
     data: 'contributor',
     orderable: false,
-    className: 'all column--xl',
+    className: 'all',
     render: function(data, type, row, meta) {
       if (data && row.receipt_type !== helpers.globals.EARMARKED_CODE) {
         return columnHelpers.buildEntityLink(
@@ -490,7 +490,7 @@ var receipts = [
   {
     data: 'committee',
     orderable: false,
-    className: 'all column--xl',
+    className: 'all',
     render: function(data, type, row, meta) {
       if (data) {
         return columnHelpers.buildEntityLink(
@@ -506,11 +506,11 @@ var receipts = [
   {
     data: 'fec_election_type_desc',
     orderable: false,
-    className: 'min-desktop column--med',
+    className: 'min-desktop',
   },
   {data: 'contributor_state', orderable: false, className: 'min-desktop hide-panel column--state'},
-  dateColumn({data: 'contribution_receipt_date', className: 'min-tablet hide-panel column--med'}),
-  currencyColumn({data: 'contribution_receipt_amount', className: 'min-tablet hide-panel column--med column--number'}),
+  dateColumn({data: 'contribution_receipt_date', className: 'min-tablet hide-panel column--small'}),
+  currencyColumn({data: 'contribution_receipt_amount', className: 'min-tablet hide-panel column--number'}),
   modalTriggerColumn
 ];
 
@@ -518,12 +518,12 @@ var reports = {
   committee:   {
     data: 'committee_name',
     orderable: false,
-    className: 'all column--large',
+    className: 'all',
     render: renderCommitteeColumn
   },
   document_type: {
     data: 'document_description',
-    className: 'all column--doc-download column--large',
+    className: 'all column--doc-download',
     orderable: false,
     render: function(data, type, row) {
       var doc_description = row.document_description ? row.document_description : row.form_type;
@@ -582,7 +582,7 @@ var loans = [
   {
     data: 'committee',
     orderable: false,
-    className: 'all column--large',
+    className: 'all',
     render: function (data) {
       if (data) {
         return columnHelpers.buildEntityLink(
@@ -598,9 +598,9 @@ var loans = [
   {
     data: 'loan_source_name',
     orderable: false,
-    className: 'all column--large',
+    className: 'all',
   },
-  dateColumn({data: 'incurred_date', orderable: true, className: 'min-tablet hide-panel column--med'}),
+  dateColumn({data: 'incurred_date', orderable: true, className: 'min-tablet hide-panel column--small'}),
   currencyColumn({data: 'payment_to_date', className: 'min-desktop hide-panel column--number'}),
   currencyColumn({data: 'original_loan_amount', className: 'min-desktop hide-panel column--number'}),
   modalTriggerColumn

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -315,6 +315,15 @@ var filings = {
   pages: pagesColumn,
   version: versionColumn,
   receipt_date: receiptDateColumn,
+  receipt_date_unordable: {
+    data: 'receipt_date',
+    className: 'min-tablet hide-panel column--small',
+    orderable: false,
+    render: function(data, type, row) {
+      var parsed = moment(row.receipt_date, 'YYYY-MM-DDTHH:mm:ss');
+      return parsed.isValid() ? parsed.format('MM/DD/YYYY') : 'Invalid date';
+    }
+  },
   coverage_start_date: dateColumn({data: 'coverage_start_date', className: 'min-tablet hide-panel column--med', orderable: false}),
   coverage_end_date: dateColumn({data: 'coverage_end_date', className: 'min-tablet hide-panel column--med', orderable: false}),
   total_receipts: currencyColumn({data: 'total_receipts', className: 'min-desktop hide-panel column--number'}),

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -21,14 +21,6 @@ var supportOpposeColumn = {
   }
 };
 
-var amendmentIndicatorColumn = {
-  data: 'amendment_indicator',
-  className: 'hide-panel hide-efiling column--med min-desktop',
-  render: function(data) {
-    return decoders.amendments[data] || '';
-  }
-};
-
 var versionColumn = {
   data: 'most_recent',
   className: 'hide-panel hide-efiling column--med min-desktop',
@@ -613,7 +605,6 @@ module.exports = {
   currencyColumn: currencyColumn,
   barCurrencyColumn: barCurrencyColumn,
   supportOpposeColumn: supportOpposeColumn,
-  amendmentIndicatorColumn: amendmentIndicatorColumn,
   candidates: candidates,
   candidateOffice: candidateOffice,
   committees: committees,

--- a/static/js/pages/candidate-single.js
+++ b/static/js/pages/candidate-single.js
@@ -15,19 +15,6 @@ var aggregateCallbacks = {
   afterRender: tables.barsAfterRender.bind(undefined, undefined),
 };
 
-var filingsColumns = [
-  columnHelpers.urlColumn('pdf_url', {
-    data: 'document_description',
-    className: 'all',
-    orderable: false
-  }),
-  columns.amendmentIndicatorColumn,
-  columns.dateColumn({
-    data: 'receipt_date',
-    className: 'min-tablet'
-  }),
-];
-
 var expenditureColumns = [
   {
     data: 'total',
@@ -196,19 +183,6 @@ var individualContributionsColumns = [
 //   * Disbursements by transaction
 // - Individual contributions:
 //   * Contributor state, size, all transactions
-
-function initFilingsTable() {
-  var $table = $('table[data-type="filing"]');
-  var candidateId = $table.attr('data-candidate');
-  var path = ['candidate', candidateId, 'filings'];
-  tables.DataTable.defer($table, {
-    path: path,
-    columns: filingsColumns,
-    order: [[2, 'desc']],
-    dom: tables.simpleDOM,
-    pagingType: 'simple',
-  });
-}
 
 function initOtherDocumentsTable() {
   var $table = $('table[data-type="other-documents"]');
@@ -477,7 +451,6 @@ function initContributionsTables() {
 }
 
 $(document).ready(function() {
-  initFilingsTable();
   initOtherDocumentsTable();
   initSpendingTables();
   initDisbursementsTable();

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -287,7 +287,7 @@ var filingsColumns = columnHelpers.getColumns(
 
 var filingsReportsColumns = columnHelpers.getColumns(
   columns.filings,
-  ['document_type', 'version', 'receipt_date_unordable', 'pages', 'modal_trigger']
+  ['document_type', 'version', 'receipt_date_unorderable', 'pages', 'modal_trigger']
 );
 
 $(document).ready(function() {

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -287,7 +287,7 @@ var filingsColumns = columnHelpers.getColumns(
 
 var filingsReportsColumns = columnHelpers.getColumns(
   columns.filings,
-  ['document_type', 'version', 'receipt_date', 'pages', 'modal_trigger']
+  ['document_type', 'version', 'receipt_date_unordable', 'pages', 'modal_trigger']
 );
 
 $(document).ready(function() {
@@ -541,6 +541,7 @@ $(document).ready(function() {
       case 'filings-reports':
         opts = _.extend({
           columns: filingsReportsColumns,
+          order: [],
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
             form_type: ['F3', 'F3X', 'F3P', 'F3L', 'F4', 'F7', 'F13', 'RFAI'],

--- a/static/templates/reports/candidate.hbs
+++ b/static/templates/reports/candidate.hbs
@@ -31,7 +31,9 @@
       {{#if csv_url}}
       <a target="_blank" href="{{ csv_url }}">CSV</a> |
       {{/if}}
+      {{#if pdf_url }}
       <a target="_blank" href="{{ pdf_url }}">PDF</a>
+      {{/if}}
       {{#if fec_url}}
       | <a target="_blank" href="{{ fec_url }}">FEC</a>
       {{/if}}

--- a/static/templates/reports/ie-only.hbs
+++ b/static/templates/reports/ie-only.hbs
@@ -31,7 +31,9 @@
       {{#if csv_url}}
       <a target="_blank" href="{{ csv_url }}">CSV</a> |
       {{/if}}
+      {{#if pdf_url}}
       <a target="_blank" href="{{ pdf_url }}">PDF</a>
+      {{/if}}
       {{#if fec_url}}
       | <a target="_blank" href="{{ fec_url }}">FEC</a>
       {{/if}}

--- a/static/templates/reports/pac.hbs
+++ b/static/templates/reports/pac.hbs
@@ -31,7 +31,9 @@
       {{#if csv_url}}
       <a target="_blank" href="{{ csv_url }}">CSV</a> |
       {{/if}}
+      {{#if pdf_url}}
       <a target="_blank" href="{{ pdf_url }}">PDF</a>
+      {{/if}}
       {{#if fec_url}}
       | <a target="_blank" href="{{ fec_url }}">FEC</a>
       {{/if}}

--- a/static/templates/reports/reportType.hbs
+++ b/static/templates/reports/reportType.hbs
@@ -26,9 +26,11 @@
         <a class="dropdown__value" target="_blank" href="{{ fec_url }}">.fec</a>
       </li>
       {{/if}}
+      {{#if pdf_url}}
       <li class="dropdown__item">
         <a class="dropdown__value" target="_blank" href="{{ pdf_url }}">.pdf</a>
       </li>
+      {{/if}}
     </ul>
   </div>
   {{/if}}


### PR DESCRIPTION
The committee filings table isn't manually sortable, since it uses a complex sorting query to get filings to display in a certain order. However, due to a quirk in the datatables library, it was rendering it as if the first column was sorting, which made it seem like you should be able to sort it in the other direction. This removes the apparent (but not functional) sort styling from the document description and receipt date columns:

![image](https://cloud.githubusercontent.com/assets/1696495/26650516/89e30b50-45fe-11e7-8cc9-a6fd853c533c.png)

Resolves https://github.com/18F/FEC/issues/4155
Resolves https://github.com/18F/openFEC-web-app/issues/2041

This also makes it so that reports tables only show links to PDFs if the `pdf_url` is actually present for a given report.

Resolves https://github.com/18F/FEC/issues/4158

---

## Update
This also fixes an issue we're experiencing with wonky column widths in Firefox as a result of using `table-layout: fixed` with a mix of percentage and px based column widths. Firefox is using the percentage value and actually calculating the width correctly, whereas Chrome expands the column if there's space available. The better way to go, however, is to just use `table-layout: auto` and let the browser handle all the work of sizing the columns. This works well in general, and so I removed the column size classes in almost all instances. 

The places where I kept it was `column--med` for the version columns, but changed it to a min-width value set in px and then `column--small` for all date columns, because those have predictable widths and so can be constrained in order to give more space to other columns.

This requires an update to fec-style.

The end result is no more of this:
![image](https://cloud.githubusercontent.com/assets/1696495/26659126/66aeb81c-4623-11e7-84e3-315376686bbd.png)
![image](https://cloud.githubusercontent.com/assets/1696495/26659152/91c97fa0-4623-11e7-8ed0-c2781f9668e0.png)


And more of this:
![image](https://cloud.githubusercontent.com/assets/1696495/26659135/75199fc0-4623-11e7-9c0f-8171163d07a6.png)

![image](https://cloud.githubusercontent.com/assets/1696495/26659159/9bfe3592-4623-11e7-9b3f-02910299c7fd.png)

Resolves https://github.com/18F/FEC/issues/4153
Resolves https://github.com/18F/openFEC-web-app/issues/2093