### PR TITLE
Feature/raising spending candidate pages

### DIFF
--- a/openfecwebapp/filters.py
+++ b/openfecwebapp/filters.py
@@ -30,6 +30,12 @@ def date_filter(value, fmt='%m/%d/%Y'):
         return None
     return ensure_date(value).strftime(fmt)
 
+@app.template_filter('date_full')
+def date_full_filter(value, fmt='%B %d, %Y'):
+    if value is None:
+        return None
+    return ensure_date(value).strftime(fmt)
+
 @app.template_filter('ao_document_date')
 def ao_document_date(value):
     date = date_filter(value)

--- a/openfecwebapp/templates/candidates-single.html
+++ b/openfecwebapp/templates/candidates-single.html
@@ -58,7 +58,11 @@
             data-name="individual-contributions"
             tabindex="3"
             aria-controls="panel3"
-            href="#section-3">Individual contributions</a>
+            href="#section-3">Raising</a>
+            <ul>
+              <li>Total receipts</li>
+              <li>Individual contribution transactions</li>
+            </ul>
         </li>
         <li class="side-nav__item" role="presentation">
           <a
@@ -67,7 +71,11 @@
             data-name="itemized-disbursements"
             tabindex="2"
             aria-controls="panel4"
-            href="#section-4">Disbursements</a>
+            href="#section-4">Spending</a>
+            <ul>
+              <li>Total disbursements</li>
+              <li>Disbursement transactions</li>
+            </ul>
         </li>
         <li class="side-nav__item" role="presentation">
           <a

--- a/openfecwebapp/templates/candidates-single.html
+++ b/openfecwebapp/templates/candidates-single.html
@@ -47,7 +47,7 @@
             class="side-nav__link"
             role="tab"
             data-name="about-candidate"
-            tabindex="1"
+            tabindex="0"
             aria-controls="panel2"
             href="#section-2">About this candidate</a>
         </li>
@@ -56,7 +56,7 @@
             class="side-nav__link"
             role="tab"
             data-name="raising"
-            tabindex="3"
+            tabindex="0"
             aria-controls="panel3"
             href="#section-3">Raising</a>
             <ul>
@@ -69,7 +69,7 @@
             class="side-nav__link"
             role="tab"
             data-name="spending"
-            tabindex="2"
+            tabindex="0"
             aria-controls="panel4"
             href="#section-4">Spending</a>
             <ul>
@@ -82,7 +82,7 @@
             class="side-nav__link"
             role="tab"
             data-name="other-spending"
-            tabindex="4"
+            tabindex="0"
             aria-controls="panel5"
             href="#section-5">Spending by others to support or oppose</a>
         </li>

--- a/openfecwebapp/templates/candidates-single.html
+++ b/openfecwebapp/templates/candidates-single.html
@@ -55,26 +55,26 @@
           <a
             class="side-nav__link"
             role="tab"
-            data-name="individual-contributions"
+            data-name="raising"
             tabindex="3"
             aria-controls="panel3"
             href="#section-3">Raising</a>
             <ul>
-              <li>Total receipts</li>
-              <li>Individual contribution transactions</li>
+              <li><a href="#total-receipts">Total receipts</a></li>
+              <li><a href="#individual-contribution-transactions">Individual contribution transactions</a></li>
             </ul>
         </li>
         <li class="side-nav__item" role="presentation">
           <a
             class="side-nav__link"
             role="tab"
-            data-name="itemized-disbursements"
+            data-name="spending"
             tabindex="2"
             aria-controls="panel4"
             href="#section-4">Spending</a>
             <ul>
-              <li>Total disbursements</li>
-              <li>Disbursement transactions</li>
+              <li><a href="#total-disbursements">Total disbursements</a></li>
+              <li><a href="#disbursement-transactions">Disbursement transactions</a></li>
             </ul>
         </li>
         <li class="side-nav__item" role="presentation">
@@ -100,8 +100,8 @@
       {% include 'partials/candidate/financial-summary.html' %}
       {% include 'partials/candidate/about-candidate.html' %}
       {% include 'partials/candidate/other-spending-tab.html' %}
-      {% include 'partials/candidate/itemized-disbursements.html' %}
-      {% include 'partials/candidate/individual-contributions.html' %}
+      {% include 'partials/candidate/raising.html' %}
+      {% include 'partials/candidate/spending.html' %}
     </div>
   </div>
 

--- a/openfecwebapp/templates/committees-single.html
+++ b/openfecwebapp/templates/committees-single.html
@@ -30,9 +30,26 @@
     <nav class="sidebar side-nav-alt">
       <ul class="tablist" role="tablist" data-name="tab">
         {% if committee_type not in ['C', 'E'] %}
-          {{ tabs.side_tab('Financial summary', 'summary', 'panel1', '#section-1') }}
+        <li class="side-nav__item" role="presentation">
+          <a
+            class="side-nav__link"
+            role="tab"
+            data-name="summary"
+            tabindex="0"
+            aria-controls="panel1"
+            href="#section-1"
+            aria-selected="true">Financial Summary</a>
+        </li>
         {% endif %}
