### PR TITLE
Hotfix/remove 24 48

### DIFF
--- a/openfecwebapp/templates/partials/committee/raising.html
+++ b/openfecwebapp/templates/partials/committee/raising.html
@@ -16,7 +16,7 @@
         <div class="content__section--narrow">
           <div class="row u-margin-bottom">
             <div class="usa-width-one-half">
-              <span class="t-big-data">{{ raising_summary[0][0]|currency }}</span>
+              <span class="t-big-data">{{ totals.0.receipts|currency }}</span>
             </div>
           </div>
           <div class="row">

--- a/openfecwebapp/templates/partials/committee/spending.html
+++ b/openfecwebapp/templates/partials/committee/spending.html
@@ -18,7 +18,7 @@
         <div class="content__section--narrow">
           <div class="row u-margin-bottom">
             <div class="usa-width-one-half">
-              <span class="t-big-data">{{ spending_summary[0][0]|currency }}</span>
+              <span class="t-big-data">{{ totals.0.disbursements|currency }}</span>
             </div>
           </div>
           <div class="row">

--- a/openfecwebapp/templates/partials/independent-expenditures-filter.html
+++ b/openfecwebapp/templates/partials/independent-expenditures-filter.html
@@ -30,7 +30,10 @@ Filter independent expenditures
   <div class="filters__inner">
     {{ typeahead.field('committee_id', 'Spender name or ID') }}
     {{ years.cycles('cycle', 'Years') }}
-    {{ reports.type()}}
+    <div class="message message--small message--alert">
+      <span class="t-block">Data disclosed on monthly and quarterly form 3X and form 5 reports may not reflect the most recently reported information.</span>
+      <span class="t-block u-margin--top"><a href="http://classic.fec.gov/data/IndependentExpenditure.do">Browse 24- and 48-hour reports</a> for the most current data.</span>
+    </div>
     {{ reports.form()}}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Candidate mentioned</button>

--- a/openfecwebapp/templates/partials/independent-expenditures-filter.html
+++ b/openfecwebapp/templates/partials/independent-expenditures-filter.html
@@ -22,6 +22,10 @@ Filter independent expenditures
   {{ text.field('candidate_name', 'Candidate mentioned', id_suffix='_raw')}}
   {{ misc.support_oppose('_raw') }}
   {{ date.field('expenditure_date', 'Expenditure date', dates, id_suffix='_raw') }}
+  <div class="message message--small message--alert">
+    <span class="t-block">Data disclosed on monthly and quarterly form 3X and form 5 reports may not reflect the most recently reported information.</span>
+    <span class="t-block u-margin--top"><a href="http://classic.fec.gov/data/IndependentExpenditure.do">Browse 24- and 48-hour reports</a> for the most current data.</span>
+  </div>
 </div>
 {% endblock %}
 

--- a/static/js/pages/independent-expenditures.js
+++ b/static/js/pages/independent-expenditures.js
@@ -14,6 +14,7 @@ $(document).ready(function() {
     autoWidth: false,
     title: 'Independent expenditures',
     path: ['schedules', 'schedule_e'],
+    query: {is_notice: 'false'},
     columns: columns.independentExpenditures,
     paginator: tables.SeekPaginator,
     rowCallback: tables.modalRenderRow,


### PR DESCRIPTION
While we're currently resolving bugs that are causing inconsistent results in the 24/48-hour reports data, this removes the filter for those and instead adds a warning and a link to the classic site: http://classic.fec.gov/data/IndependentExpenditure.do

![image](https://user-images.githubusercontent.com/1696495/27296420-9e2aead4-54d5-11e7-90a0-6116098c1585.png)

Also, it fixes an unrelated bug where the total receipts/disbursements numbers on raising and spending pages were referencing the `raising_summary` and `spending_summary` dictionaries, but [those dictionaries are only created](https://github.com/18F/openFEC-web-app/blob/develop/openfecwebapp/views.py#L145) if there's `totals` and `reports`. The template already checks for `totals` before showing this figure, so since there's no reason to not just use that number directly, this does that. 
