### PR TITLE
Feature/committee efilings

### DIFF
--- a/openfecwebapp/app.py
+++ b/openfecwebapp/app.py
@@ -147,6 +147,7 @@ app.jinja_env.globals.update({
     'series_group_has_data': series_group_has_data,
     'cycle_start': cycle_start,
     'cycle_end': cycle_end,
+    'two_days_ago': utils.two_days_ago(),
     'election_url': get_election_url,
     'constants': constants,
     'cycles': utils.get_cycles(),

--- a/openfecwebapp/templates/committees-single.html
+++ b/openfecwebapp/templates/committees-single.html
@@ -114,6 +114,15 @@
             tabindex="0"
             aria-controls="panel5"
             href="#section-5">Filings</a>
+            <ul>
+              {% if has_raw_filings %}
+              <li><a href="#raw-filings">Raw electronic filings</a></li>
+              {% endif %}
+              <li><a href="#reports">Regularly filed reports</a></li>
+              <li><a href="#notices">24- and 48-hour reports</a></li>
+              <li><a href="#statements">Statements of organization</a></li>
+              <li><a href="#other">Other documents</a></li>
+            </ul>
         </li>
       </ul>
     </nav>

--- a/openfecwebapp/templates/macros/entity-pages.html
+++ b/openfecwebapp/templates/macros/entity-pages.html
@@ -1,5 +1,5 @@
 {% macro filings_table(title, dataType, cycle, committee_id, showTrigger=False) %}
-    <div class="entity__figure">
+    <div class="entity__figure row" id="{{dataType}}">
       <div class="heading--section heading--with-action">
         <h3 class="heading__left">{{ title }}</h3>
         <a class="heading__right button button--alt button--browse"
@@ -21,5 +21,29 @@
           {% endif %}
         </thead>
       </table>
+    </div>
+{% endmacro %}
+
+{% macro raw_filings_table(cycle, committee_id) %}
+    <div class="entity__figure row" id="raw-filings">
+      <div class="heading--section heading--with-action">
+        <h3 class="heading__left">Raw electronic filings</h3>
+        <a class="heading__right button button--alt button--browse"
+           href="{{url_for('filings', data_type='efiling', committee_id=committee_id, cycle=cycle)}}">
+          Filter this data
+        </a>
+      </div>
+      <div class="tag__category">
+        <div class="tag__item">Filed on or after: {{two_days_ago}}</div>
+      </div>
+      <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="raw-filings" data-min-date="{{ two_days_ago }}" data-cycle="{{ cycle }}" data-committee="{{ committee_id }}">
+        <thead>
+          <th scope="col">Document</th>
+          <th scope="col">Date filed</th>
+        </thead>
+      </table>
+      <div class="datatable__note">
+        <p class="t-note">This data has not yet been categorized and coded by the FEC. It's pulled directly from a committee's raw, electronic reports. It doesn't include paper filings.</p>
+      </div>
     </div>
 {% endmacro %}

--- a/openfecwebapp/templates/partials/committee/filings.html
+++ b/openfecwebapp/templates/partials/committee/filings.html
@@ -7,6 +7,9 @@
   </h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     {{ select.committee_cycle_select(cycles, cycle, 'filings')}}
+    {% if has_raw_filings %}
+      {{ entity.raw_filings_table(cycle, committee_id) }}
+    {% endif %}
     {{ entity.filings_table('Regularly filed reports', 'reports', cycle, committee_id, showTrigger=True) }}
     {{ entity.filings_table('24- and 48-hour reports', 'notices', cycle, committee_id) }}
     {{ entity.filings_table('Statements of organization', 'statements', cycle, committee_id) }}

--- a/openfecwebapp/utils.py
+++ b/openfecwebapp/utils.py
@@ -174,3 +174,8 @@ def get_state_senate_cycles(state):
         if state.upper() in constants.SENATE_CLASSES[str(senate_class)]:
             senate_cycles += get_senate_cycles(senate_class)
     return senate_cycles
+
+def two_days_ago():
+    """Find the date two days ago"""
+    two_days_ago = datetime.datetime.today() - datetime.timedelta(days=2)
+    return two_days_ago.strftime('%m/%d/%y')

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -160,6 +160,21 @@ def render_committee(committee, candidates, cycle, redirect_to_previous):
                 return redirect(
                     url_for('committee_page', c_id=committee['committee_id'], cycle=c)
                 )
+
+    # If it's not a senate committee and we're in the current cycle
+    # check if there's any raw filings in the last two days
+    if committee['committee_type'] != 'S' and cycle == utils.current_cycle():
+        raw_filings = api_caller._call_api(
+            'efile', 'filings',
+            cycle=cycle,
+            committee_id=committee['committee_id'],
+            min_receipt_date=utils.two_days_ago()
+        )
+        if len(raw_filings.get('results')) > 0:
+            tmpl_vars['has_raw_filings'] = True
+    else:
+        tmpl_vars['has_raw_filings'] = False
+
     return render_template('committees-single.html', **tmpl_vars)
 
 

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -279,6 +279,10 @@ var aggregateCallbacks = {
 };
 
 // Settings for filings tables
+var rawFilingsColumns = columnHelpers.getColumns(
+  columns.filings,
+  ['document_type', 'receipt_date']
+);
 
 var filingsColumns = columnHelpers.getColumns(
   columns.filings,
@@ -537,6 +541,23 @@ $(document).ready(function() {
             timePeriod: context.timePeriod
           },
         });
+        break;
+      case 'raw-filings':
+        var min_date = $table.attr('data-min-date');
+        opts = _.extend({
+          columns: rawFilingsColumns,
+          order: [[1, 'desc']],
+          path: ['efile', 'filings'],
+          query: _.extend({
+            committee_id: committeeId,
+            min_receipt_date: min_date,
+            sort: ['-receipt_date']
+          }, query),
+          callbacks: {
+            afterRender: filings.renderModal
+          }
+        }, filingsOpts);
+        tables.DataTable.defer($table, opts);
         break;
       case 'filings-reports':
         opts = _.extend({


### PR DESCRIPTION
This is a blunt way of adding raw filings to committee pages:
![image](https://user-images.githubusercontent.com/1696495/26988381-f72ea2b2-4d03-11e7-9aad-0e9183dbef22.png)

The way it works is:
- On the server-side: if we're looking at the current cycle and the committee isn't a senate committee, call `/efile/filings` and see if the committee has any filings in the last two days
- If so, add the raw filings section to the template (this is why the call needs to be made server-side first)
- On the client side, call `/efile/filings` again to get the filings and build the data table

Pro:
- It's done and works well

Cons:
- It makes two API calls to the same endpoint. This is a little bit of an unfortunate consequence of the way the pages and data tables are architected. Theoretically possible to resolve, but would take more time.
- It doesn't dedupe the raw filings from the processed filings, but with only two days worth, it's unlikely to be a huge issue and just replicates the functionality in the classic viewer.

cc @LindsayYoung @jwchumley 