### PR TITLE
Fix/line numbers

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -349,8 +349,9 @@ RAISING_FORMATTER = OrderedDict([
     ('individual_contributions',  # F3, F3P, F3X
         {'label': 'Total individual contributions', 'level': '3'}),
     ('individual_itemized_contributions',  # F3, F3P, F3X
-        {'label': 'Itemized individual contributions', 'level': '4',
-            'link': 'individual_contributions'}),
+        {'label': 'Itemized individual contributions', 'level': '4', 'type': {
+            'link': 'receipts', 'P': 'F3P-17A', 'H': 'F3-11AI', 'S': 'F3-11AI', 'O': 'F3X-11AI'
+        }}),
     ('individual_unitemized_contributions',  # F3, F3P, F3X
         {'label': 'Unitemized individual contributions', 'level': '4'}),
     ('political_party_committee_contributions',

--- a/openfecwebapp/templates/macros/tables.html
+++ b/openfecwebapp/templates/macros/tables.html
@@ -1,4 +1,13 @@
 {% macro summary(data, committee_id, cycle, office_or_committee) %}
+
+{% if office_or_committee not in ['P', 'H', 'S'] %}
+  {#
+  Form 3 line numbers are currently coded as type=O, but since more committees
+  use this form, we need to force those all to look for the O value.
+  #}
+  {% set office_or_committee = 'O' %}
+{% endif %}
+
 <figure>
 <table class="simple-table">
   {% for item in data %}


### PR DESCRIPTION
This makes the itemized individual contributions lines in financial summaries go to the receipts page, filtered down to the correct line number.

It also fixes an issue where the line numbers were only being added for `committee_type=O` but setting all non candidate committees to `O` in the financial summary table template in order to get the correct line number value. It's a hacky way to do it, but since we're going to be refactoring how this works soon, it was the quicker, safer solution.