### PR TITLE
Removing disbursement purpose filter

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -213,22 +213,6 @@ candidate_status_extended = OrderedDict([
     ('P', 'Statutory candidate in prior cycle'),
 ])
 
-disbursement_categories = OrderedDict([
-    ('transfers', 'Transfers'),
-    ('contributions', 'Contributions'),
-    ('loan-repayments', 'Loan repayments'),
-    ('refunds', 'Refunds'),
-    ('administrative', 'Administrative'),
-    ('travel', 'Travel'),
-    ('fundraising', 'Fundraising'),
-    ('advertising', 'Advertising'),
-    ('polling', 'Polling'),
-    ('materials', 'Materials'),
-    ('events', 'Events'),
-    ('contributions', 'Contributions'),
-    ('other', 'Other'),
-])
-
 pac_party_types = OrderedDict([
     ('N', 'PAC - nonqualified'),
     ('Q', 'PAC - qualified'),

--- a/openfecwebapp/templates/partials/disbursements-filter.html
+++ b/openfecwebapp/templates/partials/disbursements-filter.html
@@ -37,7 +37,6 @@ Filter disbursements
   <button type="button" class="js-accordion-trigger accordion__button">Transaction details</button>
   <div class="accordion__content">
     {{ text.field('disbursement_description', 'Description') }}
-    {% include 'partials/filters/disbursement-purpose.html' %}
     {{ range.amount('amount', 'Disbursement amount') }}
     {{ text.field('image_number', 'Image number') }}
     <div class="message message--info message--small">

--- a/openfecwebapp/templates/partials/filters/disbursement-purpose.html
+++ b/openfecwebapp/templates/partials/filters/disbursement-purpose.html
@@ -1,7 +1,0 @@
-{% import 'macros/filters/checkbox.html' as checkbox %}
-
-{{ checkbox.checkbox_dropdown(
-  'disbursement_purpose_category',
-  'Purpose',
-  options=constants.disbursement_categories,
-) }}

--- a/openfecwebapp/templates/partials/operating-expenditures-filter.html
+++ b/openfecwebapp/templates/partials/operating-expenditures-filter.html
@@ -32,7 +32,6 @@ Filter operating expenditures
   <button type="button" class="js-accordion-trigger accordion__button">Transaction information</button>
   <div class="accordion__content">
     {{ text.field('disbursement_description', 'Description') }}
-    {% include 'partials/filters/disbursement-purpose.html' %}
     {{ text.field('min_amount', 'Minimum expenditure', {'data-suffix': 'or more', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
     {{ text.field('max_amount', 'Maximum expenditure', {'data-suffix': 'or less', 'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true' }) }}
     {{ date.field('date', 'Disbursement date', dates ) }}


### PR DESCRIPTION
This removes the disbursement purpose filter per the discussion in Slack. The logic behind this filter is still too complicated and inconsistent, and this functionality will soon be partially replaced by the line number filter.

![image](https://user-images.githubusercontent.com/1696495/26894067-2a8b2e84-4b72-11e7-9310-f9b27d6de950.png)

cc @jwchumley 