### PR TITLE
Feature/css refactor

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,12 +39,7 @@ gulp.task('copy-fonts', function() {
     .pipe(gulp.dest('./dist/fonts'));
 });
 
-gulp.task('copy-maps', function() {
-  return gulp.src('./node_modules/congressional-districts/**/*')
-    .pipe(gulp.dest('./dist/json/districts'));
-});
-
-gulp.task('build-sass', ['copy-vendor-images', 'copy-images', 'copy-fonts', 'copy-maps'], function() {
+gulp.task('build-sass', ['copy-vendor-images', 'copy-images', 'copy-fonts'], function() {
   return gulp.src('./static/styles/*.scss')
     .pipe(rename(function(path) {
       path.dirname = './dist/styles';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,12 +34,17 @@ gulp.task('copy-images', function() {
     .pipe(gulp.dest('./dist/img'));
 });
 
+gulp.task('copy-fonts', function() {
+  return gulp.src(['./static/fonts/**/*', './node_modules/fec-style/fonts/**/*'])
+    .pipe(gulp.dest('./dist/fonts'));
+});
+
 gulp.task('copy-maps', function() {
   return gulp.src('./node_modules/congressional-districts/**/*')
     .pipe(gulp.dest('./dist/json/districts'));
 });
 
-gulp.task('build-sass', ['copy-vendor-images', 'copy-images', 'copy-maps'], function() {
+gulp.task('build-sass', ['copy-vendor-images', 'copy-images', 'copy-fonts', 'copy-maps'], function() {
   return gulp.src('./static/styles/*.scss')
     .pipe(rename(function(path) {
       path.dirname = './dist/styles';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,7 +67,6 @@ var fs = require('fs');
 var path = require('path');
 var file = require('gulp-file');
 var concat = require('concat-stream');
-var factor = require('factor-bundle');
 
 var del = require('del');
 var extend = require('gulp-extend');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,9 +17,6 @@ var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');
 var uglify = require('gulp-uglify');
 
-var appEnv = require('cfenv').getAppEnv();
-
-
 var debug = !!process.env.FEC_WEB_DEBUG;
 var analytics = !!process.env.FEC_WEB_GOOGLE_ANALYTICS;
 var production = ['stage', 'prod'].indexOf(process.env.FEC_WEB_ENVIRONMENT) !== -1;

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -5,6 +5,10 @@
   {{ title }}
 {% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/common.css') }}" />
+{% endblock %}
+
 {% block body %}
   {{ header.header(title, '') }}
   <div class="tab-interface">

--- a/openfecwebapp/templates/advanced.html
+++ b/openfecwebapp/templates/advanced.html
@@ -5,7 +5,7 @@
   {{ title }}
 {% endblock %}
 
-{% block extra_css %}
+{% block css %}
 <link rel="stylesheet" href="{{ asset_for('dist/styles/common.css') }}" />
 {% endblock %}
 

--- a/openfecwebapp/templates/candidates-single.html
+++ b/openfecwebapp/templates/candidates-single.html
@@ -6,6 +6,10 @@
     {{ name }} - Candidate overview
 {% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/entity.css') }}" />
+{% endblock %}
+
 {% set breadcrumbs=[('', 'Candidate profiles')] %}
 
 {% block body %}

--- a/openfecwebapp/templates/candidates-single.html
+++ b/openfecwebapp/templates/candidates-single.html
@@ -6,7 +6,7 @@
     {{ name }} - Candidate overview
 {% endblock %}
 
-{% block extra_css %}
+{% block css %}
 <link rel="stylesheet" href="{{ asset_for('dist/styles/entity.css') }}" />
 {% endblock %}
 

--- a/openfecwebapp/templates/committees-single.html
+++ b/openfecwebapp/templates/committees-single.html
@@ -7,7 +7,7 @@
     {{ name }} - committee overview
 {% endblock %}
 
-{% block extra_css %}
+{% block css %}
 <link rel="stylesheet" href="{{ asset_for('dist/styles/entity.css') }}" />
 {% endblock %}
 

--- a/openfecwebapp/templates/committees-single.html
+++ b/openfecwebapp/templates/committees-single.html
@@ -7,6 +7,10 @@
     {{ name }} - committee overview
 {% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/entity.css') }}" />
+{% endblock %}
+
 {% set breadcrumbs=[('', 'Committee profiles')] %}
 
 {% block body %}

--- a/openfecwebapp/templates/datatable.html
+++ b/openfecwebapp/templates/datatable.html
@@ -8,6 +8,10 @@
   Browse {{ title }}
 {% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/datatables.css') }}" />
+{% endblock %}
+
 {% block body %}
 
 {{ header.header(breadcrumbs_title | title, breadcrumbs) }}
@@ -18,7 +22,7 @@
       <div class="data-container__widgets js-data-widgets">
         <noscript>
           <h1>{{ title }}</h1>
-        </noscript>        
+        </noscript>
         <div class="js-filter-tags data-container__tags">
         </div>
       </div>

--- a/openfecwebapp/templates/datatable.html
+++ b/openfecwebapp/templates/datatable.html
@@ -8,7 +8,7 @@
   Browse {{ title }}
 {% endblock %}
 
-{% block extra_css %}
+{% block css %}
 <link rel="stylesheet" href="{{ asset_for('dist/styles/datatables.css') }}" />
 {% endblock %}
 

--- a/openfecwebapp/templates/election-lookup.html
+++ b/openfecwebapp/templates/election-lookup.html
@@ -6,6 +6,10 @@
   Find candidates and elections by location
 {% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/elections.css') }}" />
+{% endblock %}
+
 {% block body %}
   {{ header.header(title) }}
 <section class="main" id="election-lookup" >

--- a/openfecwebapp/templates/election-lookup.html
+++ b/openfecwebapp/templates/election-lookup.html
@@ -6,7 +6,7 @@
   Find candidates and elections by location
 {% endblock %}
 
-{% block extra_css %}
+{% block css %}
 <link rel="stylesheet" href="{{ asset_for('dist/styles/elections.css') }}" />
 {% endblock %}
 

--- a/openfecwebapp/templates/elections.html
+++ b/openfecwebapp/templates/elections.html
@@ -8,6 +8,10 @@
   {{ title }}
 {% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/elections.css') }}" />
+{% endblock %}
+
 {% block body %}
 <div class="tab-interface">
   {{ header.header(title) }}

--- a/openfecwebapp/templates/elections.html
+++ b/openfecwebapp/templates/elections.html
@@ -8,7 +8,7 @@
   {{ title }}
 {% endblock %}
 
-{% block extra_css %}
+{% block css %}
 <link rel="stylesheet" href="{{ asset_for('dist/styles/elections.css') }}" />
 {% endblock %}
 

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -6,7 +6,7 @@
   {{ title }}
 {% endblock %}
 
-{% block extra_css %}
+{% block css %}
 <link rel="stylesheet" href="{{ asset_for('dist/styles/data-landing.css') }}" />
 {% endblock %}
 

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -6,6 +6,10 @@
   {{ title }}
 {% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/data-landing.css') }}" />
+{% endblock %}
+
 {% block body %}
 <section class="hero hero--primary hero--data" aria-labelledby="hero-heading">
   <div class="hero__image"></div>

--- a/openfecwebapp/templates/layouts/legal-doc-landing.html
+++ b/openfecwebapp/templates/layouts/legal-doc-landing.html
@@ -6,6 +6,10 @@
 
 {% block title %}{{ display_name | capitalize }}{% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/legal.css') }}" />
+{% endblock %}
+
 {% block body %}
 <header class="page-header slab slab--primary">
   {{ breadcrumb.breadcrumbs(display_name.capitalize(), breadcrumb_links) }}

--- a/openfecwebapp/templates/layouts/legal-doc-landing.html
+++ b/openfecwebapp/templates/layouts/legal-doc-landing.html
@@ -6,7 +6,7 @@
 
 {% block title %}{{ display_name | capitalize }}{% endblock %}
 
-{% block extra_css %}
+{% block css %}
 <link rel="stylesheet" href="{{ asset_for('dist/styles/legal.css') }}" />
 {% endblock %}
 

--- a/openfecwebapp/templates/layouts/legal-doc-search-results.html
+++ b/openfecwebapp/templates/layouts/legal-doc-search-results.html
@@ -13,7 +13,7 @@
   {% endif %}
 {% endblock %}
 
-{% block extra_css %}
+{% block css %}
 <link rel="stylesheet" href="{{ asset_for('dist/styles/legal.css') }}" />
 {% endblock %}
 

--- a/openfecwebapp/templates/layouts/legal-doc-search-results.html
+++ b/openfecwebapp/templates/layouts/legal-doc-search-results.html
@@ -13,6 +13,10 @@
   {% endif %}
 {% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/legal.css') }}" />
+{% endblock %}
+
 {% block header %}
 {% endblock %}
 

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -7,10 +7,9 @@
 
   {% include 'partials/meta-tags.html' %}
 
-  <link rel="stylesheet" href="{{ asset_for('dist/styles/global.css') }}" />
-
-  {% block extra_css %}
-  {% endblock %}
+  {% block css %}
+  <link rel="stylesheet" href="{{ asset_for('dist/styles/base.css') }}" />
+  {% endblock css %}
 
   {% if api_location %}
   <script>

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -7,8 +7,10 @@
 
   {% include 'partials/meta-tags.html' %}
 
-  <link rel="stylesheet" href="{{ asset_for('dist/styles/styles.css') }}" />
-  <link rel="stylesheet" href="{{ asset_for('dist/styles/fec.css') }}" />
+  <link rel="stylesheet" href="{{ asset_for('dist/styles/global.css') }}" />
+
+  {% block extra_css %}
+  {% endblock %}
 
   {% if api_location %}
   <script>

--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -60,7 +60,7 @@
           <img src="{{ url_for('static', filename='img/us_flag_small.png') }}" alt="US flag signifying that this is a United States Federal Government website">
         </span>
       </div>
-      <img src="{{ url_for('static', filename='img/print-logo.png') }}" class="u-print-only" alt="FEC logo">
+      <div class="site-title--print"></div>
       <a title="Home" href="{{ cms_url }}/" rel="home" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
       <ul class="utility-nav list--flat">
         <li class="utility-nav__item"><a href="{{ cms_url }}/calendar/">Calendar</a></li>

--- a/openfecwebapp/templates/legal-advisory-opinion.html
+++ b/openfecwebapp/templates/legal-advisory-opinion.html
@@ -10,9 +10,8 @@
   {{ breadcrumb.breadcrumbs('AO %s' % (advisory_opinion.no,), breadcrumb_links) }}
 </header>
 
-{% block extra_css %}
-<link rel="stylesheet" href="{{ asset_for('dist/styles/legal.css') }}" />
-<link rel="stylesheet" href="{{ asset_for('dist/styles/common.css') }}" />
+{% block css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/legal-common.css') }}" />
 {% endblock %}
 
 <div class="main">

--- a/openfecwebapp/templates/legal-advisory-opinion.html
+++ b/openfecwebapp/templates/legal-advisory-opinion.html
@@ -10,6 +10,11 @@
   {{ breadcrumb.breadcrumbs('AO %s' % (advisory_opinion.no,), breadcrumb_links) }}
 </header>
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/legal.css') }}" />
+<link rel="stylesheet" href="{{ asset_for('dist/styles/common.css') }}" />
+{% endblock %}
+
 <div class="main">
 <div class="container">
   <div class="row">

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -12,7 +12,7 @@
   {% endif %}
 {% endblock %}
 
-{% block extra_css %}
+{% block css %}
 <link rel="stylesheet" href="{{ asset_for('dist/styles/legal.css') }}" />
 {% endblock %}
 

--- a/openfecwebapp/templates/legal-search-results.html
+++ b/openfecwebapp/templates/legal-search-results.html
@@ -12,6 +12,10 @@
   {% endif %}
 {% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/legal.css') }}" />
+{% endblock %}
+
 {% block body %}
 <header class="page-header slab slab--primary">
   {{ breadcrumb.breadcrumbs('Search results', breadcrumb_links) }}

--- a/openfecwebapp/templates/partials/hero.html
+++ b/openfecwebapp/templates/partials/hero.html
@@ -1,5 +1,4 @@
 {% import 'macros/search.html' as search %}
-{% import 'macros/page-header.html' as header %}
 
 <section class="hero hero--primary" aria-labelledby="hero-heading">
   <div class="container">

--- a/openfecwebapp/templates/raising-breakdown.html
+++ b/openfecwebapp/templates/raising-breakdown.html
@@ -1,6 +1,10 @@
 {% extends "layouts/sidebar-page.html" %}
 {% import "macros/breakdowns.html" as breakdowns %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/data-landing.css') }}" />
+{% endblock %}
+
 {% block page_title %}
   <h1 class="icon-heading--raising-circle">{{ title }}</h1>
 {% endblock %}

--- a/openfecwebapp/templates/raising-breakdown.html
+++ b/openfecwebapp/templates/raising-breakdown.html
@@ -1,7 +1,7 @@
 {% extends "layouts/sidebar-page.html" %}
 {% import "macros/breakdowns.html" as breakdowns %}
 
-{% block extra_css %}
+{% block css %}
 <link rel="stylesheet" href="{{ asset_for('dist/styles/data-landing.css') }}" />
 {% endblock %}
 

--- a/openfecwebapp/templates/spending-breakdown.html
+++ b/openfecwebapp/templates/spending-breakdown.html
@@ -1,6 +1,10 @@
 {% extends "layouts/sidebar-page.html" %}
 {% import "macros/breakdowns.html" as breakdowns %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ asset_for('dist/styles/data-landing.css') }}" />
+{% endblock %}
+
 {% block page_title %}
   <h1 class="icon-heading--spending-circle">{{ title }}</h1>
 {% endblock %}

--- a/openfecwebapp/templates/spending-breakdown.html
+++ b/openfecwebapp/templates/spending-breakdown.html
@@ -1,7 +1,7 @@
 {% extends "layouts/sidebar-page.html" %}
 {% import "macros/breakdowns.html" as breakdowns %}
 
-{% block extra_css %}
+{% block css %}
 <link rel="stylesheet" href="{{ asset_for('dist/styles/data-landing.css') }}" />
 {% endblock %}
 

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
     "es6-weak-map": "2.0.1",
-    "fec-style": "12.1.0",
+    "fec-style": "13.0.0",
     "glossary-panel": "1.0.0",
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",

--- a/static/styles/base.scss
+++ b/static/styles/base.scss
@@ -1,0 +1,3 @@
+// Base styles for elements shared by all pages
+
+@import 'fec-style/scss/base';

--- a/static/styles/common.scss
+++ b/static/styles/common.scss
@@ -1,3 +1,3 @@
-// Styles for global elements shared by all pages
+// Styles for more general elements over base
 
 @import 'fec-style/scss/common';

--- a/static/styles/common.scss
+++ b/static/styles/common.scss
@@ -1,0 +1,3 @@
+// Styles for global elements shared by all pages
+
+@import 'fec-style/scss/common';

--- a/static/styles/data-landing.scss
+++ b/static/styles/data-landing.scss
@@ -1,4 +1,5 @@
 @import 'fec-style/scss/base';
+
 @import 'fec-style/scss/components/hero';
 @import 'fec-style/scss/components/overviews';
 @import 'fec-style/scss/components/figures';

--- a/static/styles/data-landing.scss
+++ b/static/styles/data-landing.scss
@@ -1,10 +1,16 @@
 @import 'fec-style/scss/base';
 @import 'fec-style/scss/components/hero';
 @import 'fec-style/scss/components/search-bar';
-@import 'fec-style/scss/components/breakdowns';
-@import 'fec-style/scss/components/charts';
 @import 'fec-style/scss/components/overviews';
 @import 'fec-style/scss/components/figures';
 @import 'fec-style/scss/components/icons';
 @import 'fec-style/scss/components/type-styles';
-// @import 'components/reaction-boxes';
+
+// for spending raising breakdown pages
+@import 'fec-style/scss/components/breakdowns';
+@import 'fec-style/scss/components/sidebar';
+@import 'fec-style/scss/components/side-nav';
+@import 'fec-style/scss/components/table-styles';
+@import 'fec-style/scss/components/results-info';
+@import 'fec-style/scss/components/charts';
+

--- a/static/styles/data-landing.scss
+++ b/static/styles/data-landing.scss
@@ -5,5 +5,6 @@
 @import 'fec-style/scss/components/charts';
 @import 'fec-style/scss/components/overviews';
 @import 'fec-style/scss/components/figures';
+@import 'fec-style/scss/components/icons';
 @import 'fec-style/scss/components/type-styles';
 // @import 'components/reaction-boxes';

--- a/static/styles/data-landing.scss
+++ b/static/styles/data-landing.scss
@@ -1,6 +1,5 @@
 @import 'fec-style/scss/base';
 @import 'fec-style/scss/components/hero';
-@import 'fec-style/scss/components/search-bar';
 @import 'fec-style/scss/components/overviews';
 @import 'fec-style/scss/components/figures';
 @import 'fec-style/scss/components/icons';

--- a/static/styles/data-landing.scss
+++ b/static/styles/data-landing.scss
@@ -1,0 +1,7 @@
+@import 'fec-style/scss/base';
+@import 'fec-style/scss/components/hero';
+@import 'fec-style/scss/components/search-bar';
+@import 'fec-style/scss/components/breakdowns';
+@import 'fec-style/scss/components/charts';
+@import 'fec-style/scss/components/overviews';
+// @import 'components/reaction-boxes';

--- a/static/styles/data-landing.scss
+++ b/static/styles/data-landing.scss
@@ -13,3 +13,4 @@
 @import 'fec-style/scss/components/table-styles';
 @import 'fec-style/scss/components/results-info';
 @import 'fec-style/scss/components/charts';
+@import 'fec-style/scss/components/modals';

--- a/static/styles/data-landing.scss
+++ b/static/styles/data-landing.scss
@@ -4,4 +4,6 @@
 @import 'fec-style/scss/components/breakdowns';
 @import 'fec-style/scss/components/charts';
 @import 'fec-style/scss/components/overviews';
+@import 'fec-style/scss/components/figures';
+@import 'fec-style/scss/components/type-styles';
 // @import 'components/reaction-boxes';

--- a/static/styles/data-landing.scss
+++ b/static/styles/data-landing.scss
@@ -13,4 +13,3 @@
 @import 'fec-style/scss/components/table-styles';
 @import 'fec-style/scss/components/results-info';
 @import 'fec-style/scss/components/charts';
-

--- a/static/styles/datatables.scss
+++ b/static/styles/datatables.scss
@@ -1,7 +1,7 @@
 @import 'fec-style/scss/base';
 
 @import 'fec-style/scss/components/accordions';
-
+@import 'fec-style/scss/components/messages';
 @import 'fec-style/scss/components/datatable-panel';
 @import 'fec-style/scss/components/datatables';
 @import 'fec-style/scss/components/results-info';
@@ -14,3 +14,4 @@
 @import 'fec-style/scss/components/toggles';
 @import 'fec-style/scss/components/tooltips';
 @import 'fec-style/scss/components/type-styles';
+@import 'fec-style/scss/components/pagination';

--- a/static/styles/datatables.scss
+++ b/static/styles/datatables.scss
@@ -1,6 +1,5 @@
 @import 'fec-style/scss/base';
 
-@import 'fec-style/scss/components/search-bar';
 @import 'fec-style/scss/components/accordions';
 
 @import 'fec-style/scss/components/datatable-panel';

--- a/static/styles/datatables.scss
+++ b/static/styles/datatables.scss
@@ -1,0 +1,17 @@
+@import 'fec-style/scss/base';
+
+@import 'fec-style/scss/components/search-bar';
+@import 'fec-style/scss/components/accordions';
+
+@import 'fec-style/scss/components/datatable-panel';
+@import 'fec-style/scss/components/datatables';
+@import 'fec-style/scss/components/results-info';
+@import 'fec-style/scss/components/downloads';
+@import 'fec-style/scss/components/data-container';
+@import 'fec-style/scss/components/filters';
+@import 'fec-style/scss/components/date-grid';
+@import 'fec-style/scss/components/dropdowns';
+@import 'fec-style/scss/components/tags';
+@import 'fec-style/scss/components/toggles';
+@import 'fec-style/scss/components/tooltips';
+@import 'fec-style/scss/components/type-styles';

--- a/static/styles/elections.scss
+++ b/static/styles/elections.scss
@@ -4,8 +4,11 @@
 @import 'fec-style/scss/components/entity-header';
 @import 'fec-style/scss/components/datatables';
 @import 'fec-style/scss/components/results-info';
+@import 'fec-style/scss/components/toggles';
+@import 'fec-style/scss/components/filters';
 @import 'fec-style/scss/components/search-controls';
 @import 'fec-style/scss/components/search-results';
 @import 'fec-style/scss/components/page-controls';
 @import 'fec-style/scss/components/headings';
 @import 'fec-style/scss/components/maps';
+

--- a/static/styles/elections.scss
+++ b/static/styles/elections.scss
@@ -11,4 +11,4 @@
 @import 'fec-style/scss/components/page-controls';
 @import 'fec-style/scss/components/headings';
 @import 'fec-style/scss/components/maps';
-
+@import 'fec-style/scss/components/messages';

--- a/static/styles/elections.scss
+++ b/static/styles/elections.scss
@@ -1,0 +1,11 @@
+@import 'leaflet/dist/leaflet';
+
+@import 'fec-style/scss/base';
+@import 'fec-style/scss/components/entity-header';
+@import 'fec-style/scss/components/datatables';
+@import 'fec-style/scss/components/results-info';
+@import 'fec-style/scss/components/search-controls';
+@import 'fec-style/scss/components/search-results';
+@import 'fec-style/scss/components/page-controls';
+@import 'fec-style/scss/components/headings';
+@import 'fec-style/scss/components/maps';

--- a/static/styles/entity.scss
+++ b/static/styles/entity.scss
@@ -1,0 +1,10 @@
+@import 'fec-style/scss/base';
+
+@import 'fec-style/scss/common';
+@import 'fec-style/scss/components/entity-header';
+@import 'fec-style/scss/components/candidate-page';
+@import 'fec-style/scss/components/data-container';
+@import 'fec-style/scss/components/datatables';
+@import 'fec-style/scss/components/table-styles';
+@import 'fec-style/scss/components/results-info';
+@import 'fec-style/scss/components/callouts';

--- a/static/styles/fec.scss
+++ b/static/styles/fec.scss
@@ -1,1 +1,0 @@
-@import "fec-style/scss/styles.scss";

--- a/static/styles/global.scss
+++ b/static/styles/global.scss
@@ -1,0 +1,3 @@
+// Styles for global elements shared by all pages
+
+@import 'fec-style/scss/global';

--- a/static/styles/global.scss
+++ b/static/styles/global.scss
@@ -1,3 +1,0 @@
-// Styles for global elements shared by all pages
-
-@import 'fec-style/scss/global';

--- a/static/styles/legal-common.scss
+++ b/static/styles/legal-common.scss
@@ -1,0 +1,9 @@
+@import 'fec-style/scss/base';
+
+@import 'fec-style/scss/common';
+
+@import 'fec-style/scss/components/legal-search';
+@import 'fec-style/scss/components/search-controls';
+@import 'fec-style/scss/components/posts';
+@import 'fec-style/scss/components/table-styles';
+@import 'datatables';

--- a/static/styles/legal.scss
+++ b/static/styles/legal.scss
@@ -1,7 +1,8 @@
 @import 'fec-style/scss/base';
 
+@import 'datatables';
 @import 'fec-style/scss/components/legal-search';
 @import 'fec-style/scss/components/search-controls';
 @import 'fec-style/scss/components/posts';
+@import 'fec-style/scss/components/headings';
 @import 'fec-style/scss/components/table-styles';
-@import 'datatables';

--- a/static/styles/legal.scss
+++ b/static/styles/legal.scss
@@ -1,0 +1,7 @@
+@import 'fec-style/scss/base';
+
+@import 'fec-style/scss/components/legal-search';
+@import 'fec-style/scss/components/search-controls';
+@import 'fec-style/scss/components/posts';
+@import 'fec-style/scss/components/table-styles';
+@import 'datatables';

--- a/static/styles/styles.scss
+++ b/static/styles/styles.scss
@@ -1,3 +1,0 @@
-// Put overrides here and vendor styles here
-
-@import "leaflet/dist/leaflet";


### PR DESCRIPTION
This supports the CSS refactor from https://github.com/18F/fec-style/pull/743 by creating new stylesheets for specific pages. It also adds a step to the build script to copy over all font files.