### PR TITLE
Show coverage dates on raising and spending tables

### DIFF
--- a/openfecwebapp/templates/partials/candidate/raising.html
+++ b/openfecwebapp/templates/partials/candidate/raising.html
@@ -89,6 +89,11 @@
         </div>
 
         <div id="contributor-state" class="panel-toggle-element">
+          <div class="results-info results-info--simple">
+            <div class="tag__category">
+              <div class="tag__item">Coverage dates: {{aggregate.coverage_start_date|date}} to {{aggregate.coverage_end_date|date}}</div>
+            </div>
+          </div>
           <div class="map-table">
             <table
                 class="data-table data-table--heading-borders data-table--entity"
@@ -114,6 +119,11 @@
         </div>
 
         <div id="contribution-size" class="panel-toggle-element" aria-hidden="true">
+          <div class="results-info results-info--simple">
+            <div class="tag__category">
+              <div class="tag__item">Coverage dates: {{aggregate.coverage_start_date|date}} to {{aggregate.coverage_end_date|date}}</div>
+            </div>
+          </div>
           <table
              class="data-table data-table--heading-borders data-table--entity"
              data-type="contribution-size"
@@ -126,10 +136,10 @@
         </div>
 
         <div id="all-transactions" class="panel-toggle-element" aria-hidden="true">
-          <div class="results-info results-info--simple">]
+          <div class="results-info results-info--simple">
             <div class="u-float-left tag__category">
-              <div class="tag__item">Transaction date: {{cycle_start(max_cycle)|date}} to {{cycle_end(max_cycle)|date}}</div>
-            </div>            
+              <div class="tag__item">Coverage dates: {{aggregate.coverage_start_date|date}} to {{aggregate.coverage_end_date|date}}</div>
+            </div>
             <div class="u-float-right">
               <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="individual-contributions" aria-hidden="true">
               </div>

--- a/openfecwebapp/templates/partials/candidate/raising.html
+++ b/openfecwebapp/templates/partials/candidate/raising.html
@@ -61,7 +61,7 @@
     <div id="individual-contribution-transactions" class="entity__figure row">
       <div class="content__section">
         <div class="heading--section heading--with-action">
-          <h3 class="heading__left">All individual contribution transactions</h3>
+          <h3 class="heading__left">Individual contributions</h3>
           <a class="heading__right button--alt button--browse"
               href="{{ url_for(
                 'individual_contributions',
@@ -96,7 +96,7 @@
           </div>
           <div class="map-table">
             <table
-                class="data-table data-table--heading-borders data-table--entity"
+                class="data-table data-table--heading-borders"
                 data-type="contributor-state"
                 data-cycle="{{ max_cycle }}"
               >

--- a/openfecwebapp/templates/partials/candidate/raising.html
+++ b/openfecwebapp/templates/partials/candidate/raising.html
@@ -36,9 +36,7 @@
           <a class="heading__right button--alt button--browse"
               href="{{ url_for(
                 'receipts',
-                two_year_transaction_period=max_cycle,
-                min_date=cycle_start(max_cycle) | date(fmt='%m-%d-%Y'),
-                max_date=cycle_end(max_cycle) | date(fmt='%m-%d-%Y')
+                two_year_transaction_period=max_cycle
               ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter all receipts</a>
         </div>
         <div class="content__section--narrow">
@@ -66,8 +64,6 @@
               href="{{ url_for(
                 'individual_contributions',
                 two_year_transaction_period=max_cycle,
-                min_date=cycle_start(max_cycle) | date(fmt='%m-%d-%Y'),
-                max_date=cycle_end(max_cycle) | date(fmt='%m-%d-%Y')
               ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
           </div>
         <div class="row">

--- a/openfecwebapp/templates/partials/candidate/spending.html
+++ b/openfecwebapp/templates/partials/candidate/spending.html
@@ -38,9 +38,7 @@
             <a class="heading__right button--alt button--browse"
               href="{{ url_for(
                 'disbursements',
