### PR TITLE
Remove election_year filter for top raisers and spenders

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -265,7 +265,6 @@ def load_top_candidates(sort, office=None, cycle=constants.DEFAULT_TIME_PERIOD, 
         response = _call_api(
             'candidates', 'totals',
             sort_hide_null=True,
-            election_year=cycle,
             cycle=cycle,
             election_full=False,
             office=office,


### PR DESCRIPTION
This removes the election year filter when showing top raising and spending candidates which means that candidates running in odd years will show up:

![image](https://cloud.githubusercontent.com/assets/1696495/26692969/709016fc-46b7-11e7-85d9-e7beafd6975a.png)

![image](https://cloud.githubusercontent.com/assets/1696495/26692975/75d4bb90-46b7-11e7-8e3d-992de4936faf.png)

Resolves https://github.com/18F/FEC/issues/4169