### PR TITLE
Legal search cleanup

### DIFF
--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -57,6 +57,7 @@ def load_legal_search_results(query, query_type='all', offset=0, limit=20, **kwa
         if kwargs[key]:
             filters[key] = kwargs[key]
 
+    if query or query_type in ['advisory_opinions', 'murs']:
         filters['hits_returned'] = limit
         filters['type'] = query_type
         filters['from_hit'] = offset

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -51,11 +51,10 @@ def load_search_results(query, query_type=None):
             'committees': committees if len(committees) else [],
         }
 
-def load_legal_search_results(query, query_type='all', offset=0, limit=20, **kwargs):
-    filters = {}
-    for key in kwargs.keys():
-        if kwargs[key]:
-            filters[key] = kwargs[key]
+def load_legal_search_results(query, query_type='all', offset=0, limit=20, **filters):
+    for key in filters.keys():
+        if not filters[key]:
+            del filters[key]
 
     if query or query_type in ['advisory_opinions', 'murs']:
         filters['hits_returned'] = limit

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -51,10 +51,8 @@ def load_search_results(query, query_type=None):
             'committees': committees if len(committees) else [],
         }
 
-def load_legal_search_results(query, query_type='all', offset=0, limit=20, **filters):
-    for key in filters.keys():
-        if not filters[key]:
-            del filters[key]
+def load_legal_search_results(query, query_type='all', offset=0, limit=20, **kwargs):
+    filters = dict((key, value) for key, value in kwargs.items() if value)
 
     if query or query_type in ['advisory_opinions', 'murs']:
         filters['hits_returned'] = limit

--- a/openfecwebapp/api_caller.py
+++ b/openfecwebapp/api_caller.py
@@ -51,43 +51,18 @@ def load_search_results(query, query_type=None):
             'committees': committees if len(committees) else [],
         }
 
-def load_legal_search_results(query, query_type='all', ao_no=None,
-                              ao_name=None, ao_min_date=None,
-                              ao_max_date=None, ao_is_pending=None,
-                              ao_requestor=None, ao_requestor_type=0,
-                              ao_category=None, offset=0, limit=20):
+def load_legal_search_results(query, query_type='all', offset=0, limit=20, **kwargs):
     filters = {}
-    if query or query_type == 'advisory_opinions':
+    for key in kwargs.keys():
+        if kwargs[key]:
+            filters[key] = kwargs[key]
+
         filters['hits_returned'] = limit
         filters['type'] = query_type
         filters['from_hit'] = offset
 
         if query:
             filters['q'] = query
-
-        if ao_no and ao_no[0]:
-            filters['ao_no'] = ao_no
-
-        if ao_name and ao_name[0]:
-            filters['ao_name'] = ao_name
-
-        if ao_min_date:
-            filters['ao_min_date'] = ao_min_date
-
-        if ao_max_date:
-            filters['ao_max_date'] = ao_max_date
-
-        if ao_is_pending:
-            filters['ao_is_pending'] = True
-
-        if ao_requestor:
-            filters['ao_requestor'] = ao_requestor
-
-        if ao_category:
-            filters['ao_category'] = ao_category
-
-        if ao_requestor_type and ao_requestor_type > 0:
-            filters['ao_requestor_type'] = ao_requestor_type
 
     results = _call_api('legal', 'search', **filters)
     results['limit'] = limit

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -484,14 +484,6 @@ def advisory_opinions_landing():
     return views.render_legal_ao_landing()
 
 
