### PR TITLE
[HOTFIX] Restrict recent AOs to only final opinions and withdrawals

### DIFF
--- a/openfecwebapp/templates/legal-advisory-opinions-landing.html
+++ b/openfecwebapp/templates/legal-advisory-opinions-landing.html
@@ -95,7 +95,7 @@
       <h3><a href="{{ url_for('advisory_opinion_page', ao_no=ao.no) }}">AO {{ ao.no }} {{ ao.name }}</a></h3>
       <p class="t-sans">{{ ao.summary }}</p>
       {% for doc in ao.documents %}
-        {% if doc.category == 'Final Opinion' %}
+        {% if doc.category in ['Final Opinion', 'Withdrawal of Request'] %}
           <p class="t-sans post__doc"><a href="{{ doc.url }}">{{ doc.category }} | PDF</a></p>
         {% endif %}
       {% endfor %}

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -86,6 +86,7 @@ def render_legal_ao_landing():
     recent_aos = api_caller.load_legal_search_results(
         query='',
         query_type='advisory_opinions',
+        ao_category=['F', 'W'],
         ao_min_date=ao_min_date
     )
     pending_aos = api_caller.load_legal_search_results(

--- a/tests/unit/test_legal_search.py
+++ b/tests/unit/test_legal_search.py
@@ -117,7 +117,7 @@ class TestLegalSearch(unittest.TestCase):
         # so this mocks the two different calls and then we assert they happend
         # http://stackoverflow.com/questions/7242433/asserting-successive-calls-to-a-mock-method
         calls = [
-            mock.call(query='', query_type='advisory_opinions', ao_min_date=ao_min_date),
+            mock.call(query='', query_type='advisory_opinions', ao_min_date=ao_min_date, ao_category=['F', 'W']),
             mock.call(query='', query_type='advisory_opinions', ao_is_pending=True, ao_category='R')
         ]
         load_legal_search_results.assert_has_calls(calls, any_order=True)


### PR DESCRIPTION
We're currently showing _all_ recent AOs, including pending opinions, on the [AO landing page](https://www.fec.gov/data/legal/advisory-opinions/). This change correctly only shows AOs with final opinions or withdrawal requests.

![image](https://user-images.githubusercontent.com/1696495/27243076-11cf8c76-5295-11e7-9dc5-7c17896fe474.png)

h/t @jbucelato