### PR TITLE
Added about menu item to main navigation

### DIFF
--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -101,24 +101,26 @@
 
       <div class="grid grid--6-wide">
 
-        <div class="grid__item"></div>
-
         <div class="grid__item">
           <ul>
             <li>
-              <a href="{{ cms_url }}/about/">About the FEC</a>
+              <a href="{{ cms_url }}/about/">About</a>
             </li>
             <li>
               <a href="{{ cms_url }}/about/careers/">Careers</a>
             </li>
             <li>
-              <a href="{{ cms_url }}/contact-us/">Contact</a>
+              <a href="{{ cms_url }}/press/">Press</a>
             </li>
             <li>
-              <a href="{{ cms_url }}/press/">Press</a>
+              <a href="{{ cms_url }}/contact-us/">Contact</a>
             </li>
           </ul>
         </div>
+
+        <div class="grid__item"></div>
+
+        <div class="grid__item"></div>
 
         <div class="grid__item">
           <ul>
@@ -133,20 +135,6 @@
             </li>
             <li>
               <a href="{{ cms_url }}/about/reports-about-fec/strategy-budget-and-performance/">Strategy, budget and performance</a>
-            </li>
-          </ul>
-        </div>
-
-        <div class="grid__item">
-          <ul>
-            <li>
-              <a href="https://api.open.fec.gov/">OpenFEC API</a>
-            </li>
-            <li>
-              <a href="https://github.com/18F/fec">GitHub repository</a>
-            </li>
-            <li>
-              <a href="https://github.com/18F/FEC/blob/master/release_notes/release_notes.md">Release notes</a>
             </li>
           </ul>
         </div>
@@ -171,7 +159,13 @@
         <div class="grid__item">
           <ul>
             <li>
-              <a href="{{ cms_url }}/updates/">Latest updates</a>
+              <a href="https://api.open.fec.gov/">OpenFEC API</a>
+            </li>
+            <li>
+              <a href="https://github.com/18F/fec">GitHub repository</a>
+            </li>
+            <li>
+              <a href="https://github.com/18F/FEC/blob/master/release_notes/release_notes.md">Release notes</a>
             </li>
           </ul>
         </div>

--- a/openfecwebapp/templates/partials/navigation.html
+++ b/openfecwebapp/templates/partials/navigation.html
@@ -22,7 +22,7 @@
           <span class="site-nav__link__title">Legal resources</span>
         </a>
       </li>
-      <li class="site-nav__item" data-submenu="about">
+      <li class="site-nav__item--secondary" data-submenu="about">
         <a href="{{ cms_url }}/about" tabindex="0" class="site-nav__link {% if parent == 'about' %}is-parent{% endif %}">
           <span class="site-nav__link__title">About</span>
         </a>

--- a/openfecwebapp/templates/partials/navigation.html
+++ b/openfecwebapp/templates/partials/navigation.html
@@ -22,6 +22,11 @@
           <span class="site-nav__link__title">Legal resources</span>
         </a>
       </li>
+      <li class="site-nav__item" data-submenu="about">
+        <a href="{{ cms_url }}/about" tabindex="0" class="site-nav__link {% if parent == 'about' %}is-parent{% endif %}">
+          <span class="site-nav__link__title">About</span>
+        </a>
+      </li>
       <li class="site-nav__item utility-nav__item u-under-lg-only">
         <a class="site-nav__link" href="{{ cms_url }}/calendar">Calendar</a>
       </li>


### PR DESCRIPTION
This is work to add the About menu to the main navigation of the openFEC-web-app: https://github.com/18F/fec-cms/issues/1139

Also updated footer

Dependent on fec-style PR here: https://github.com/18F/fec-style/pull/748