### PR TITLE
Pass candidate name in links to IE page

### DIFF
--- a/openfecwebapp/templates/partials/candidate/other-spending-tab.html
+++ b/openfecwebapp/templates/partials/candidate/other-spending-tab.html
@@ -20,8 +20,9 @@
           href="{{ url_for(
             'independent_expenditures',
             min_date=cycle_start(min_cycle) | date(fmt='%m-%d-%Y'),
-            max_date=cycle_end(max_cycle) | date(fmt='%m-%d-%Y')
-          ) }}&candidate_id={{ candidate_id }}">Filter this data</a>
+            max_date=cycle_end(max_cycle) | date(fmt='%m-%d-%Y'),
+            candidate_id=candidate_id,
+            candidate_name=name) }}">Filter this data</a>
       </div>
       <div class="results-info results-info--simple js-other-spending-totals" data-spending-type="independentExpenditures">
         <div class="usa-width-one-half">


### PR DESCRIPTION
This goes with the fix to make raw/processed filters retain filter values https://github.com/18F/fec-style/pull/736.

This fix is because the candidate filter for processed IEs uses candidate ID but the candidate filter for raw IEs uses candidate name (because the ID hasn't been coded yet). So this passes the candidate name through so that when clicking through from this link and then toggling to raw it will show up:

![image](https://user-images.githubusercontent.com/1696495/27246220-e8daee72-52a4-11e7-9688-fd5ab4281db0.png)
 