-        {{ tabs.side_tab('About this committee', 'about', 'panel2', '#section-2') }}
+        <li class="side-nav__item" role="presentation">
+          <a
+            class="side-nav__link"
+            role="tab"
+            data-name="about-committee"
+            tabindex="1"
+            aria-controls="panel2"
+            href="#section-2">About this committee</a>
+        </li>
         {% if committee_type in ['C'] %}
           {{ tabs.side_tab('Communication cost', 'communication-cost-committee', 'panel6', '#section-1') }}
         {% endif %}
@@ -40,9 +57,33 @@
           {{ tabs.side_tab('Electioneering communication', 'electioneering-committee', 'panel6', '#section-1') }}
         {% endif %}
         {% if committee_type not in ['C'] %}
-          {{ tabs.side_tab('Individual contributions', 'receipts', 'panel3', '#section-3') }}
+          <li class="side-nav__item" role="presentation">
+            <a
+              class="side-nav__link"
+              role="tab"
+              data-name="raising"
+              tabindex="3"
+              aria-controls="panel3"
+              href="#section-3">Raising</a>
+              <ul>
+                <li><a href="#total-receipts">Total receipts</a></li>
+                <li><a href="#individual-contribution-transactions">Individual contribution transactions</a></li>
+              </ul>
+          </li>
         {% endif %}
-          {{ tabs.side_tab('Disbursements', 'disbursements', 'panel4', '#section-4') }}
+        <li class="side-nav__item" role="presentation">
+          <a
+            class="side-nav__link"
+            role="tab"
+            data-name="spending"
+            tabindex="2"
+            aria-controls="panel4"
+            href="#section-4">Spending</a>
+            <ul>
+              <li><a href="#total-disbursements">Total disbursements</a></li>
+              <li><a href="#disbursement-transactions">Disbursement transactions</a></li>
+            </ul>
+        </li>
         {% if committee_type not in ['P', 'H', 'S', 'Z', 'C', 'E', 'D'] %}
           {{ tabs.side_tab('Independent expenditures', 'independent-expenditures-committee', 'panel7', '#section-6') }}
         {% endif %}
@@ -57,9 +98,9 @@
         {% include 'partials/committee/financial-summary.html' %}
       {% endif %}
       {% if committee_type not in ['C'] %}
-        {% include 'partials/committee/receipts.html' %}
+        {% include 'partials/committee/raising.html' %}
       {% endif %}
-      {% include 'partials/committee/disbursements.html' %}
+      {% include 'partials/committee/spending.html' %}
       {% if committee_type not in ['P', 'H', 'S', 'Z', 'C', 'E', 'D'] %}
         {% include 'partials/committee/independent-expenditures.html' %}
       {% endif %}

--- a/openfecwebapp/templates/committees-single.html
+++ b/openfecwebapp/templates/committees-single.html
@@ -46,7 +46,7 @@
             class="side-nav__link"
             role="tab"
             data-name="about-committee"
-            tabindex="1"
+            tabindex="0"
             aria-controls="panel2"
             href="#section-2">About this committee</a>
         </li>
@@ -62,7 +62,7 @@
               class="side-nav__link"
               role="tab"
               data-name="raising"
-              tabindex="3"
+              tabindex="0"
               aria-controls="panel3"
               href="#section-3">Raising</a>
               <ul>
@@ -76,7 +76,7 @@
             class="side-nav__link"
             role="tab"
             data-name="spending"
-            tabindex="2"
+            tabindex="0"
             aria-controls="panel4"
             href="#section-4">Spending</a>
             <ul>

--- a/openfecwebapp/templates/partials/candidate/individual-contributions.html
+++ b/openfecwebapp/templates/partials/candidate/individual-contributions.html
@@ -9,147 +9,154 @@
 
     {{ select.candidate_cycle_select(cycles, max_cycle, id="cycle-5") }}
 
-  <span class="t-sans t-bold">Data is included from these committees:</span>
+    <span class="t-sans t-bold">Data is included from these committees:</span>
 
-  <ul class="list--bulleted">
-    {% for committee in committee_groups['P'] | reverse %}
-    {% if committee.cycle == max_cycle %}
-    <li>
-      <a class="t-sans" href="{{ url_for('committee_page', c_id=committee.committee_id, cycle=committee.related_cycle) }}">{{ committee.name }}</a>
-    </li>
-    {% endif %}
-    {% endfor %}
-    {% for committee in committee_groups['A'] | reverse %}
-    {% if committee.cycle == max_cycle %}
-    <li>
-      <a class="t-sans" href="{{ url_for('committee_page', c_id=committee.committee_id, cycle=committee.related_cycle) }}">{{ committee.name }}</a>
-    </li>
-    {% endif %}
-    {% endfor %}
-  </ul>
+    <ul class="list--bulleted">
+      {% for committee in committee_groups['P'] | reverse %}
+      {% if committee.cycle == max_cycle %}
+      <li>
+        <a class="t-sans" href="{{ url_for('committee_page', c_id=committee.committee_id, cycle=committee.related_cycle) }}">{{ committee.name }}</a>
+      </li>
+      {% endif %}
+      {% endfor %}
+      {% for committee in committee_groups['A'] | reverse %}
+      {% if committee.cycle == max_cycle %}
+      <li>
+        <a class="t-sans" href="{{ url_for('committee_page', c_id=committee.committee_id, cycle=committee.related_cycle) }}">{{ committee.name }}</a>
+      </li>
+      {% endif %}
+      {% endfor %}
+    </ul>
 
