### PR TITLE
Feature/report coverage dates & RFAI N/A version status

### DIFF
--- a/openfecwebapp/templates/macros/entity-pages.html
+++ b/openfecwebapp/templates/macros/entity-pages.html
@@ -14,6 +14,10 @@
         <thead>
           <th scope="col">Document</th>
           <th scope="col">Version</th>
+          {% if dataType == 'reports' %}
+          <th scope="col">Coverage start date</th>
+          <th scope="col">Coverage end date</th>
+          {% endif %}
           <th scope="col">Date filed</th>
           <th scope="col">Pages</th>
           {% if showTrigger %}
@@ -39,6 +43,8 @@
       <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="raw-filings" data-min-date="{{ two_days_ago }}" data-cycle="{{ cycle }}" data-committee="{{ committee_id }}">
         <thead>
           <th scope="col">Document</th>
+          <th scope="col">Coverage start date</th>
+          <th scope="col">Coverage end date</th>
           <th scope="col">Date filed</th>
         </thead>
       </table>

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -73,11 +73,17 @@ var pagesColumn = {
   orderable: false,
   className: 'min-tablet hide-panel column--xs column--number',
   render: function(data, type, row) {
-    // Image numbers begin with YYYYMMDD, which makes for a very big number
+    // Image numbers in 2015 and later begin with YYYYMMDD,
+    // which makes for a very big number.
     // This results in inaccurate subtraction
     // so instead we slice it after the first 8 digits
+    // Earlier image numbers are only 11 digits, so we just leave those as-is
     var shorten = function(number) {
-      return Number(number.toString().slice(8));
+      if (number.toString().length === 18) {
+        return Number(number.toString().slice(8));
+      } else {
+        return number;
+      }
     };
     var pages = shorten(row.ending_image_number) - shorten(row.beginning_image_number) + 1;
     return pages.toLocaleString();

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -26,6 +26,10 @@ var versionColumn = {
   className: 'hide-panel hide-efiling column--med min-desktop',
   orderable: false,
   render: function(data, type, row) {
+    // RFAIs don't have version, so show NA
+    if (row.form_type === 'RFAI') {
+      return '<i class="icon-blank"></i>Not applicable';
+    }
     var version = helpers.amendmentVersion(data);
     if (version === 'Version unknown') {
       return '<i class="icon-blank"></i>Version unknown<br>' +

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -26,8 +26,8 @@ var versionColumn = {
   className: 'hide-panel hide-efiling column--med min-desktop',
   orderable: false,
   render: function(data, type, row) {
-    // RFAIs don't have version, so show NA
-    if (row.form_type === 'RFAI') {
+    // RFAIs and FRQs should just show N/A because they can't be amended
+    if (['RFAI', 'FRQ'].indexOf(row.form_type) >= 0) {
       return '<i class="icon-blank"></i>Not applicable';
     }
     var version = helpers.amendmentVersion(data);

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -283,7 +283,7 @@ var aggregateCallbacks = {
 // Settings for filings tables
 var rawFilingsColumns = columnHelpers.getColumns(
   columns.filings,
-  ['document_type', 'receipt_date']
+  ['document_type', 'coverage_start_date', 'coverage_end_date', 'receipt_date']
 );
 
 var filingsColumns = columnHelpers.getColumns(
@@ -293,7 +293,7 @@ var filingsColumns = columnHelpers.getColumns(
 
 var filingsReportsColumns = columnHelpers.getColumns(
   columns.filings,
-  ['document_type', 'version', 'receipt_date_unorderable', 'pages', 'modal_trigger']
+  ['document_type', 'version', 'coverage_start_date', 'coverage_end_date', 'receipt_date_unorderable', 'pages', 'modal_trigger']
 );
 
 $(document).ready(function() {


### PR DESCRIPTION
This adds coverage dates to the regularly filed reports table on committee pages:
![image](https://user-images.githubusercontent.com/1696495/27246691-2808325a-52a8-11e7-89f1-ea800c3589a0.png)

And the raw filings table:
![image](https://user-images.githubusercontent.com/1696495/27246742-9f5bcce0-52a8-11e7-811d-1367dac10c19.png)

Resolves https://github.com/18F/FEC/issues/4217

It also rolls in an earlier requested change, which is to not show a version status on RFAIs, as they can't be amended:
![image](https://user-images.githubusercontent.com/1696495/27246810-11fa4934-52a9-11e7-97dd-ff02b25c35bd.png)

Resolves https://github.com/18F/FEC/issues/3942

It also fixes the negative page number issue by accounting for the fact that image numbers switched from 11 to 18 digits in 2015. This adds the code to just check the length and if it's 18 digits, it slices it after the first 8, and if it's not, it leaves it alone:
![image](https://user-images.githubusercontent.com/1696495/27247793-d76639e2-52b0-11e7-89f0-61e438e86b3d.png)

Resolves https://github.com/18F/FEC/issues/4232
Resolves https://github.com/18F/openFEC/issues/2475