-                two_year_transaction_period=max_cycle,
-                min_date=cycle_start(max_cycle) | date(fmt='%m-%d-%Y'),
-                max_date=cycle_end(max_cycle) | date(fmt='%m-%d-%Y')
+                two_year_transaction_period=max_cycle
               ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter all disbursements</a>
         </div>
 
@@ -68,9 +66,7 @@
           <a class="heading__right button--alt button--browse"
               href="{{ url_for(
                 'disbursements',
-                two_year_transaction_period=max_cycle,
-                min_date=cycle_start(max_cycle) | date(fmt='%m-%d-%Y'),
-                max_date=cycle_end(max_cycle) | date(fmt='%m-%d-%Y')
+                two_year_transaction_period=max_cycle
               ) }}{% for id in committee_ids %}&committee_id={{ id }}{% endfor %}">Filter this data</a>
         </div>
 

--- a/openfecwebapp/templates/partials/candidate/spending.html
+++ b/openfecwebapp/templates/partials/candidate/spending.html
@@ -63,7 +63,7 @@
 
     <div id="disbursement-transactions" class="entity__figure row">
       <div class="content__section">
-        <div class="heading--section heading--with-action">
+        <div class="heading--section heading--with-action u-no-margin">
           <h3 class="heading__left">Disbursement transactions</h3>
           <a class="heading__right button--alt button--browse"
               href="{{ url_for(
@@ -76,7 +76,7 @@
 
         <div class="results-info results-info--simple">
           <div class="u-float-left tag__category">
-            <div class="tag__item">Transaction date: {{cycle_start(max_cycle)|date}} to {{cycle_end(max_cycle)|date}}</div>
+            <div class="tag__item">Coverage dates: {{aggregate.coverage_start_date|date}} to {{aggregate.coverage_end_date|date}}</div>
           </div>
           <div class="u-float-right">
             <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="itemized-disbursements" aria-hidden="true">
@@ -84,7 +84,6 @@
             <button type="button" class="js-export button button--cta button--export" data-export-for="itemized-disbursements">Export</button>
           </div>
         </div>
-
         <table
             class="data-table data-table--heading-borders"
             data-type="itemized-disbursements"

--- a/openfecwebapp/templates/partials/committee/raising.html
+++ b/openfecwebapp/templates/partials/committee/raising.html
@@ -58,10 +58,10 @@
         </label>
       </fieldset>
       <div class="row">
-        <div id="by-state" class="panel-toggle-element">
+        <div id="by-state" class="panel-toggle-element" aria-hidden="true">
           <div class="results-info results-info--simple">
             <div class="u-float-left tag__category">
-              <div class="tag__item">Transaction date: {{cycle_start(cycle)|date}} to {{cycle_end(cycle)|date}}</div>
+              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
             </div>
             <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-state">Export</button>
           </div>
@@ -91,7 +91,7 @@
         <div id="by-contribution-size" class="panel-toggle-element" aria-hidden="true">
           <div class="results-info results-info--simple">
             <div class="u-float-left tag__category">
-              <div class="tag__item">Transaction date: {{cycle_start(cycle)|date}} to {{cycle_end(cycle)|date}}</div>
+              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
             </div>
             <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="contribution-size">Export</button>
           </div>
@@ -109,7 +109,7 @@
         <div id="by-employer" class="panel-toggle-element" aria-hidden="true">
           <div class="results-info results-info--simple">
             <div class="u-float-left tag__category">
-              <div class="tag__item">Transaction date: {{cycle_start(cycle)|date}} to {{cycle_end(cycle)|date}}</div>
+              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
             </div>
             <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-employer">Export</button>
           </div>
@@ -130,7 +130,7 @@
         <div id="by-occupation" class="panel-toggle-element" aria-hidden="true">
           <div class="results-info results-info--simple">
             <div class="u-float-left tag__category">
-              <div class="tag__item">Transaction date: {{cycle_start(cycle)|date}} to {{cycle_end(cycle)|date}}</div>
+              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
             </div>
             <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="receipts-by-occupation">Export</button>
           </div>