-  <div class="entity__figure row">
+    <div class="entity__figure row">
+      <div class="content__section">
+        <h3>Total receipts</h3>
 
-    <div class="content__section">
-
-      <h3>Individual contributions by transaction</h3>
-
-      <div class="row">
-        <fieldset class="toggles js-toggles">
-          <legend class="label">View by:</legend>
-
-          <a class="u-float-right button--alt button--browse"
-              href="{{ url_for(
-                'individual_contributions',
-                two_year_transaction_period=max_cycle,
-                min_date=cycle_start(max_cycle) | date(fmt='%m-%d-%Y'),
-                max_date=cycle_end(max_cycle) | date(fmt='%m-%d-%Y')
-              ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
-
-          <label for="toggle-state">
-            <input id="toggle-state" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="contributor-state" checked />
-            <span class="button--alt">State</span>
-          </label>
-          <label for="toggle-size">
-            <input id="toggle-size" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="contribution-size" />
-            <span class="button--alt">Size</span>
-          </label>
-          <label for="toggle-all">
-            <input id="toggle-all" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="all-transactions" />
-            <span class="button--alt">All transactions</span>
-          </label>
-        </fieldset>
       </div>
+    </div>
 
-      <div id="contributor-state" class="panel-toggle-element">
+    <div class="entity__figure row">
+      <div class="content__section">
+        <h3>Individual contributions by transaction</h3>
 
-        <div class="results-info results-info--simple">
-          <ul class="u-float-left">
-            <li class="tag__category">
-              <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
-            </li>
-          </ul>
+        <div class="row">
+          <fieldset class="toggles js-toggles">
+            <legend class="label">View by:</legend>
+
+            <a class="u-float-right button--alt button--browse"
+                href="{{ url_for(
+                  'individual_contributions',
+                  two_year_transaction_period=max_cycle,
+                  min_date=cycle_start(max_cycle) | date(fmt='%m-%d-%Y'),
+                  max_date=cycle_end(max_cycle) | date(fmt='%m-%d-%Y')
+                ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
+
+            <label for="toggle-state">
+              <input id="toggle-state" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="contributor-state" checked />
+              <span class="button--alt">State</span>
+            </label>
+            <label for="toggle-size">
+              <input id="toggle-size" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="contribution-size" />
+              <span class="button--alt">Size</span>
+            </label>
+            <label for="toggle-all">
+              <input id="toggle-all" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="all-transactions" />
+              <span class="button--alt">All transactions</span>
+            </label>
+          </fieldset>
         </div>
 
-        <div class="map-table">
+        <div id="contributor-state" class="panel-toggle-element">
+
+          <div class="results-info results-info--simple">
+            <ul class="u-float-left">
+              <li class="tag__category">
+                <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
+              </li>
+            </ul>
+          </div>
+
+          <div class="map-table">
+            <table
+                class="data-table data-table--heading-borders"
+                data-type="contributor-state"
+                data-cycle="{{ max_cycle }}"
+              >
+              <thead>
+                <th scope="col">State</th>
+                <th scope="col">Total contributed</th>
+              </thead>
+            </table>
+          </div>
+
+          <div class="map-panel">
+            <div class="state-map" data-candidate-id="{{ candidate_id }}" data-cycle="{{ max_cycle }}">
+              <div class="legend-container">
+                <span class="t-sans t-block">By state: total amount received</span>
+                <svg></svg>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div id="contribution-size" class="panel-toggle-element" aria-hidden="true">
+          <div class="results-info results-info--simple">
+            <ul class="u-float-left">
+              <li class="tag__category">
+                <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
+              </li>
+            </ul>
+          </div>
+
           <table
-              class="data-table data-table--heading-borders"
-              data-type="contributor-state"
-              data-cycle="{{ max_cycle }}"
-            >
+             class="data-table data-table--heading-borders"
+             data-type="contribution-size"
+             data-cycle="{{ max_cycle }}">
             <thead>
-              <th scope="col">State</th>
+              <th scope="col">Contribution size</th>
               <th scope="col">Total contributed</th>
             </thead>
           </table>
         </div>
 
