### PR TITLE
Show all transactions as first tab

### DIFF
--- a/openfecwebapp/templates/partials/candidate/raising.html
+++ b/openfecwebapp/templates/partials/candidate/raising.html
@@ -68,23 +68,23 @@
           </div>
         <div class="row">
           <fieldset class="toggles js-toggles">
-            <legend class="label">View by:</legend>
+            <legend class="label">Group by:</legend>
+            <label for="toggle-all">
+              <input id="toggle-all" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="all-transactions" checked>
+              <span class="button--alt">All transactions</span>
+            </label>
             <label for="toggle-state">
-              <input id="toggle-state" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="contributor-state" checked />
+              <input id="toggle-state" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="contributor-state">
               <span class="button--alt">State</span>
             </label>
             <label for="toggle-size">
-              <input id="toggle-size" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="contribution-size" />
+              <input id="toggle-size" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="contribution-size">
               <span class="button--alt">Size</span>
-            </label>
-            <label for="toggle-all">
-              <input id="toggle-all" type="radio" class="js-panel-toggle-control" name="individual-contributions" value="all-transactions" />
-              <span class="button--alt">All transactions</span>
             </label>
           </fieldset>
         </div>
 
-        <div id="contributor-state" class="panel-toggle-element">
+        <div id="contributor-state" class="panel-toggle-element" aria-hidden="true">
           <div class="results-info results-info--simple">
             <div class="tag__category">
               <div class="tag__item">Coverage dates: {{aggregate.coverage_start_date|date}} to {{aggregate.coverage_end_date|date}}</div>
@@ -121,7 +121,7 @@
             </div>
           </div>
           <table
-             class="data-table data-table--heading-borders data-table--entity"
+             class="data-table data-table--heading-borders"
              data-type="contribution-size"
              data-cycle="{{ max_cycle }}">
             <thead>
@@ -131,7 +131,7 @@
           </table>
         </div>
 
-        <div id="all-transactions" class="panel-toggle-element" aria-hidden="true">
+        <div id="all-transactions" class="panel-toggle-element">
           <div class="results-info results-info--simple">
             <div class="u-float-left tag__category">
               <div class="tag__item">Coverage dates: {{aggregate.coverage_start_date|date}} to {{aggregate.coverage_end_date|date}}</div>

--- a/openfecwebapp/templates/partials/committee/raising.html
+++ b/openfecwebapp/templates/partials/committee/raising.html
@@ -36,8 +36,12 @@
       </div>
       <fieldset class="row toggles js-toggles">
         <legend class="label">Group by:</legend>
+        <label for="toggle-itemized">
+          <input id="toggle-itemized" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="itemized-contributions" checked>
+          <span class="button--alt">All transactions</span>
+        </label>
         <label for="toggle-state">
-          <input id="toggle-state" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-state" checked>
+          <input id="toggle-state" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-state">
           <span class="button--alt">State</span>
         </label>
         <label for="toggle-contribution-size">
@@ -51,10 +55,6 @@
         <label for="toggle-occupation">
           <input id="toggle-occupation" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="by-occupation">
           <span class="button--alt">Occupation</span>
-        </label>
-        <label for="toggle-itemized">
-          <input id="toggle-itemized" type="radio" class="js-panel-toggle-control" name="receipt-aggregate" value="itemized-contributions">
-          <span class="button--alt">All transactions</span>
         </label>
       </fieldset>
       <div class="row">
@@ -148,7 +148,7 @@
           {{ disclaimer.disclaimer('receipts', committee.committee_id, cycle) }}
         </div>
 
-        <div id="itemized-contributions" class="panel-toggle-element" aria-hidden="true">
+        <div id="itemized-contributions" class="panel-toggle-element">
           <div class="results-info results-info--simple">
             <div class="u-float-left tag__category">
               <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>

--- a/openfecwebapp/templates/partials/committee/spending.html
+++ b/openfecwebapp/templates/partials/committee/spending.html
@@ -129,21 +129,21 @@
 
       <fieldset class="row toggles js-toggles">
         <legend class="label">Group by:</legend>