@@ -151,7 +151,7 @@
         <div id="itemized-contributions" class="panel-toggle-element" aria-hidden="true">
           <div class="results-info results-info--simple">
             <div class="u-float-left tag__category">
-              <div class="tag__item">Transaction date: {{cycle_start(cycle)|date}} to {{cycle_end(cycle)|date}}</div>
+              <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
             </div>
             <div class="u-float-right">
               <button type="button" class="js-export button button--cta button--export" data-export-for="itemized-receipts">Export</button>

--- a/openfecwebapp/templates/partials/committee/spending.html
+++ b/openfecwebapp/templates/partials/committee/spending.html
@@ -46,7 +46,7 @@
         </a>
       </div>
       <div class="tag__category">
-        <div class="tag__item">Transaction date: {{cycle_start(cycle)|date}} to {{cycle_end(cycle)|date}}</div>
+        <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
       </div>
       <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="communication-cost-committee" data-committee="{{ committee_id }}" data-cycle="{{ cycle }}">
         <thead>
@@ -75,7 +75,7 @@
       </div>
       <p>Any broadcast, cable or satellite communication that (1) refers to a clearly identified candidate for federal office; (2) is publicly distributed within certain time periods before an election and (3) is targeted to the relevant electorate.</p>
       <div class="tag__category">
-        <div class="tag__item">Transaction date: {{cycle_start(cycle)|date}} to {{cycle_end(cycle)|date}}</div>
+        <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
       </div>
       <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="electioneering-committee" data-committee="{{ committee_id }}" data-cycle="{{ cycle }}">
         <thead>
@@ -103,7 +103,7 @@
       </div>
       <p>This tab shows spending that this committee has made in support of or opposition to a candidate. None of the funds are directly given to or spent by the candidate.</p>
       <div class="tag__category">
-        <div class="tag__item">Transaction date: {{cycle_start(cycle)|date}} to {{cycle_end(cycle)|date}}</div>
+        <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
       </div>
       <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="independent-expenditure-committee" data-committee="{{ committee_id }}" data-cycle="{{ cycle }}">
         <thead>
@@ -146,7 +146,7 @@
       <div id="by-recipient" class="panel-toggle-element" aria-hidden="false">
         <div class="results-info results-info--simple">
           <div class="u-float-left tag__category">
-            <div class="tag__item">Transaction date: {{cycle_start(cycle)|date}} to {{cycle_end(cycle)|date}}</div>
+            <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
           </div>
           <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="disbursements-by-recipient">Export</button>
         </div>
@@ -167,7 +167,7 @@
       <div id="itemized-disbursements" class="panel-toggle-element" aria-hidden="true">
         <div class="results-info results-info--simple">
           <div class="u-float-left tag__category">
-            <div class="tag__item">Transaction date: {{cycle_start(cycle)|date}} to {{cycle_end(cycle)|date}}</div>
+            <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
           </div>
           <div class="u-float-right">
             <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="itemized-disbursements" aria-hidden="true">
@@ -198,7 +198,7 @@
       <div id="to-committees" class="panel-toggle-element" aria-hidden="true">
         <div class="results-info results-info--simple">
           <div class="u-float-left tag__category">
-            <div class="tag__item">Transaction date: {{cycle_start(cycle)|date}} to {{cycle_end(cycle)|date}}</div>
+            <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
           </div>
           <button type="button" class="u-float-right js-export button button--cta button--export" data-export-for="disbursements-by-recipient-id">Export</button>
         </div>


### PR DESCRIPTION
In order to make clear to users what data is included in the raising and spending detailed tables on candidate and committee pages, this adds the coverage dates. Previously in this release we were adding simply transaction dates, which span the entire cycle; this can be confusing because it doesn't show which reports are actually included.

It also makes the "All transactions" tab the first, default-opened tab.

For example:
![image](https://user-images.githubusercontent.com/1696495/27106639-27fca5f4-5049-11e7-8f25-6d0c608d5682.png)