-        <div class="map-panel">
-          <div class="state-map" data-candidate-id="{{ candidate_id }}" data-cycle="{{ max_cycle }}">
-            <div class="legend-container">
-              <span class="t-sans t-block">By state: total amount received</span>
-              <svg></svg>
+        <div id="all-transactions" class="panel-toggle-element" aria-hidden="true">
+          <div class="results-info results-info--simple">
+            <ul class="u-float-left">
+              <li class="tag__category">
+                <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
+              </li>
+            </ul>
+
+            <div class="u-float-right">
+              <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="individual-contributions" aria-hidden="true">
+              </div>
+              <button type="button" class="js-export button button--cta button--export" data-export-for="individual-contributions">Export</button>
             </div>
           </div>
+
+          <table
+              class="data-table data-table--heading-borders"
+              data-type="individual-contributions"
+              data-candidate-id="{{ candidate_id }}"
+              data-committee-id="{% for c in committee_groups['P'] | reverse %}{{ c.committee_id }},{% endfor %}{% for c in committee_groups['A'] | reverse %}{{ c.committee_id }},{% endfor %}"
+              data-name="{{ name }}"
+              data-cycle="{{ max_cycle }}"
+              data-duration="2"
+            >
+            <thead>
+              <tr>
+                <th scope="col">Contributor name</th>
+                <th scope="col">Recipient</th>
+                <th scope="col">Receipt date</th>
+                <th scope="col">Amount</th>
+              </tr>
+            </thead>
+          </table>
         </div>
-
-      </div>
-
-      <div id="contribution-size" class="panel-toggle-element" aria-hidden="true">
-        <div class="results-info results-info--simple">
-          <ul class="u-float-left">
-            <li class="tag__category">
-              <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
-            </li>
-          </ul>
-        </div>
-
-        <table
-           class="data-table data-table--heading-borders"
-           data-type="contribution-size"
-           data-cycle="{{ max_cycle }}">
-          <thead>
-            <th scope="col">Contribution size</th>
-            <th scope="col">Total contributed</th>
-          </thead>
-        </table>
-      </div>
-
-      <div id="all-transactions" class="panel-toggle-element" aria-hidden="true">
-        <div class="results-info results-info--simple">
-          <ul class="u-float-left">
-            <li class="tag__category">
-              <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
-            </li>
-          </ul>
-
-          <div class="u-float-right">
-            <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="individual-contributions" aria-hidden="true">
-            </div>
-            <button type="button" class="js-export button button--cta button--export" data-export-for="individual-contributions">Export</button>
-          </div>
-        </div>
-
-        <table
-            class="data-table data-table--heading-borders"
-            data-type="individual-contributions"
-            data-candidate-id="{{ candidate_id }}"
-            data-committee-id="{% for c in committee_groups['P'] | reverse %}{{ c.committee_id }},{% endfor %}{% for c in committee_groups['A'] | reverse %}{{ c.committee_id }},{% endfor %}"
-            data-name="{{ name }}"
-            data-cycle="{{ max_cycle }}"
-            data-duration="2"
-          >
-          <thead>
-            <tr>
-              <th scope="col">Contributor name</th>
-              <th scope="col">Recipient</th>
-              <th scope="col">Receipt date</th>
-              <th scope="col">Amount</th>
-            </tr>
-          </thead>
-        </table>
       </div>
     </div>
+
   </div>
 
 </section>

--- a/openfecwebapp/templates/partials/candidate/itemized-disbursements.html
+++ b/openfecwebapp/templates/partials/candidate/itemized-disbursements.html
@@ -31,7 +31,13 @@
     </ul>
 
     <div class="entity__figure row">
+      <div class="content__section">
+        <h3>Total disbursements</h3>
 
+      </div>
+    </div>
+
+    <div class="entity__figure row">
       <div class="content__section">
         <div class="results-info results-info--simple">
           <h3 class="u-no-margin">Disbursements by transaction</h3>

--- a/openfecwebapp/templates/partials/candidate/raising.html
+++ b/openfecwebapp/templates/partials/candidate/raising.html
@@ -32,7 +32,7 @@
 
         <div class="usa-width-one-half">
           <span class="t-big-data u-no-margin">{{ raising_summary[0][0]|currency }}</span>
-          <span class="t-block t-sans">raised in total receipts by this candidate's authorized committees from <strong>January 1, {{ max_cycle - 1 }} to December 31, {{ max_cycle }}.</strong></span>
+          <span class="t-block t-sans">raised in total receipts by this candidate's authorized committees from <strong>{{aggregate.coverage_start_date|date_full}} to {{aggregate.coverage_end_date|date_full}}.</strong></span>
         </div>
 
         <div class="usa-width-one-half">

--- a/openfecwebapp/templates/partials/candidate/raising.html
+++ b/openfecwebapp/templates/partials/candidate/raising.html
@@ -32,6 +32,21 @@
       <div class="content__section">
         <h3>Total receipts</h3>
 
