### PR TITLE
Set default senate cycle to the current two year period

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 START_YEAR = 1979
 END_YEAR = 2018
 DEFAULT_TIME_PERIOD = 2018
+DEFAULT_PRESIDENTIAL_YEAR = 2016
 DISTRICT_MAP_CUTOFF = 2018 # The year we show district maps for on election pages
 
 states = OrderedDict([

--- a/openfecwebapp/templates/macros/filters/election-filter.html
+++ b/openfecwebapp/templates/macros/filters/election-filter.html
@@ -2,9 +2,11 @@
   {% if office == 'president' %}
     {% set duration = 4 %}
     {% set years = range(2020, 1976, -4) %}
+    {% set default_cycle = constants.DEFAULT_PRESIDENTIAL_YEAR %}
   {% elif office == 'senate' %}
     {% set duration = 6 %}
     {% set years = range(2022, 1976, -2) %}
+    {% set default_cycle = constants.DEFAULT_TIME_PERIOD %}
   {% endif %}
   <div
       id="{{ name }}-field"
@@ -14,6 +16,7 @@
       data-cycle-name="{{ cycle_name }}"
       data-full-name="{{ full_name }}"
       data-duration="{{ duration }}"
+      data-default-cycle="{{ default_cycle }}"
     >
   <label class="label" for="{{ name }}">{{ title }}</label>
   <select id="{{name}}" name="{{ name }}" class="js-election select--full">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1696495/28731014-1b908fd6-7387-11e7-86a3-640ce1bdef7d.png)

This makes it so that on https://fec.gov/data/candidates/senate/ , the default time period is whatever the constant `DEFAULT_TIME_PERIOD` is set to (now, 2018). While on https://fec.gov/data/candidates/president/ it stays 2016.

Requires a tweak in fec-style.

Resolves https://github.com/18F/openFEC-web-app/issues/2228