### PR TITLE
Adding ao number field to landing page

### DIFF
--- a/openfecwebapp/templates/legal-advisory-opinions-landing.html
+++ b/openfecwebapp/templates/legal-advisory-opinions-landing.html
@@ -12,32 +12,46 @@
     <a class="button button--cta button--go" href="{{ cms_url }}/legal-resources/advisory-opinions-process">The advisory opinion process</a>
   </div>
   <div class="u-no-print">
-    <div class="slab slab--neutral slab--inline">
-      <div class="container">
-        <div class="row">
-          <form action="{{ url_for('advisory_opinions') }}" autocomplete="off" class="search__container  js-search">
-            <label for="search-input" class="label">Search or browse advisory opinions</label>
-            <div class="combo combo--search--medium combo--search--inline">
-              <input id="search-input" type="text" name="search" class="combo__input">
-              <button class="combo__button button--search button--standard" type="submit">
-                <span class="u-visually-hidden">Search</span>
-              </button>
+    <div class="slab slab--neutral slab--inline u-padding--left u-padding--right">
+      <div class="heading--section heading--with-action">
+        <h2 class="heading__left">Search advisory opinions</h2>
+        <a class="button button--alt button--go heading__right" href="{{url_for('advisory_opinions')}}">Advanced search</a>
+      </div>
+      <div class="row">
+        <form action="{{ url_for('advisory_opinions') }}" autocomplete="off" class="search__container u-padding--top">
+          <div class="search-controls__row">
+            <div class="search-controls__either">
+              <label for="ao_no" class="label">Find by AO number</label>
+              <div class="combo combo--search--medium combo--search--inline">
+                <input type="text" id="ao_no" name="ao_no" class="combo__input">
+                <button class="combo__button button--search button--standard" type="submit">
+                  <span class="u-visually-hidden">Search</span>
+                </button>
+              </div>
+              <span class="t-note t-sans search__example">Example: 2003-38</span>
             </div>
-          </form>
-        </div>
-        <div class="row">
-          <div class="row search__example">
-            <span class="t-note t-sans">Examples: spending prohibitions; 2003-38</span>
-            <a class="u-float-right t-sans" href="{{url_for('advisory_opinions')}}">Advanced search</a>
+            <div class="search-controls__or search-controls__or--vertical">or</div>
+            <div class="search-controls__either">
+              <label for="search-input" class="label">Search by keyword</label>
+              <div class="combo combo--search--medium combo--search--inline">
+                <input id="search-input" type="text" name="search" class="combo__input">
+                <button class="combo__button button--search button--standard" type="submit">
+                  <span class="u-visually-hidden">Search</span>
+                </button>
+              </div>
+              <div class="row search__example">
+                <span class="t-note t-sans">Examples: charity, "spending prohibitions"</span>
+              </div>
+            </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="message message--info">
-            <h3>This feature is still in progress</h3>
-            <p>We&#39;re actively building the <strong>advisory opinion search</strong>, and it doesn&#39;t yet include some
-            advanced search functions. If you can&#39;t find what you&#39;re looking for, you can still <a href="http://saos.fec.gov/saos/searchao">search
-            opinions on the old FEC.gov</a>.</p>
-          </div>
+        </form>
+      </div>
+      <div class="row">
+        <div class="message message--info">
+          <h3>This feature is still in progress</h3>
+          <p>We&#39;re actively building the <strong>advisory opinion search</strong>, and it doesn&#39;t yet include some
+          advanced search functions. If you can&#39;t find what you&#39;re looking for, you can still <a href="http://saos.fec.gov/saos/searchao">search
+          opinions on the old FEC.gov</a>.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Per a discussion in Slack, this adds the AO number field to the AO landing page and also updates the help text to include an example in quotation marks:

![image](https://cloud.githubusercontent.com/assets/1696495/26746208/1d5601b2-47a3-11e7-896e-491c022b9eeb.png)