+        <div class="usa-width-one-half">
+          <span class="t-big-data u-no-margin">{{ raising_summary[0][0]|currency }}</span>
+          <span class="t-block t-sans">raised in total receipts by this candidate's authorized committees from <strong>January 1, {{ max_cycle - 1 }} to December 31, {{ max_cycle }}.</strong></span>
+        </div>
+
+        <div class="usa-width-one-half">
+          <a class="button--alt button--browse"
+            href="{{ url_for(
+              'receipts',
+              two_year_transaction_period=max_cycle,
+              min_date=cycle_start(max_cycle) | date(fmt='%m-%d-%Y'),
+              max_date=cycle_end(max_cycle) | date(fmt='%m-%d-%Y')
+            ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter all receipts</a>
+          <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of receipt.</span>
+        </div>
       </div>
     </div>
 
@@ -71,7 +86,7 @@
           <div class="results-info results-info--simple">
             <ul class="u-float-left">
               <li class="tag__category">
-                <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
+                <div class="tag__item">Report year: {{ max_cycle - 1 }} to {{ max_cycle }}</div>
               </li>
             </ul>
           </div>
@@ -104,7 +119,7 @@
           <div class="results-info results-info--simple">
             <ul class="u-float-left">
               <li class="tag__category">
-                <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
+                <div class="tag__item">Report year: {{ max_cycle - 1 }} to {{ max_cycle }}</div>
               </li>
             </ul>
           </div>
@@ -124,7 +139,7 @@
           <div class="results-info results-info--simple">
             <ul class="u-float-left">
               <li class="tag__category">
-                <div class="tag__item">Report year: {{max_cycle - 1}} to {{max_cycle}}</div>
+                <div class="tag__item">Report year: {{ max_cycle - 1 }} to {{ max_cycle }}</div>
               </li>
             </ul>
 

--- a/openfecwebapp/templates/partials/candidate/raising.html
+++ b/openfecwebapp/templates/partials/candidate/raising.html
@@ -27,7 +27,7 @@
     </ul>
 
     <div id="total-receipts" class="entity__figure row">
-      <div class="content__section">
+      <div class="content__section--narrow">
         <h3>Total receipts</h3>
 
         <div class="usa-width-one-half">

--- a/openfecwebapp/templates/partials/candidate/raising.html
+++ b/openfecwebapp/templates/partials/candidate/raising.html
@@ -31,8 +31,8 @@
         <h3>Total receipts</h3>
 
         <div class="usa-width-one-half">
-          <span class="t-big-data u-no-margin">{{ raising_summary[0][0]|currency }}</span>
-          <span class="t-block t-sans">raised in total receipts by this candidate's authorized committees from <strong>{{aggregate.coverage_start_date|date_full}} to {{aggregate.coverage_end_date|date_full}}.</strong></span>
+          <span class="t-big-data u-no-margin">{{ two_year_totals['receipts']|currency }}</span>
+          <span class="t-block t-sans">raised in total receipts by this candidate's authorized committees from <strong>{{two_year_totals.coverage_start_date|date_full}} to {{two_year_totals.coverage_end_date|date_full}}.</strong></span>
         </div>
 
         <div class="usa-width-one-half">

--- a/openfecwebapp/templates/partials/candidate/raising.html
+++ b/openfecwebapp/templates/partials/candidate/raising.html
@@ -2,7 +2,7 @@
 
 <section id="section-3" role="tabpanel" aria-hidden="true" aria-labelledby="section-3-heading">
   <div class="heading--section">
-    <h2 id="section-3-heading">Individual contributions</h2>
+    <h2 id="section-3-heading">Raising</h2>
   </div>
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
@@ -28,16 +28,16 @@
       {% endfor %}
     </ul>
 
-    <div class="entity__figure row">
+    <div id="total-receipts" class="entity__figure row">
       <div class="content__section">
         <h3>Total receipts</h3>
 
       </div>
     </div>
 
-    <div class="entity__figure row">
+    <div id="individual-contribution-transactions" class="entity__figure row">
       <div class="content__section">
-        <h3>Individual contributions by transaction</h3>
+        <h3>All individual contribution transactions</h3>
 
         <div class="row">
           <fieldset class="toggles js-toggles">

--- a/openfecwebapp/templates/partials/candidate/raising.html
+++ b/openfecwebapp/templates/partials/candidate/raising.html
@@ -1,9 +1,7 @@
 {% import 'macros/cycle-select.html' as select %}
 
 <section id="section-3" role="tabpanel" aria-hidden="true" aria-labelledby="section-3-heading">
-  <div class="heading--section">
-    <h2 id="section-3-heading">Raising</h2>
-  </div>
+  <h2 id="section-3-heading">Raising</h2>
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 

--- a/openfecwebapp/templates/partials/candidate/spending.html
+++ b/openfecwebapp/templates/partials/candidate/spending.html
@@ -29,7 +29,7 @@
     </ul>
 
     <div id="total-disbursements" class="entity__figure row">
-      <div class="content__section">
+      <div class="content__section--narrow">
         <h3>Total disbursements</h3>
 
         <div class="usa-width-one-half">

--- a/openfecwebapp/templates/partials/candidate/spending.html
+++ b/openfecwebapp/templates/partials/candidate/spending.html
@@ -4,7 +4,7 @@
 
 <section id="section-4" role="tabpanel" aria-hidden="true" aria-labelledby="section-4-heading">
   <div class="heading--section">
