### PR TITLE
HOTFIX: Only show raising and spending tabs if there's data

### DIFF
--- a/openfecwebapp/templates/candidates-single.html
+++ b/openfecwebapp/templates/candidates-single.html
@@ -60,6 +60,7 @@
               <li><a href="#committees">Committees</a></li>
             </ul>
         </li>
+        {% if two_year_totals %}
         <li class="side-nav__item" role="presentation">
           <a
             class="side-nav__link"
@@ -86,6 +87,7 @@
               <li><a href="#disbursement-transactions">Disbursement transactions</a></li>
             </ul>
         </li>
+        {% endif %}
         <li class="side-nav__item" role="presentation">
           <a
             class="side-nav__link"
@@ -114,8 +116,10 @@
       {% include 'partials/candidate/financial-summary.html' %}
       {% include 'partials/candidate/about-candidate.html' %}
       {% include 'partials/candidate/other-spending-tab.html' %}
-      {% include 'partials/candidate/raising.html' %}
-      {% include 'partials/candidate/spending.html' %}
+      {% if two_year_totals %}
+        {% include 'partials/candidate/raising.html' %}
+        {% include 'partials/candidate/spending.html' %}
+      {% endif %}
     </div>
   </div>
 

--- a/openfecwebapp/templates/partials/candidate/raising.html
+++ b/openfecwebapp/templates/partials/candidate/raising.html
@@ -87,7 +87,7 @@
         <div id="contributor-state" class="panel-toggle-element" aria-hidden="true">
           <div class="results-info results-info--simple">
             <div class="tag__category">
-              <div class="tag__item">Coverage dates: {{aggregate.coverage_start_date|date}} to {{aggregate.coverage_end_date|date}}</div>
+              <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{two_year_totals.coverage_end_date|date}}</div>
             </div>
           </div>
           <div class="map-table">
@@ -117,7 +117,7 @@
         <div id="contribution-size" class="panel-toggle-element" aria-hidden="true">
           <div class="results-info results-info--simple">
             <div class="tag__category">
-              <div class="tag__item">Coverage dates: {{aggregate.coverage_start_date|date}} to {{aggregate.coverage_end_date|date}}</div>
+              <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{two_year_totals.coverage_end_date|date}}</div>
             </div>
           </div>
           <table
@@ -134,7 +134,7 @@
         <div id="all-transactions" class="panel-toggle-element">
           <div class="results-info results-info--simple">
             <div class="u-float-left tag__category">
-              <div class="tag__item">Coverage dates: {{aggregate.coverage_start_date|date}} to {{aggregate.coverage_end_date|date}}</div>
+              <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{two_year_totals.coverage_end_date|date}}</div>
             </div>
             <div class="u-float-right">
               <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="individual-contributions" aria-hidden="true">

--- a/openfecwebapp/templates/partials/candidate/spending.html
+++ b/openfecwebapp/templates/partials/candidate/spending.html
@@ -72,7 +72,7 @@
 
         <div class="results-info results-info--simple">
           <div class="u-float-left tag__category">
-            <div class="tag__item">Coverage dates: {{aggregate.coverage_start_date|date}} to {{aggregate.coverage_end_date|date}}</div>
+            <div class="tag__item">Coverage dates: {{two_year_totals.coverage_start_date|date}} to {{two_year_totals.coverage_end_date|date}}</div>
           </div>
           <div class="u-float-right">
             <div class="message message--info message--mini t-left-aligned data-container__message" data-export-message-for="itemized-disbursements" aria-hidden="true">


### PR DESCRIPTION
This fixes errors caused by trying to load certain template partials when a candidate page has no financial data. If there's no data, there is no `two_year_totals` template variable, which the `raising.html` and `spending.html` partials need. So this just doesn't show those tabs on candidates without financial data, which I think makes sense:

![image](https://user-images.githubusercontent.com/1696495/27194024-ea61fd20-51b5-11e7-88d0-f1c9232b3c56.png)

It also fixes a mistake from earlier where the coverage dates shown on the raising and spending pages were for the entire 4 or 6 year range, rather than just the two-years, which they should be.