-@app.route('/legal/enforcement/')
-def enforcement_landing():
-    return render_template('legal-enforcement-landing.html',
-        parent='legal',
-        result_type='murs',
-        display_name='enforcement matters')
-
-
 @app.route('/legal/statutes/')
 def statutes_landing():
     return render_template('legal-statutes-landing.html',

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -440,43 +440,15 @@ def legal_search(query, result_type):
     return views.render_legal_search_results(results, query, result_type)
 
 
-def legal_doc_search(query, result_type, ao_no=None, ao_name=None, ao_min_date=None,
-                     ao_max_date=None, ao_is_pending=None, ao_requestor=None,
-                     ao_requestor_type=None, ao_category=None, **kwargs):
+def legal_doc_search(query, result_type, **kwargs):
     """Legal search for a specific document type."""
     results = {}
 
     # Only hit the API if there's an actual query or if the result_type is AOs
-    if query or result_type == 'advisory_opinions':
-        results = api_caller.load_legal_search_results(query, result_type,
-                    ao_no, ao_name, ao_min_date, ao_max_date, ao_is_pending,
-                    ao_requestor, ao_requestor_type, ao_category, **kwargs)
+    if query or result_type in ['advisory_opinions', 'murs']:
+        results = api_caller.load_legal_search_results(query, result_type, **kwargs)
 
-    if ao_no:
-        if ao_no[0]:
-            ao_no = ao_no[0]
-        else:
-            ao_no = None
-
-    if ao_name:
-        if ao_name[0]:
-            ao_name = ao_name[0]
-        else:
-            ao_name = None
-
-    if not ao_min_date:
-        ao_min_date = '04/01/1975'
-    else:
-        ao_min_date = ao_min_date.strftime('%m/%d/%Y')
-
-    if not ao_max_date:
-        ao_max_date = datetime.date.today().strftime('%m/%d/%Y')
-    else:
-        ao_max_date = ao_max_date.strftime('%m/%d/%Y')
-
-    return views.render_legal_doc_search_results(results, query, result_type,
-                        ao_no, ao_name, ao_min_date, ao_max_date, ao_is_pending,
-                        ao_requestor, ao_requestor_type, ao_category)
+    return views.render_legal_doc_search_results(results, query, result_type)
 
 
 @app.route('/legal/advisory-opinions/')
@@ -495,26 +467,10 @@ def statutes_landing():
 @app.route('/legal/search/advisory-opinions/')
 @use_kwargs({
     'query': fields.Str(load_from='search'),
-    'offset': fields.Int(missing=0),
-    'ao_no': fields.List(fields.Str, missing=None),
-    'ao_name': fields.List(fields.Str, missing=None),
-    'ao_min_date': fields.Date(missing=None),
-    'ao_max_date': fields.Date(missing=None),
-    'ao_is_pending': fields.Bool(missing=None),
-    'ao_requestor': fields.Str(missing=None),
-    'ao_requestor_type': fields.Int(missing=0),
-    'ao_category': fields.List(fields.Str, missing=None)
+    'offset': fields.Int(missing=0)
 })
-def advisory_opinions(query, offset, ao_no=None, ao_name=None, ao_min_date=None, ao_max_date=None,
-                        ao_is_pending=None, ao_requestor=None, ao_requestor_type=None,
-                        ao_category=None):
-    return legal_doc_search(query, 'advisory_opinions', offset=offset,
-                            ao_no=ao_no, ao_name=ao_name,
-                            ao_min_date=ao_min_date, ao_max_date=ao_max_date,
-                            ao_is_pending=ao_is_pending,
-                            ao_requestor=ao_requestor,
-                            ao_requestor_type=ao_requestor_type,
-                            ao_category=ao_category)
+def advisory_opinions(query, offset):
+    return legal_doc_search(query, 'advisory_opinions')
 
 
 @app.route('/legal/search/statutes/')

--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -485,10 +485,18 @@ def statutes(query, offset):
 @app.route('/legal/search/enforcement/')
 @use_kwargs({
     'query': fields.Str(load_from='search'),
+    'mur_no': fields.Str(load_from='mur_no'),
+    'mur_respondents': fields.Str(load_from='mur_respondents'),
+    'mur_election_cycles': fields.Int(load_from='mur_election_cycles'),
     'offset': fields.Int(missing=0),
 })
-def murs(query, offset):
-    return legal_doc_search(query, 'murs', offset=offset)
+def murs(query, offset, mur_no=None, mur_respondents=None, mur_election_cycles=None,
+    **kwargs):
+    return legal_doc_search(query, 'murs',
+        mur_no=mur_no,
+        mur_respondents=mur_respondents,
+        mur_election_cycles=mur_election_cycles,
+        offset=offset)
 
 
 # TODO migrating from /legal/regulations -> /legal/search/regulations,

--- a/openfecwebapp/templates/layouts/legal-doc-search-results.html
+++ b/openfecwebapp/templates/layouts/legal-doc-search-results.html
@@ -13,10 +13,10 @@
   {% endif %}
 {% endblock %}
 
+{% block header %}
+{% endblock %}
+
 {% block body %}
-<header class="page-header slab slab--primary">
-  {{ breadcrumb.breadcrumbs(document_type_display_name.capitalize(), breadcrumb_links) }}
-</header>
 
 {% block search %}
 <section class="main__content--full data-container__wrapper">

--- a/openfecwebapp/templates/layouts/legal-doc-search-results.html
+++ b/openfecwebapp/templates/layouts/legal-doc-search-results.html
@@ -21,8 +21,8 @@
 {% block search %}
 <section class="main__content--full data-container__wrapper">
   <div id="filters" class="filters is-open">
-    <button class="filters__header js-filter-toggle" type="button">
-      <span class="filters__title">Search {{ document_type_display_name }}</span>
+    <button class="filters__header filters__toggle js-filter-toggle" type="button">
+      <span class="filters__title">Edit filters</span>
     </button>
     <div class="filters__content">
       <form id="category-filters" action="{{ url_for(result_type) }}">
@@ -34,10 +34,13 @@
       </form>
     </div>
   </div>
-  <div id="results-{{ result_type }}" class="content__section data-container__body">
-    <div class="results-info results-info--simple">
-      <div class="results-info__left">
-        <h2 class="results-info__title">Searching {{ document_type_display_name }}{% if query %} for &ldquo;{{ query }}&rdquo;{% endif %}</h2>
+  <div id="results-{{ result_type }}" class="content__section">
+    <div class="data-container__widgets">
+      <div class="data-container__head">
+        <h1 class="data-container__title">{{ document_type_display_name }}{% if query %} for &ldquo;{{ query }}&rdquo;{% endif %}</h1>
+      </div>
+      <div class="u-padding--left u-padding--right">
+        {% block message %}{% endblock %}
       </div>
     </div>
     {% if results.total_all %}

--- a/openfecwebapp/templates/layouts/legal-doc-search-results.html
+++ b/openfecwebapp/templates/layouts/legal-doc-search-results.html
@@ -37,7 +37,7 @@
   <div id="results-{{ result_type }}" class="content__section">
     <div class="data-container__widgets">
       <div class="data-container__head">
-        <h1 class="data-container__title">{{ document_type_display_name }}{% if query %} for &ldquo;{{ query }}&rdquo;{% endif %}</h1>
+        <h1 class="data-container__title">{{ document_type_display_name|capitalize }}</h1>
       </div>
       <div class="u-padding--left u-padding--right">
         {% block message %}{% endblock %}
@@ -46,18 +46,20 @@
     {% if results.total_all %}
       {% block results %}{% endblock %}
     {% else %}
-    <div class="message message--no-icon">
-      <h2 class="message__title">No results</h2>
-      <p>Sorry, we didn&rsquo;t find any documents matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your search{% endif %}.</p>
-      <div class="message--alert__bottom">
-        <p>Think this was a mistake?</p>
-        <ul class="list--buttons">
-          {% if query %}
-          <li><a class="button button--standard" href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources=Administrative_Fine%2CAdvisory_Opinion%2CAlternative_Dispute_Resolution%2CAudit_Reports%2CMatters_Under_Review%2CMatters_Under_Review_Archived%2CRulemaster%2CCandidate_Summary%2CCommittee_Summary%2Cfec.gov&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&">Try FEC.gov</a></li>
-          {% endif %}
-          <li><a class="button button--standard" href="mailto:{{ contact_email }}">Email our team</a></li>
-          <li><a class="button button--standard" href="https://github.com/18f/fec/issues">File an issue</a></li>
-        </ul>
+    <div class="u-padding--left u-padding--right">
+      <div class="message message--no-icon">
+        <h2 class="message__title">No results</h2>
+        <p>Sorry, we didn&rsquo;t find any documents matching {% if query %}<span class="t-bold">{{ query }}</span>{% else %}your search{% endif %}.</p>
+        <div class="message--alert__bottom">
+          <p>Think this was a mistake?</p>
+          <ul class="list--buttons">
+            {% if query %}
+            <li><a class="button button--standard" href="http://search04.fec.gov/vivisimo/cgi-bin/query-meta?v%3Asources=Administrative_Fine%2CAdvisory_Opinion%2CAlternative_Dispute_Resolution%2CAudit_Reports%2CMatters_Under_Review%2CMatters_Under_Review_Archived%2CRulemaster%2CCandidate_Summary%2CCommittee_Summary%2Cfec.gov&query={{ query }}&x=0&y=0&v%3aproject=fec_search_02_prj&v%3aframe=form&form=advanced-fec&">Try FEC.gov</a></li>
+            {% endif %}
+            <li><a class="button button--standard" href="mailto:{{ contact_email }}">Email our team</a></li>
+            <li><a class="button button--standard" href="https://github.com/18f/fec/issues">File an issue</a></li>
+          </ul>
+        </div>
       </div>
     </div>
     {% endif %}

--- a/openfecwebapp/templates/legal-archived-mur.html
+++ b/openfecwebapp/templates/legal-archived-mur.html
@@ -2,7 +2,7 @@
 {% import 'macros/breadcrumbs.html' as breadcrumb %}
 {% import 'macros/legal.html' as legal %}
 
-{% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources'), (url_for('enforcement_landing'), 'Enforcement')] %}
+{% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources'), (cms_url + '/legal-resources/enforcement', 'Enforcement')] %}
 
 {% block title %}MUR #{{ mur.no }}{% endblock %}
 

--- a/openfecwebapp/templates/legal-current-mur.html
+++ b/openfecwebapp/templates/legal-current-mur.html
@@ -2,8 +2,6 @@
 {% import 'macros/breadcrumbs.html' as breadcrumb %}
 {% import 'macros/legal.html' as legal %}
 
-{% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources'), (cms_url + '/legal-resources/enforcement', 'Enforcement')] %}
-
 {% block title %}MUR #{{ mur.no }}{% endblock %}
 
 {% block body %}

--- a/openfecwebapp/templates/legal-current-mur.html
+++ b/openfecwebapp/templates/legal-current-mur.html
@@ -2,7 +2,7 @@
 {% import 'macros/breadcrumbs.html' as breadcrumb %}
 {% import 'macros/legal.html' as legal %}
 
-{% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources'), (url_for('enforcement_landing'), 'Enforcement')] %}
+{% set breadcrumb_links=[(cms_url + '/legal-resources', 'Legal resources'), (cms_url + '/legal-resources/enforcement', 'Enforcement')] %}
 
 {% block title %}MUR #{{ mur.no }}{% endblock %}
 

--- a/openfecwebapp/templates/legal-search-results-advisory_opinions.html
+++ b/openfecwebapp/templates/legal-search-results-advisory_opinions.html
@@ -2,6 +2,12 @@
 {% import 'macros/legal.html' as legal %}
 {% set document_type_display_name = 'advisory opinions' %}
 
+{% block header %}
+<header class="page-header slab slab--primary">
+  {{ breadcrumb.breadcrumbs('Search results', [(cms_url + '/legal-resources', 'Legal resources'), (url_for('advisory_opinions_landing'), 'Advisory opinions')]) }}
+</header>
+{% endblock %}
+
 {% block search %}
 <input id="query" type="hidden" value="{{ query }}" />
 <input id="contact-email" type="hidden" value="{{ contact_email }}" />

--- a/openfecwebapp/templates/legal-search-results-murs.html
+++ b/openfecwebapp/templates/legal-search-results-murs.html
@@ -2,6 +2,12 @@
 {% import 'macros/legal.html' as legal %}
 {% set document_type_display_name = 'Matters Under Review' %}
 
+{% block header %}
+<header class="page-header slab slab--primary">
+  {{ breadcrumb.breadcrumbs('Search results', [(cms_url + '/legal-resources', 'Legal resources'), (cms_url + '/legal-resources/enforcement', 'Enforcement')]) }}
+</header>
+{% endblock %}
+
 {% block filters %}
   {{ legal.keyword_search(result_type, query) }}
 {% endblock %}

--- a/openfecwebapp/templates/legal-search-results-murs.html
+++ b/openfecwebapp/templates/legal-search-results-murs.html
@@ -10,6 +10,17 @@
 
 {% block filters %}
   {{ legal.keyword_search(result_type, query) }}
+  <div class="filter">
+    <label class="label" for="mur_no">MUR number</label>
+    <input id="mur_no" name="mur_no" type="text" value="{{request.args.mur_no}}">
+  </div>
+  <div class="filter">
+    <label class="label" for="mur_respondents">MUR respondents</label>
+    <input id="mur_respondents" name="mur_respondents" type="text" value="{{request.args.mur_respondents}}">
+  </div>
+  <div class="filter">
+    <button type="submit" class="button button--cta">Apply filters</button>
+  </div>
 {% endblock %}
 
 {% block message %}

--- a/openfecwebapp/templates/legal-search-results-murs.html
+++ b/openfecwebapp/templates/legal-search-results-murs.html
@@ -12,8 +12,7 @@
   {{ legal.keyword_search(result_type, query) }}
 {% endblock %}
 
-{% block results %}
-{% with murs = results.murs %}
+{% block message %}
 <div class="message message--info">
   <h3>This feature is still in progress.</h3>
   <p>We&#39;re actively building the <strong>MUR search</strong>, and it doesn&#39;t yet include some
@@ -21,6 +20,11 @@
   you can still <a href="http://eqs.fec.gov/eqs/searcheqs">search MURS on the old fec.gov</a>.</p>
   <p>Additionally, use the <a href="{{ classic_url }}/MUR/">MUR archive</a> to search for cases closed between 1975 and 1998.</p>
 </div>
+{% endblock %}
+
+{% block results %}
+{% with murs = results.murs %}
+
 {% include 'partials/legal-search-results-mur.html' %}
 {% endwith %}
 

--- a/openfecwebapp/templates/legal-search-results-regulations.html
+++ b/openfecwebapp/templates/legal-search-results-regulations.html
@@ -14,7 +14,9 @@
 
 {% block results %}
 {% with regulations = results.regulations %}
-{% include 'partials/legal-search-results-regulation.html' %}
+<div class="data-container__datatable">
+  {% include 'partials/legal-search-results-regulation.html' %}
+</div>
 {% endwith %}
 
 {% with results=results %}

--- a/openfecwebapp/templates/legal-search-results-regulations.html
+++ b/openfecwebapp/templates/legal-search-results-regulations.html
@@ -2,6 +2,12 @@
 {% import 'macros/legal.html' as legal %}
 {% set document_type_display_name = 'regulations' %}
 
+{% block header %}
+<header class="page-header slab slab--primary">
+  {{ breadcrumb.breadcrumbs('Search results', [(cms_url + '/legal-resources', 'Legal resources'), (cms_url + '/legal-resources/regulations', 'Regulations')]) }}
+</header>
+{% endblock %}
+
 {% block filters %}
   {{ legal.keyword_search(result_type, query) }}
 {% endblock %}

--- a/openfecwebapp/templates/legal-search-results-statutes.html
+++ b/openfecwebapp/templates/legal-search-results-statutes.html
@@ -14,7 +14,9 @@
 
 {% block results %}
 {% with statutes = results.statutes %}
-{% include 'partials/legal-search-results-statute.html' %}
+<div class="data-container__datatable">
+  {% include 'partials/legal-search-results-statute.html' %}
+</div>
 {% endwith %}
 
 {% with results=results %}

--- a/openfecwebapp/templates/legal-search-results-statutes.html
+++ b/openfecwebapp/templates/legal-search-results-statutes.html
@@ -2,6 +2,12 @@
 {% import 'macros/legal.html' as legal %}
 {% set document_type_display_name = 'statutes' %}
 
+{% block header %}
+<header class="page-header slab slab--primary">
+  {{ breadcrumb.breadcrumbs('Search results', [(cms_url + '/legal-resources', 'Legal resources'), (url_for('statutes_landing'), 'Statutes')]) }}
+</header>
+{% endblock %}
+
 {% block filters %}
   {{ legal.keyword_search(result_type, query) }}
 {% endblock %}

--- a/openfecwebapp/templates/partials/candidates-filter.html
+++ b/openfecwebapp/templates/partials/candidates-filter.html
@@ -1,6 +1,5 @@
 {% extends 'partials/filters.html' %}
 
-{% import 'macros/filters/text.html' as text %}
 {% import 'macros/filters/states.html' as states %}
 {% import 'macros/filters/typeahead-filter.html' as typeahead %}
 {% import 'macros/filters/years.html' as years %}

--- a/openfecwebapp/templates/partials/legal-search-results-mur.html
+++ b/openfecwebapp/templates/partials/legal-search-results-mur.html
@@ -1,4 +1,4 @@
-<div class="simple-table simple-table--responsive simple-table--display legal-search-results legal-mur">
+<div class="simple-table simple-table--responsive simple-table--display legal-search-results legal-mur data-container__datatable">
   <div class="simple-table__header">
     <div class="simple-table__header-cell cell--25">Name</div>
     <div class="simple-table__header-cell">Matches</div>

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -41,23 +41,13 @@ def render_legal_search_results(results, query, result_type):
     )
 
 
-def render_legal_doc_search_results(results, query, result_type, ao_no, ao_name,
-                ao_min_date, ao_max_date, ao_is_pending, ao_requestor, ao_requestor_type,
-                ao_category):
+def render_legal_doc_search_results(results, query, result_type):
     return render_template(
         'legal-search-results-%s.html' % result_type,
         parent='legal',
         results=results,
         result_type=result_type,
-        query=query,
-        ao_no=ao_no,
-        ao_name=ao_name,
-        ao_min_date=ao_min_date,
-        ao_max_date=ao_max_date,
-        ao_is_pending=ao_is_pending,
-        ao_requestor=ao_requestor,
-        ao_requestor_type=ao_requestor_type,
-        ao_category=ao_category
+        query=query
     )
 
 

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -87,7 +87,7 @@ def render_legal_ao_landing():
         query='',
         query_type='advisory_opinions',
         ao_category=['F', 'W'],
-        ao_min_date=ao_min_date
+        ao_min_issue_date=ao_min_date
     )
     pending_aos = api_caller.load_legal_search_results(
         query='',

--- a/static/js/legal/Filters.js
+++ b/static/js/legal/Filters.js
@@ -14,7 +14,7 @@ function Filters(props) {
   const resultCountChange = props.query.resultCount - props.query.lastResultCount;
 
   return <div>
-            <div className="filters accordion__content">
+            <div className="accordion__content">
               <TextFilter key="ao_no" name="ao_no" label="AO number" value={props.query.ao_no}
                   handleChange={props.setQuery} getResults={props.getResults} />
               <TextFilter key="ao_requestor" name="ao_requestor" label="Requestor Name (or AO Name)" value={props.query.ao_requestor}

--- a/static/js/legal/LegalSearch.js
+++ b/static/js/legal/LegalSearch.js
@@ -127,13 +127,21 @@ class LegalSearch extends React.Component {
                 getResults={this.getResults} instantQuery={this.instantQuery} />
         </div>
       </div>
-      <div id="results-{{ result_type }}" className="content__section data-container__body">
-        <div className="results-info results-info--simple">
-          <div className="results-info__left">
-            <h2 className="results-info__title">Searching advisory opinions</h2>
+      <div id="results-aos" className="content__section data-container">
+        <div className="data-container__widgets">
+          <div className="data-container__head">
+            <h1 className="data-container__title">Advisory opinions</h1>
+          </div>
+          <Tags query={this.state.lastQuery} resultCount={this.state.resultCount} handleRemove={this.instantQuery} />
+          <div className="u-padding--left u-padding--right">
+            <div className="message message--info">
+              <h3>This feature is still in progress</h3>
+              <p>We&#39;re actively building the <strong>advisory opinion search</strong>, and it doesn&#39;t yet include some
+              advanced search functions. If you can&#39;t find what you&#39;re looking for, you can still <a href="http://saos.fec.gov/saos/searchao">search
+              opinions on the old fec.gov</a>.</p>
+            </div>
           </div>
         </div>
-        <Tags query={this.state.lastQuery} resultCount={this.state.resultCount} handleRemove={this.instantQuery} />
         <SearchResults advisory_opinions={this.state.advisory_opinions} q={this.state.q} loading={this.state.loading} />
         <Pagination from_hit={this.state.from_hit} advisory_opinions={this.state.advisory_opinions}
           resultCount={this.state.resultCount} handleChange={this.instantQuery} />

--- a/static/js/legal/SearchResults.js
+++ b/static/js/legal/SearchResults.js
@@ -30,13 +30,7 @@ function SearchResults(props) {
           </div>
   } else {
     if(props.advisory_opinions && props.advisory_opinions.length > 0) {
-      return <div>
-        <div className="message message--info">
-          <h3>This feature is still in progress</h3>
-          <p>We&#39;re actively building the <strong>advisory opinion search</strong>, and it doesn&#39;t yet include some
-          advanced search functions. If you can&#39;t find what you&#39;re looking for, you can still <a href="http://saos.fec.gov/saos/searchao">search
-          opinions on the old fec.gov</a>.</p>
-        </div>
+      return <div className="data-container__datatable">
         <table className="simple-table simple-table--display">
           <thead className="simple-table__header">
             <tr>
@@ -46,8 +40,9 @@ function SearchResults(props) {
               <th scope="col" className="simple-table__header-cell">This opinion is cited by these later opinions</th>
             </tr>
           </thead>
+          <tbody>
             { props.advisory_opinions.map((advisory_opinion) => {
-              return <tbody key={"CASE " + advisory_opinion.no} className="simple-table__row"><tr>
+              return <tr key={"CASE " + advisory_opinion.no} className="simple-table__row">
                 <td scope="row" className="simple-table__cell"><div><i className="icon i-folder icon--inline--left"></i><strong>
                 <a href={advisoryOpinionLink(advisory_opinion.no)}>AO {advisory_opinion.no}</a></strong></div>
                     <div><a href={advisoryOpinionLink(advisory_opinion.no)}>{advisory_opinion.name}</a></div>
@@ -64,8 +59,8 @@ function SearchResults(props) {
               {advisory_opinion.highlights.length > 0 && <tr><td scope="row" className="simple-table__cell">Keyword matches in documents</td>
                 <td colSpan="3" className="t-serif legal-search-result__hit u-padding--top simple-table__cell"
                 dangerouslySetInnerHTML={ highlights(advisory_opinion) }></td></tr>}
-              </tbody>
             }) }
+          </tbody>
         </table>
         </div>
     } else {

--- a/static/js/legal/Tags.js
+++ b/static/js/legal/Tags.js
@@ -100,7 +100,7 @@ function Tags(props) {
   }
 
   if(getTagCategories()) {
-    return <div><div className="row"><h3 className="tags__title">
+    return <div className="data-container__tags"><div className="row"><h3 className="tags__title">
     Viewing <span className="tags__count">{props.resultCount}</span> {(getTagCategories().length > 0) ? " filtered results for:" : " results"}
     </h3></div>
     <ul className="tags">

--- a/tests/unit/test_legal_search.py
+++ b/tests/unit/test_legal_search.py
@@ -58,18 +58,6 @@ class TestLegalSearch(unittest.TestCase):
             'regulations', offset=0)
 
     @mock.patch.object(api_caller, 'load_legal_search_results')
-    def test_search_advisory_opinions(self, load_legal_search_results):
-        load_legal_search_results.return_value = factory.advisory_opinions_search_results()
-        response = self.app.get('/legal/search/advisory-opinions/',
-                data={
-                    'search': 'in kind donation',
-                    'search_type': 'advisory_opinions'})
-        assert response.status_code == 200
-
-        load_legal_search_results.assert_called_once_with('in kind donation',
-            'advisory_opinions', offset=0)
-
-    @mock.patch.object(api_caller, 'load_legal_search_results')
     def test_search_pagination(self, load_legal_search_results):
         load_legal_search_results.return_value = factory.regulations_search_results()
         response = self.app.get('/legal/search/regulations/',

--- a/tests/unit/test_legal_search.py
+++ b/tests/unit/test_legal_search.py
@@ -93,22 +93,22 @@ class TestLegalSearch(unittest.TestCase):
         assert results['statutes_returned'] == 4
         assert results['regulations_returned'] == 5
 
-    # @mock.patch.object(api_caller, 'load_legal_search_results')
-    # def test_ao_landing_page(self, load_legal_search_results):
-    #     today = datetime.date.today()
-    #     ao_min_date = today - datetime.timedelta(weeks=26)
-    #     response = self.app.get('legal/advisory-opinions/')
-    #
-    #     assert response.status_code == 200
-    #
-    #     # load_legal_search_results gets called twice in this view,
-    #     # so this mocks the two different calls and then we assert they happend
-    #     # http://stackoverflow.com/questions/7242433/asserting-successive-calls-to-a-mock-method
-    #     calls = [
-    #         mock.call(query='', query_type='advisory_opinions', ao_min_issued_date=ao_min_date, ao_category=['F', 'W']),
-    #         mock.call(query='', query_type='advisory_opinions', ao_is_pending=True, ao_category='R')
-    #     ]
-    #     load_legal_search_results.assert_has_calls(calls, any_order=True)
+    @mock.patch.object(api_caller, 'load_legal_search_results')
+    def test_ao_landing_page(self, load_legal_search_results):
+        today = datetime.date.today()
+        ao_min_date = today - datetime.timedelta(weeks=26)
+        response = self.app.get('legal/advisory-opinions/')
+
+        assert response.status_code == 200
+
+        # load_legal_search_results gets called twice in this view,
+        # so this mocks the two different calls and then we assert they happend
+        # http://stackoverflow.com/questions/7242433/asserting-successive-calls-to-a-mock-method
+        calls = [
+            mock.call(query='', query_type='advisory_opinions', ao_min_issue_date=ao_min_date, ao_category=['F', 'W']),
+            mock.call(query='', query_type='advisory_opinions', ao_is_pending=True, ao_category='R')
+        ]
+        load_legal_search_results.assert_has_calls(calls, any_order=True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_legal_search.py
+++ b/tests/unit/test_legal_search.py
@@ -55,7 +55,7 @@ class TestLegalSearch(unittest.TestCase):
 
         assert response.status_code == 200
         load_legal_search_results.assert_called_once_with('in kind donation',
-            'regulations', None, None, None, None, None, None, None, None, offset=0)
+            'regulations', offset=0)
 
     @mock.patch.object(api_caller, 'load_legal_search_results')
     def test_search_advisory_opinions(self, load_legal_search_results):
@@ -67,7 +67,7 @@ class TestLegalSearch(unittest.TestCase):
         assert response.status_code == 200
 
         load_legal_search_results.assert_called_once_with('in kind donation',
-            'advisory_opinions', None, None, None, None, None, None, 0, None, offset=0)
+            'advisory_opinions', offset=0)
 
     @mock.patch.object(api_caller, 'load_legal_search_results')
     def test_search_pagination(self, load_legal_search_results):
@@ -79,7 +79,7 @@ class TestLegalSearch(unittest.TestCase):
                     'offset': 20})
         assert response.status_code == 200
         load_legal_search_results.assert_called_once_with('in kind donation',
-         'regulations', None, None, None, None, None, None, None, None, offset=20)
+         'regulations', offset=20)
 
     @mock.patch.object(api_caller, 'load_legal_search_results')
     def test_search_statutes(self, load_legal_search_results):
@@ -89,8 +89,8 @@ class TestLegalSearch(unittest.TestCase):
                     'search': 'in kind donation',
                     'search_type': 'statutes'})
         assert response.status_code == 200
-        load_legal_search_results.assert_called_once_with('in kind donation', 'statutes',
-            None, None, None, None, None, None, None, None, offset=0)
+        load_legal_search_results.assert_called_once_with('in kind donation',
+            'statutes', offset=0)
 
     @mock.patch.object(api_caller, '_call_api')
     def test_result_counts(self, _call_api_mock):
@@ -105,22 +105,22 @@ class TestLegalSearch(unittest.TestCase):
         assert results['statutes_returned'] == 4
         assert results['regulations_returned'] == 5
 
-    @mock.patch.object(api_caller, 'load_legal_search_results')
-    def test_ao_landing_page(self, load_legal_search_results):
-        today = datetime.date.today()
-        ao_min_date = today - datetime.timedelta(weeks=26)
-        response = self.app.get('legal/advisory-opinions/')
-
-        assert response.status_code == 200
-
-        # load_legal_search_results gets called twice in this view,
-        # so this mocks the two different calls and then we assert they happend
-        # http://stackoverflow.com/questions/7242433/asserting-successive-calls-to-a-mock-method
-        calls = [
-            mock.call(query='', query_type='advisory_opinions', ao_min_date=ao_min_date, ao_category=['F', 'W']),
-            mock.call(query='', query_type='advisory_opinions', ao_is_pending=True, ao_category='R')
-        ]
-        load_legal_search_results.assert_has_calls(calls, any_order=True)
+    # @mock.patch.object(api_caller, 'load_legal_search_results')
+    # def test_ao_landing_page(self, load_legal_search_results):
+    #     today = datetime.date.today()
+    #     ao_min_date = today - datetime.timedelta(weeks=26)
+    #     response = self.app.get('legal/advisory-opinions/')
+    #
+    #     assert response.status_code == 200
+    #
+    #     # load_legal_search_results gets called twice in this view,
+    #     # so this mocks the two different calls and then we assert they happend
+    #     # http://stackoverflow.com/questions/7242433/asserting-successive-calls-to-a-mock-method
+    #     calls = [
+    #         mock.call(query='', query_type='advisory_opinions', ao_min_issued_date=ao_min_date, ao_category=['F', 'W']),
+    #         mock.call(query='', query_type='advisory_opinions', ao_is_pending=True, ao_category='R')
+    #     ]
+    #     load_legal_search_results.assert_has_calls(calls, any_order=True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This started as an endeavor to clean up some of the filter style notes that @jenniferthibault documented in https://github.com/18F/openFEC-web-app/issues/2141 and ended up rolling in a few other cleanup items.

First, it adds the correct classes to the AO search results so they mirror the other data tables.

![image](https://user-images.githubusercontent.com/1696495/27312217-bdeee4ce-551b-11e7-8ffb-3500545ba263.png)

Second, I updated the breadcrumbs across legal search results pages so that they include their immediate parent pages, as well as the main top-level legal resource page. This has been a small thing that's been driving me nuts.

Third, I removed a bunch of the old unnecessary server-side AO search results code, since it all happens client-side now. Mainly that involved refactoring the api caller functions to use `**kwargs` instead of a bunch of `ao_*` named arguments. 

Interestingly enough, doing so, made it really easy to plop in a few of the MUR filters while we wait to extend the new React code base to MURs. 

![image](https://user-images.githubusercontent.com/1696495/27312264-05b6024c-551c-11e7-9400-a65381e4126e.png)
