### PR TITLE
Fixed more info links on advanced data committees tab

### DIFF
--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -187,7 +187,7 @@
               <div class="icon-heading grid__item">
                 <i class="icon-heading__image icon-circle--checklist"><span class="u-visually-hidden">Icon of a checklist</span></i>
                 <div class="icon-heading__content">
-                  <a href="{{ cms_url }}/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Help for candidates and their committees</a>
+                  <a href="{{ cms_url }}/help-candidates-and-committees#candidates-and-their-authorized-committees">Help for candidates and their committees</a>
                 </div>
               </div>
             </div>

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -206,13 +206,13 @@
               </div>
               <div class="post">
                 <h3><a href="{{ url_for('filings', form_type='RFAI') }}">Requests for Additional Information sent to committees</a></h3>
-                <p>Requests for Additional Information (RFAIs) are sent to committees when a Campaign Finance Analyst needs additional clarification on a committee’s filing or identifies an error, omission or possible prohibited activity. Search RFAIs by committee or date.</p>
+                <p>Requests for Additional Information (RFAIs) are sent to committees when a Campaign Finance Analyst needs additional clarification on a committee's filing or identifies an error, omission or possible prohibited activity. Search RFAIs by committee or date.</p>
               </div>
             </div>
             <div class="content__section--extra" data-content-prefix="pacronym">
               <h3>PACronyms</h3>
               <p>PACronyms, an alphabetical list of acronyms, abbreviations, initials and common names of federal political action committees (PACs), was prepared to help researchers readily identify committees when their full names are not disclosed on campaign finance reports.</p>
-              <p>The list includes the PACronym, FEC ID number, full committee name, city and state, name of sponsoring, connected, or affiliated organization, committee designation and committee type.  Unless noted otherwise in the full committee name, the acronym “PAC” refers to “political action committee.”  The PACronym is listed in italics if the committee's PACronym is not specifically provided on the committee's Statement of Organization (FEC Form 1).</p>
+              <p>The list includes the PACronym, FEC ID number, full committee name, city and state, name of sponsoring, connected, or affiliated organization, committee designation and committee type.  Unless noted otherwise in the full committee name, the acronym "PAC" refers to "political action committee."  The PACronym is listed in italics if the committee's PACronym is not specifically provided on the committee's Statement of Organization (FEC Form 1).</p>
               <ul class="list--buttons">
                 <li>
                   <a class="button button--standard button--document" href="http://www.fec.gov/pubrec/pacronyms/Pacronyms.pdf">Open PDF</a>
@@ -229,16 +229,16 @@
                   <h4>More information about:</h4>
                   <div class="grid grid--2-wide">
                     <div class="grid__item">
-                      <a href="{{ cms_url }}/registration-and-reporting/essentials-nonconnected-committees/">Candidates and their committees</a>
+                      <a href="{{ cms_url }}/help-candidates-and-committees/#candidates-and-their-authorized-committees">Candidates and their committees</a>
                     </div>
                     <div class="grid__item">
-                      <a href="{{ cms_url }}/registration-and-reporting/essentials-nonconnected-committees/">Nonconnected committees</a>
+                      <a href="{{ cms_url }}/help-candidates-and-committees/#political-action-committees-pacs">Nonconnected committees</a>
                     </div>
                     <div class="grid__item">
-                      <a href="{{ cms_url }}/registration-and-reporting/essentials-political-party-committees/">Political party committees</a>
+                      <a href="{{ cms_url }}/help-candidates-and-committees/#political-party-committees">Political party committees</a>
                     </div>
                     <div class="grid__item">
-                      <a href="{{ cms_url }}/registration-and-reporting/">Corporations and labor organizations</a>
+                      <a href="{{ cms_url }}/help-candidates-and-committees/#corporations-and-labor-organizations">Corporations and labor organizations</a>
                     </div>
                   </div>
                 </div>

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -229,16 +229,16 @@
                   <h4>More information about:</h4>
                   <div class="grid grid--2-wide">
                     <div class="grid__item">
-                      <a href="{{ cms_url }}/help-candidates-and-committees/#candidates-and-their-authorized-committees">Candidates and their committees</a>
+                      <a href="{{ cms_url }}/help-candidates-and-committees#candidates-and-their-authorized-committees">Candidates and their committees</a>
                     </div>
                     <div class="grid__item">
-                      <a href="{{ cms_url }}/help-candidates-and-committees/#political-action-committees-pacs">Nonconnected committees</a>
+                      <a href="{{ cms_url }}/help-candidates-and-committees#political-action-committees-pacs">Nonconnected committees</a>
                     </div>
                     <div class="grid__item">
-                      <a href="{{ cms_url }}/help-candidates-and-committees/#political-party-committees">Political party committees</a>
+                      <a href="{{ cms_url }}/help-candidates-and-committees#political-party-committees">Political party committees</a>
                     </div>
                     <div class="grid__item">
-                      <a href="{{ cms_url }}/help-candidates-and-committees/#corporations-and-labor-organizations">Corporations and labor organizations</a>
+                      <a href="{{ cms_url }}/help-candidates-and-committees#corporations-and-labor-organizations">Corporations and labor organizations</a>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Links were pointing to old reg/rptng page, so they point to help4cc page anchors