### PR TITLE
Hide net contributions and operating expenditures

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -329,15 +329,16 @@ SPENDING_FORMATTER = OrderedDict([
 CASH_FORMATTER = OrderedDict([
     ('cash_on_hand_beginning_period', {'label': 'Beginning cash on hand', 'level': '2'}), #F3, F3P, #F3X
     ('last_cash_on_hand_end_period', {'label': 'Ending cash on hand', 'term': 'ending cash on hand', 'level': '2'}), #F3, F3P, #F3X
-    ('net_contributions', {'label': 'Net contributions', 'level': '2'}), #F3, F3X
-    ('contributions', {'label': 'Total contributions', 'level': '3'}), #F3, #F3P, F3X
-    ('contribution_refunds', {'label': '(Total contribution refunds)', 'level': '3'}), #F3, F3P, F3X
-    ('net_operating_expenditures', {'label': 'Net operating expenditures', 'level': '2'}), #F3, F3X
-    ('operating_expenditures', {'label': 'Operating expenditures', 'level': '3'}), #F3, F3P, F3X
-    ('offsets_to_operating_expenditures', {'label': '(Offsets to operating expenditures)', 'level': '3'}), #F3, F3P, F3X
-    ('subtotal_offsets_to_operating_expenditures', {'label': 'Offsets to operating expenditures', 'level': '3'}), #F3P
     ('last_debts_owed_to_committee', {'label': 'Debts/loans owed to committee', 'level': '2'}), #F3, F3P, F3X
     ('last_debts_owed_by_committee', {'label': 'Debts/loans owed by committee', 'level': '2'}), #F3, F3P, F3X
+    # Commenting out net numbers because the underlying logic is incorrect
+    # ('net_contributions', {'label': 'Net contributions', 'level': '2'}), #F3, F3X
+    # ('contributions', {'label': 'Total contributions', 'level': '3'}), #F3, #F3P, F3X
+    # ('contribution_refunds', {'label': '(Total contribution refunds)', 'level': '3'}), #F3, F3P, F3X
+    # ('net_operating_expenditures', {'label': 'Net operating expenditures', 'level': '2'}), #F3, F3X
+    # ('operating_expenditures', {'label': 'Operating expenditures', 'level': '3'}), #F3, F3P, F3X
+    # ('offsets_to_operating_expenditures', {'label': '(Offsets to operating expenditures)', 'level': '3'}), #F3, F3P, F3X
+    # ('subtotal_offsets_to_operating_expenditures', {'label': 'Offsets to operating expenditures', 'level': '3'}), #F3P
 ])
 
 IE_FORMATTER = OrderedDict([


### PR DESCRIPTION
This hides the net operating expenditures and net contributions numbers (and their child lines) as the underlying logic needs some work.

The cash summary portion of financial summaries now looks like:
![image](https://user-images.githubusercontent.com/1696495/27308077-b3da9b96-5501-11e7-971d-b2fff9bc1f5b.png)

Worth nothing that these numbers are only incorrect for certain committees, but when they're wrong they're also wrong in the classic viewer.