### PR TITLE
Pass html_urls to the front-end

### DIFF
--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -299,6 +299,7 @@ var filings = {
       var pdf_url = row.pdf_url ? row.pdf_url : null;
       var csv_url = row.csv_url ? row.csv_url : null;
       var fec_url = row.fec_url ? row.fec_url : null;
+      var html_url = row.html_url ? row.html_url : null;
 
       // If it's a Form 3L we should append that to the doc title
       if (row.form_type == 'F3L') {
@@ -310,7 +311,8 @@ var filings = {
         amendment_version: amendment_version,
         fec_url: fec_url,
         pdf_url: pdf_url,
-        csv_url: csv_url
+        csv_url: csv_url,
+        html_url: html_url
       });
     }
   },
@@ -537,13 +539,15 @@ var reports = {
       var pdf_url = row.pdf_url ? row.pdf_url : null;
       var csv_url = row.csv_url ? row.csv_url : null;
       var fec_url = row.fec_url ? row.fec_url : null;
+      var html_url = row.html_url ? row.html_url : null;
 
       return reportType({
         doc_description: doc_description,
         amendment_version: amendment_version,
         pdf_url: pdf_url,
         fec_url: fec_url,
-        csv_url: csv_url
+        csv_url: csv_url,
+        html_url: html_url
       });
     }
   },


### PR DESCRIPTION
Now that `html_url` values are reliably populated by the API for filings this adds them to the tables so that the main document name is the web page URL:

![image](https://user-images.githubusercontent.com/1696495/28686772-6303c660-72da-11e7-9058-d696acc2b097.png)
