### PR TITLE
Adding zipcode filter

### DIFF
--- a/openfecwebapp/templates/partials/individual-contributions-filter.html
+++ b/openfecwebapp/templates/partials/individual-contributions-filter.html
@@ -22,6 +22,7 @@ Filter individual contributions
   <div class="accordion__content">
     {{ text.field('contributor_city', 'City') }}
     {{ states.field('contributor_state') }}
+    {{ text.field('contributor_zip', 'ZIP code')}}
     {{ text.field('contributor_employer', 'Employer') }}
     {{ text.field('contributor_occupation', 'Occupation') }}
   </div>

--- a/openfecwebapp/templates/partials/receipts-filter.html
+++ b/openfecwebapp/templates/partials/receipts-filter.html
@@ -51,6 +51,7 @@ Filter receipts
     {% include 'partials/filters/unique-receipts.html' %}
     {{ text.field('contributor_city', 'City') }}
     {{ states.field('contributor_state') }}
+    {{ text.field('contributor_zip', 'ZIP code')}}
     {{ text.field('contributor_employer', 'Employer') }}
     {{ text.field('contributor_occupation', 'Occupation') }}
   </div>


### PR DESCRIPTION
Now that https://github.com/18F/openFEC/pull/2365/ is in, we can add it to the front-end:

![image](https://user-images.githubusercontent.com/1696495/27411280-8672c48e-56a1-11e7-91bf-180046407ccd.png)

Resolves https://github.com/18F/openFEC-web-app/issues/2018