### PR TITLE
Adding SeekPaginator to itemized tables on profile pages

### DIFF
--- a/static/js/pages/candidate-single.js
+++ b/static/js/pages/candidate-single.js
@@ -166,6 +166,7 @@ var individualContributionsColumns = [
     data: 'committee',
     className: 'all',
     orderable: false,
+    paginator: tables.SeekPaginator,
     render: function(data, type, row) {
       return columnHelpers.buildEntityLink(
         row.committee.name,

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -421,6 +421,7 @@ $(document).ready(function() {
             order: [[2, 'desc']],
             useExport: true,
             singleEntityItemizedExport: true,
+            paginator: tables.SeekPaginator,
             hideEmptyOpts: {
               dataType: 'individual contributions',
               name: context.name,
@@ -464,6 +465,7 @@ $(document).ready(function() {
             order: [[3, 'desc']],
             useExport: true,
             singleEntityItemizedExport: true,
+            paginator: tables.SeekPaginator,
             hideEmptyOpts: {
               dataType: 'disbursements to committees',
               name: context.name,


### PR DESCRIPTION
This fixes an issue where the itemized tables on committee pages (and the disbursement table on candidate pages) wouldn't page through.

This is because itemized receipts and disbursement tables (which use `schedule_a` and `schedule_b` endpoints) use the `SeekPaginator` option, which paginates through using `last_index` rather than `page`. 

Resolves https://github.com/18F/FEC/issues/4416