-    <h2 id="section-4-heading">Itemized disbursements</h2>
+    <h2 id="section-4-heading">Spending</h2>
   </div>
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
@@ -30,17 +30,17 @@
       {% endfor %}
     </ul>
 
-    <div class="entity__figure row">
+    <div id="total-disbursements" class="entity__figure row">
       <div class="content__section">
         <h3>Total disbursements</h3>
 
       </div>
     </div>
 
-    <div class="entity__figure row">
+    <div id="disbursement-transactions" class="entity__figure row">
       <div class="content__section">
         <div class="results-info results-info--simple">
-          <h3 class="u-no-margin">Disbursements by transaction</h3>
+          <h3 class="u-no-margin">All disbursement transactions</h3>
 
           <a class="u-float-right button--alt button--browse"
               href="{{ url_for(

--- a/openfecwebapp/templates/partials/candidate/spending.html
+++ b/openfecwebapp/templates/partials/candidate/spending.html
@@ -34,7 +34,7 @@
 
         <div class="usa-width-one-half">
           <span class="t-big-data u-no-margin">{{ spending_summary[0][0]|currency }}</span>
-          <span class="t-block t-sans">spent in total disbursements by this candidate's authorized committees from <strong>January 1, {{ max_cycle - 1 }} to December 31, {{ max_cycle }}.</strong></span>
+          <span class="t-block t-sans">spent in total disbursements by this candidate's authorized committees from <strong>{{aggregate.coverage_start_date|date_full}} to {{aggregate.coverage_end_date|date_full}}.</strong></span>
         </div>
 
         <div class="usa-width-one-half">

--- a/openfecwebapp/templates/partials/candidate/spending.html
+++ b/openfecwebapp/templates/partials/candidate/spending.html
@@ -33,8 +33,8 @@
         <h3>Total disbursements</h3>
 
         <div class="usa-width-one-half">
-          <span class="t-big-data u-no-margin">{{ spending_summary[0][0]|currency }}</span>
-          <span class="t-block t-sans">spent in total disbursements by this candidate's authorized committees from <strong>{{aggregate.coverage_start_date|date_full}} to {{aggregate.coverage_end_date|date_full}}.</strong></span>
+          <span class="t-big-data u-no-margin">{{ two_year_totals['disbursements']|currency }}</span>
+          <span class="t-block t-sans">spent in total disbursements by this candidate's authorized committees from <strong>{{two_year_totals.coverage_start_date|date_full}} to {{two_year_totals.coverage_end_date|date_full}}.</strong></span>
         </div>
 
         <div class="usa-width-one-half">

--- a/openfecwebapp/templates/partials/candidate/spending.html
+++ b/openfecwebapp/templates/partials/candidate/spending.html
@@ -3,9 +3,7 @@
 {% import 'macros/cycle-select.html' as select %}
 
 <section id="section-4" role="tabpanel" aria-hidden="true" aria-labelledby="section-4-heading">
-  <div class="heading--section">
-    <h2 id="section-4-heading">Spending</h2>
-  </div>
+  <h2 id="section-4-heading">Spending</h2>
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
 
@@ -34,6 +32,21 @@
       <div class="content__section">
         <h3>Total disbursements</h3>
 
+        <div class="usa-width-one-half">
+          <span class="t-big-data u-no-margin">{{ spending_summary[0][0]|currency }}</span>
+          <span class="t-block t-sans">spent in total disbursements by this candidate's authorized committees from <strong>January 1, {{ max_cycle - 1 }} to December 31, {{ max_cycle }}.</strong></span>
+        </div>
+
+        <div class="usa-width-one-half">
+          <a class="button--alt button--browse"
+            href="{{ url_for(
+              'disbursements',
+              two_year_transaction_period=max_cycle,
+              min_date=cycle_start(max_cycle) | date(fmt='%m-%d-%Y'),
+              max_date=cycle_end(max_cycle) | date(fmt='%m-%d-%Y')
+            ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter all disbursements</a>
+          <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of disbursement.</span>
+        </div>
       </div>
     </div>
 

--- a/openfecwebapp/templates/partials/committee/raising.html
+++ b/openfecwebapp/templates/partials/committee/raising.html
@@ -6,27 +6,29 @@
   <h2 id="section-3-heading">Raising</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     {{ select.committee_cycle_select(cycles, cycle, 'receipts')}}
-    <div id="total-receipts" class="entity__figure row">
-      <div class="content__section--narrow">
-        <h3>Total receipts</h3>
+    {% if committee_type not in ['C', 'E'] %}
+      <div id="total-receipts" class="entity__figure row">
+        <div class="content__section--narrow">
+          <h3>Total receipts</h3>
 
