### PR TITLE
Adding links to web views of reports

### DIFF
--- a/static/templates/reports/candidate.hbs
+++ b/static/templates/reports/candidate.hbs
@@ -27,7 +27,10 @@
     {{#panelRow "Filing method"}}
       {{ decodeMeans means_filed}}
     {{/panelRow}}
-    {{#panelRow "Download"}}
+    {{#panelRow "Read report"}}
+      {{#if html_url}}
+        <a target="_blank" href="{{ html_url }}">Web</a> |
+      {{/if}}
       {{#if csv_url}}
       <a target="_blank" href="{{ csv_url }}">CSV</a> |
       {{/if}}

--- a/static/templates/reports/candidate.hbs
+++ b/static/templates/reports/candidate.hbs
@@ -29,16 +29,16 @@
     {{/panelRow}}
     {{#panelRow "Read report"}}
       {{#if html_url}}
-        <a target="_blank" href="{{ html_url }}">Web</a> |
+        <a target="_blank" href="{{ html_url }}">Webpage</a> |
       {{/if}}
       {{#if csv_url}}
-      <a target="_blank" href="{{ csv_url }}">CSV</a> |
+      <a target="_blank" href="{{ csv_url }}">.csv</a> |
       {{/if}}
       {{#if pdf_url }}
-      <a target="_blank" href="{{ pdf_url }}">PDF</a>
+      <a target="_blank" href="{{ pdf_url }}">.pdf</a>
       {{/if}}
       {{#if fec_url}}
-      | <a target="_blank" href="{{ fec_url }}">FEC</a>
+      | <a target="_blank" href="{{ fec_url }}">.fec</a>
       {{/if}}
     {{/panelRow}}
   </table>

--- a/static/templates/reports/ie-only.hbs
+++ b/static/templates/reports/ie-only.hbs
@@ -28,6 +28,9 @@
       {{ decodeMeans means_filed}}
     {{/panelRow}}
     {{#panelRow "Download"}}
+      {{#if html_url}}
+        <a target="_blank" href="{{ html_url }}">Web</a> |
+      {{/if}}
       {{#if csv_url}}
       <a target="_blank" href="{{ csv_url }}">CSV</a> |
       {{/if}}

--- a/static/templates/reports/ie-only.hbs
+++ b/static/templates/reports/ie-only.hbs
@@ -27,18 +27,18 @@
     {{#panelRow "Filing method"}}
       {{ decodeMeans means_filed}}
     {{/panelRow}}
-    {{#panelRow "Download"}}
+    {{#panelRow "Read report"}}
       {{#if html_url}}
-        <a target="_blank" href="{{ html_url }}">Web</a> |
+        <a target="_blank" href="{{ html_url }}">Webpage</a> |
       {{/if}}
       {{#if csv_url}}
-      <a target="_blank" href="{{ csv_url }}">CSV</a> |
+      <a target="_blank" href="{{ csv_url }}">.csv</a> |
       {{/if}}
-      {{#if pdf_url}}
-      <a target="_blank" href="{{ pdf_url }}">PDF</a>
+      {{#if pdf_url }}
+      <a target="_blank" href="{{ pdf_url }}">.pdf</a>
       {{/if}}
       {{#if fec_url}}
-      | <a target="_blank" href="{{ fec_url }}">FEC</a>
+      | <a target="_blank" href="{{ fec_url }}">.fec</a>
       {{/if}}
     {{/panelRow}}
   </table>

--- a/static/templates/reports/pac.hbs
+++ b/static/templates/reports/pac.hbs
@@ -28,6 +28,9 @@
       {{ decodeMeans means_filed}}
     {{/panelRow}}
     {{#panelRow "Download"}}
+      {{#if html_url}}
+        <a target="_blank" href="{{ html_url }}">Web</a> |
+      {{/if}}
       {{#if csv_url}}
       <a target="_blank" href="{{ csv_url }}">CSV</a> |
       {{/if}}

--- a/static/templates/reports/pac.hbs
+++ b/static/templates/reports/pac.hbs
@@ -27,18 +27,18 @@
     {{#panelRow "Filing method"}}
       {{ decodeMeans means_filed}}
     {{/panelRow}}
-    {{#panelRow "Download"}}
+    {{#panelRow "Read report"}}
       {{#if html_url}}
-        <a target="_blank" href="{{ html_url }}">Web</a> |
+        <a target="_blank" href="{{ html_url }}">Webpage</a> |
       {{/if}}
       {{#if csv_url}}
-      <a target="_blank" href="{{ csv_url }}">CSV</a> |
+      <a target="_blank" href="{{ csv_url }}">.csv</a> |
       {{/if}}
-      {{#if pdf_url}}
-      <a target="_blank" href="{{ pdf_url }}">PDF</a>
+      {{#if pdf_url }}
+      <a target="_blank" href="{{ pdf_url }}">.pdf</a>
       {{/if}}
       {{#if fec_url}}
-      | <a target="_blank" href="{{ fec_url }}">FEC</a>
+      | <a target="_blank" href="{{ fec_url }}">.fec</a>
       {{/if}}
     {{/panelRow}}
   </table>

--- a/static/templates/reports/reportType.hbs
+++ b/static/templates/reports/reportType.hbs
@@ -1,6 +1,8 @@
 {{#if doc_description }}
   <div class="document-description">
-    {{#if pdf_url }}
+    {{#if html_url}}
+    <a href="{{ html_url }}" target="_blank">{{ doc_description }}</a>
+    {{else if pdf_url }}
     <a href="{{ pdf_url }}" target="_blank">{{ doc_description }}</a>
     {{ else }}
     {{ doc_description }}


### PR DESCRIPTION
Pending resolution of the discussion in https://github.com/18F/openFEC/issues/2226 , this adds links to the webpage version of reports:

![image](https://user-images.githubusercontent.com/1696495/27499029-c0831dc4-5816-11e7-8d0a-bc8641d2776f.png)

The document title in the table now links to this webpage version if it exists, falling back to PDF if necessary.