+        <label for="toggle-all-disbursements">
+          <input id="toggle-all-disbursements" type="radio" class="js-panel-toggle-control" name="disbursements" value="itemized-disbursements" checked>
+          <span class="button--alt">All transactions</span>
+        </label>
         <label for="toggle-recipient">
-          <input id="toggle-recipient" type="radio" class="js-panel-toggle-control" name="disbursements" value="by-recipient" checked>
+          <input id="toggle-recipient" type="radio" class="js-panel-toggle-control" name="disbursements" value="by-recipient">
           <span class="button--alt">Recipient name</span>
         </label>
         <label for="toggle-to">
           <input id="toggle-to" type="radio" class="js-panel-toggle-control" name="disbursements" value="to-committees">
           <span class="button--alt">Recipient committee ID</span>
         </label>
-        <label for="toggle-all-disbursements">
-          <input id="toggle-all-disbursements" type="radio" class="js-panel-toggle-control" name="disbursements" value="itemized-disbursements">
-          <span class="button--alt">All transactions</span>
-        </label>
       </fieldset>
 
-      <div id="by-recipient" class="panel-toggle-element" aria-hidden="false">
+      <div id="by-recipient" class="panel-toggle-element" aria-hidden="true">
         <div class="results-info results-info--simple">
           <div class="u-float-left tag__category">
             <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>
@@ -164,7 +164,7 @@
         {{ disclaimer.disclaimer('disbursements', committee.committee_id, cycle) }}
       </div>
 
-      <div id="itemized-disbursements" class="panel-toggle-element" aria-hidden="true">
+      <div id="itemized-disbursements" class="panel-toggle-element" aria-hidden="false">
         <div class="results-info results-info--simple">
           <div class="u-float-left tag__category">
             <div class="tag__item">Coverage dates: {{totals.0.coverage_start_date|date}} to {{totals.0.coverage_end_date|date}}</div>

--- a/static/js/vendor/tablist.js
+++ b/static/js/vendor/tablist.js
@@ -56,7 +56,9 @@ function refreshTabs() {
     if ($target.length) {
       show($target);
     } else {
-      $('[role="tabpanel"]').attr('aria-hidden', null);
+      // If the tab param doesn't match any, just show the first one by default
+      var $firstTab = $($tabs.find('[role="tab"]')[0]);
+      show($firstTab);
     }
   });
 }

--- a/tests/unit/vendor/tablist.js
+++ b/tests/unit/vendor/tablist.js
@@ -16,22 +16,9 @@ describe('tablist', function() {
   });
 
   describe('init', function() {
-    it('should show all tab panels if there are no tabs', function() {
-      fixture.empty().append(
-        '<div class="tab-interface">' + 
-          '<ul role="tablist" data-name="tab"></ul>' +
-          '<section role="tabpanel" aria-hidden="true"></section>' +
-        '</div>'
-      );
-
-      tablist.init();
-
-      expect($('[role="tabpanel"]').attr('aria-hidden')).to.be.undefined;
-    });
-
     it('should show first tab if there\'s no query', function() {
       fixture.empty().append(
-        '<div class="tab-interface">' + 
+        '<div class="tab-interface">' +
           '<ul role="tablist" data-name="tab">' +
             '<li><a role="tab" data-name="tab0" href="#section-0">0</a></li>' +
             '<li><a role="tab" data-name="tab1" href="#section-1">1</a></li>' +


### PR DESCRIPTION
This makes the "all transactions" tab the default opened tab. I meant to include this in https://github.com/18F/openFEC-web-app/pull/2127 but forgot to push before it was merged. 

It also makes a change to account for the fact that our tab names are changing with this release. Now, if a something like `?tab=receipts` is included in the URL (as would be the case if someone bookmarked that tab previously) the page will default to open the first tab, whatever that is. Previously it would instead show all tabs at once, which was wrong.