-        <div class="usa-width-one-half">
-          <span class="t-big-data u-no-margin">{{ raising_summary[0][0]|currency }}</span>
-          <span class="t-block t-sans">raised in total receipts by this candidate's authorized committees from <strong>{{totals.0.coverage_start_date|date_full}} to {{totals.0.coverage_end_date|date_full}}.</strong></span>
-        </div>
+          <div class="usa-width-one-half">
+            <span class="t-big-data u-no-margin">{{ raising_summary[0][0]|currency }}</span>
+            <span class="t-block t-sans">raised in total receipts by this candidate's authorized committees from <strong>{{totals.0.coverage_start_date|date_full}} to {{totals.0.coverage_end_date|date_full}}.</strong></span>
+          </div>
 
-        <div class="usa-width-one-half">
-          <a class="button--alt button--browse"
-            href="{{ url_for(
-              'receipts',
-              two_year_transaction_period=max_cycle,
-              min_date=cycle_start(cycle) | date(fmt='%m-%d-%Y'),
-              max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y')
-            ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter all receipts</a>
-          <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of receipt.</span>
+          <div class="usa-width-one-half">
+            <a class="button--alt button--browse"
+              href="{{ url_for(
+                'receipts',
+                two_year_transaction_period=max_cycle,
+                min_date=cycle_start(cycle) | date(fmt='%m-%d-%Y'),
+                max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y')
+              ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter all receipts</a>
+            <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of receipt.</span>
+          </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <div class="entity__figure" id="individual-contribution-transactions">
       <div class="row">
         <fieldset class="toggles js-toggles u-float-left">

--- a/openfecwebapp/templates/partials/committee/raising.html
+++ b/openfecwebapp/templates/partials/committee/raising.html
@@ -3,10 +3,31 @@
 {% import 'macros/cycle-select.html' as select %}
 
 <section id="section-3" role="tabpanel" aria-hidden="true" aria-labelledby="section-3-heading">
-  <h2 id="section-3-heading">Individual contributions</h2>
+  <h2 id="section-3-heading">Raising</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     {{ select.committee_cycle_select(cycles, cycle, 'receipts')}}
-    <div class="entity__figure">
+    <div id="total-receipts" class="entity__figure row">
+      <div class="content__section--narrow">
+        <h3>Total receipts</h3>
+
+        <div class="usa-width-one-half">
+          <span class="t-big-data u-no-margin">{{ raising_summary[0][0]|currency }}</span>
+          <span class="t-block t-sans">raised in total receipts by this candidate's authorized committees from <strong>January 1, {{ cycle - 1 }} to December 31, {{ cycle }}.</strong></span>
+        </div>
+
+        <div class="usa-width-one-half">
+          <a class="button--alt button--browse"
+            href="{{ url_for(
+              'receipts',
+              two_year_transaction_period=max_cycle,
+              min_date=cycle_start(cycle) | date(fmt='%m-%d-%Y'),
+              max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y')
+            ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter all receipts</a>
+          <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of receipt.</span>
+        </div>
+      </div>
+    </div>
+    <div class="entity__figure" id="individual-contribution-transactions">
       <div class="row">
         <fieldset class="toggles js-toggles u-float-left">
           <legend class="label">Group by:</legend>

--- a/openfecwebapp/templates/partials/committee/raising.html
+++ b/openfecwebapp/templates/partials/committee/raising.html
@@ -12,7 +12,7 @@
 
         <div class="usa-width-one-half">
           <span class="t-big-data u-no-margin">{{ raising_summary[0][0]|currency }}</span>
-          <span class="t-block t-sans">raised in total receipts by this candidate's authorized committees from <strong>January 1, {{ cycle - 1 }} to December 31, {{ cycle }}.</strong></span>
+          <span class="t-block t-sans">raised in total receipts by this candidate's authorized committees from <strong>{{totals.0.coverage_start_date|date_full}} to {{totals.0.coverage_end_date|date_full}}.</strong></span>
         </div>
 
         <div class="usa-width-one-half">

--- a/openfecwebapp/templates/partials/committee/spending.html
+++ b/openfecwebapp/templates/partials/committee/spending.html
@@ -5,6 +5,7 @@
   <h2 id="section-4-heading">Spending</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     {{ select.committee_cycle_select(cycles, cycle, 'disbursements')}}
+    {% if committee_type not in ['C', 'E'] %}
     <div id="total-disbursements" class="entity__figure row">
       <div class="content__section--narrow">
         <h3>Total disbursements</h3>
@@ -26,7 +27,7 @@
         </div>
       </div>
     </div>
-
+    {% endif %}
     <div class="entity__figure" id="disbursement-transactions" >
       <div class="row">
         <fieldset class="toggles js-toggles u-float-left">

--- a/openfecwebapp/templates/partials/committee/spending.html
+++ b/openfecwebapp/templates/partials/committee/spending.html
@@ -2,10 +2,32 @@
 {% import 'macros/cycle-select.html' as select %}
 
 <section id="section-4" role="tabpanel" aria-hidden="true" aria-labelledby="section-4-heading">
-  <h2 id="section-4-heading">Disbursements</h2>
+  <h2 id="section-4-heading">Spending</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     {{ select.committee_cycle_select(cycles, cycle, 'disbursements')}}
-    <div class="entity__figure">
+    <div id="total-disbursements" class="entity__figure row">
+      <div class="content__section--narrow">
+        <h3>Total disbursements</h3>
+
+        <div class="usa-width-one-half">
+          <span class="t-big-data u-no-margin">{{ spending_summary[0][0]|currency }}</span>
+          <span class="t-block t-sans">spent in total disbursements by this candidate's authorized committees from <strong>January 1, {{ cycle - 1 }} to December 31, {{ cycle }}.</strong></span>
+        </div>
+
+        <div class="usa-width-one-half">
+          <a class="button--alt button--browse"
+            href="{{ url_for(
+              'disbursements',
+              two_year_transaction_period=cycle,
+              min_date=cycle_start(cycle) | date(fmt='%m-%d-%Y'),
+              max_date=cycle_end(cycle) | date(fmt='%m-%d-%Y')
+            ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter all disbursements</a>
+          <span class="t-block t-sans">See the <a href="?tab=summary">financial summary</a> for a breakdown of each type of disbursement.</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="entity__figure" id="disbursement-transactions" >
       <div class="row">
         <fieldset class="toggles js-toggles u-float-left">
           <legend class="label">Group by:</legend>

--- a/openfecwebapp/templates/partials/committee/spending.html
+++ b/openfecwebapp/templates/partials/committee/spending.html
@@ -11,7 +11,7 @@
 
         <div class="usa-width-one-half">
           <span class="t-big-data u-no-margin">{{ spending_summary[0][0]|currency }}</span>
-          <span class="t-block t-sans">spent in total disbursements by this candidate's authorized committees from <strong>January 1, {{ cycle - 1 }} to December 31, {{ cycle }}.</strong></span>
+          <span class="t-block t-sans">spent in total disbursements by this candidate's authorized committees from <strong>{{totals.0.coverage_start_date|date_full}} to {{totals.0.coverage_end_date|date_full}}.</strong></span>
         </div>
 
         <div class="usa-width-one-half">

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -20,6 +20,7 @@ from openfecwebapp import config
 from openfecwebapp import api_caller
 from openfecwebapp import utils
 
+
 def render_search_results(results, query):
     return render_template(
         'search-results.html',
@@ -77,6 +78,7 @@ def render_legal_mur(mur):
         mur=mur,
         parent='legal'
     )
+
 
 def render_legal_ao_landing():
     today = datetime.date.today()
@@ -182,6 +184,7 @@ report_types = {
     'I': 'ie-only'
 }
 
+
 def render_candidate(candidate, committees, cycle, election_full=True):
     # candidate fields will be top-level in the template
     tmpl_vars = candidate
@@ -271,6 +274,7 @@ def validate_referer(referer):
     if furl.furl(referer).host != furl.furl(request.url).host:
         raise ValidationError('Invalid referer.')
 
+
 class GithubView(MethodView):
 
     decorators = [cross_origin()]
@@ -307,6 +311,7 @@ class GithubView(MethodView):
         body = render_template('feedback.html', headers=request.headers, **kwargs)
         issue = self.repo.create_issue(title, body=body)
         return jsonify(issue.to_json()), 201
+
 
 def get_legal_category_order(results):
     """ Return categories in pre-defined order, moving categories with empty results

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -246,6 +246,18 @@ def render_candidate(candidate, committees, cycle, election_full=True):
 
     tmpl_vars['aggregate'] = aggregate
 
+    # Get totals for the last two-year period of a cycle for showing on
+    # raising and spending tabs
+    two_year_totals = api_caller.load_candidate_totals(
+        candidate['candidate_id'],
+        cycle=tmpl_vars['max_cycle'],
+        election_full=False
+    )
+
+    print(two_year_totals)
+
+    tmpl_vars['two_year_totals'] = two_year_totals
+
     # Get the statements of candidacy
     statement_of_candidacy = api_caller.load_candidate_statement_of_candidacy(
         candidate['candidate_id'],

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -254,8 +254,6 @@ def render_candidate(candidate, committees, cycle, election_full=True):
         election_full=False
     )
 
-    print(two_year_totals)
-
     tmpl_vars['two_year_totals'] = two_year_totals
 
     # Get the statements of candidacy


### PR DESCRIPTION
Updates for raising/spending tabs on candidate pages. https://github.com/18F/openFEC-web-app/issues/2087
- Update spending/raising tabs
  - Add sub items
- Show total receipts/disbursements and filter button link 

<img width="1408" alt="screen shot 2017-06-05 at 1 47 05 pm" src="https://cloud.githubusercontent.com/assets/24054/26802662/36aa6022-49f6-11e7-8048-47d135f23436.png">
<img width="1405" alt="screen shot 2017-06-05 at 1 47 25 pm" src="https://cloud.githubusercontent.com/assets/24054/26802661/36a79dd8-49f6-11e7-92e3-10e9424d2ed0.png">

Requires: https://github.com/18F/fec-style/pull/727