### PR TITLE
Feature/filings filters

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -233,11 +233,11 @@ house_senate_types = OrderedDict([
 ])
 
 table_columns = OrderedDict([
-    ('candidates', ['Name', 'Office', 'Election years', 'Party', 'State', 'District']),
+    ('candidates', ['Name', 'Office', 'Election years', 'Party', 'State', 'District', 'First filing date']),
     ('candidates-office-president', ['Name', 'Party', 'Receipts', 'Disbursements']),
     ('candidates-office-senate', ['Name', 'Party', 'State', 'Receipts', 'Disbursements']),
     ('candidates-office-house', ['Name', 'Party', 'State', 'District', 'Receipts', 'Disbursements']),
-    ('committees', ['Name', 'Treasurer', 'Type', 'Designation']),
+    ('committees', ['Name', 'Treasurer', 'Type', 'Designation', 'First filing date']),
     ('communication-costs', ['Committee', 'Support/Oppose', 'Candidate', 'Amount', 'Date']),
     ('disbursements', ['Spender', 'Recipient', 'State', 'Description', 'Disbursement date', 'Amount']),
     ('electioneering-communications', ['Spender', 'Candidate mentioned','Number of candidates', 'Amount per candidate', 'Date', 'Disbursement amount' ]),

--- a/openfecwebapp/templates/macros/filters/checkbox.html
+++ b/openfecwebapp/templates/macros/filters/checkbox.html
@@ -25,7 +25,7 @@
 {% macro checkbox_dropdown(name, label, selected={}, options={}) %}
 <div class="filter">
   <fieldset class="js-dropdown js-filter" data-filter="checkbox">
-    <label for="{{ name }}">{{ label }}</label>
+    <label for="{{ name }}" class="label">{{ label }}</label>
     {{ checkbox_list(name, selected, css_class='dropdown__selected') }}
     {% if options %}
     {{ checkbox_options(name, options) }}

--- a/openfecwebapp/templates/macros/filters/date.html
+++ b/openfecwebapp/templates/macros/filters/date.html
@@ -1,4 +1,4 @@
-{% macro field(name, label, dates, id_suffix='') %}
+{% macro field(name, label, id_suffix='') %}
   <div class="filter js-filter" id="{{ name }}{{id_suffix}}" data-name="{{ name }}" data-filter="date">
   <fieldset>
     <legend class="label">{{ label }}</legend>
@@ -20,7 +20,7 @@
 </div>
 {% endmacro %}
 
-{% macro partition_field(name, label, dates, show_tooltip=True) %}
+{% macro partition_field(name, label, show_tooltip=True) %}
 <div class="filter">
   <div class="js-filter js-filter-control" data-filter="select" data-validate="true" data-modifies-filter="{{ name }}" data-modifies-property="data-transaction-year" data-required-default="{{ constants.DEFAULT_TIME_PERIOD }}">
     <label class="label t-inline-block" for="two-year-transaction-period">Transaction time period</label>

--- a/openfecwebapp/templates/partials/candidates-filter.html
+++ b/openfecwebapp/templates/partials/candidates-filter.html
@@ -3,6 +3,7 @@
 {% import 'macros/filters/states.html' as states %}
 {% import 'macros/filters/typeahead-filter.html' as typeahead %}
 {% import 'macros/filters/years.html' as years %}
+{% import 'macros/filters/date.html' as date %}
 
 {% block filters %}
 <div class="filters__inner">
@@ -12,6 +13,8 @@
   {% include 'partials/filters/parties.html' %}
   {{ states.field('state') }}
   {% include 'partials/filters/districts.html' %}
+  {% import 'macros/filters/date.html' as date %}
+  {{ date.field('first_filing_date', 'Date first filed statement of candidacy', '') }}
   <div class="filter">
     <fieldset class="js-filter" data-filter="checkbox">
       <legend class="label">Candidate fundraising</legend>

--- a/openfecwebapp/templates/partials/committees-filter.html
+++ b/openfecwebapp/templates/partials/committees-filter.html
@@ -4,6 +4,7 @@
 {% import 'macros/filters/states.html' as states %}
 {% import 'macros/filters/typeahead-filter.html' as typeahead %}
 {% import 'macros/filters/years.html' as years %}
+{% import 'macros/filters/date.html' as date %}
 
 {% block filters %}
 <div class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="false">
@@ -16,6 +17,7 @@
     {{ text.field('treasurer_name', 'Most recent treasurer') }}
     {% include 'partials/filters/parties.html' %}
     {{ states.field('state') }}
+    {{ date.field('first_filing_date', 'Date first filed statement of candidacy', '') }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Committee type</button>
   <div class="accordion__content">

--- a/openfecwebapp/templates/partials/filings-filter.html
+++ b/openfecwebapp/templates/partials/filings-filter.html
@@ -18,7 +18,7 @@ Filter reports
 {% block efiling_filters %}
   <div class="filters__inner">
     {{ typeahead.field('committee_id', 'Committee name or ID', '', id_suffix='_raw') }}
-    {{ date.field('receipt_date', 'Receipt date', dates, id_suffix='_raw') }}
+    {{ date.field('receipt_date', 'Receipt date', id_suffix='_raw') }}
   </div>
 {% endblock %}
 
@@ -33,7 +33,7 @@ Filter reports
   <button type="button" class="js-accordion-trigger accordion__button">Filing date</button>
   <div class="accordion__content">
     {{ years.cycles('cycle', 'Years')  }}
-    {{ date.field('receipt_date', 'Receipt date', dates ) }}
+    {{ date.field('receipt_date', 'Receipt date' ) }}
   </div>
 
   <button type="button" class="js-accordion-trigger accordion__button">Filing information</button>

--- a/openfecwebapp/templates/partials/filings-filter.html
+++ b/openfecwebapp/templates/partials/filings-filter.html
@@ -28,6 +28,9 @@ Filter reports
   <div class="accordion__content">
     {{ typeahead.field('committee_id', 'Committee name or ID', '') }}
     {{ typeahead.field('candidate_id', 'Candidate name or ID', '', dataset='candidates') }}
+    {{ states.field('state') }}
+    {% include 'partials/filters/office-sought.html' %}
+    {% include 'partials/filters/parties.html' %}
   </div>
 
   <button type="button" class="js-accordion-trigger accordion__button">Filing date</button>

--- a/openfecwebapp/templates/partials/independent-expenditures-filter.html
+++ b/openfecwebapp/templates/partials/independent-expenditures-filter.html
@@ -21,7 +21,7 @@ Filter independent expenditures
   {{ typeahead.field('committee_id', 'Spender name or ID', id_suffix='_raw') }}
   {{ text.field('candidate_name', 'Candidate mentioned', id_suffix='_raw')}}
   {{ misc.support_oppose('_raw') }}
-  {{ date.field('expenditure_date', 'Expenditure date', dates, id_suffix='_raw') }}
+  {{ date.field('expenditure_date', 'Expenditure date', id_suffix='_raw') }}
 </div>
 {% endblock %}
 

--- a/openfecwebapp/templates/partials/loans-filter.html
+++ b/openfecwebapp/templates/partials/loans-filter.html
@@ -10,7 +10,7 @@
   <div class="filters__inner">
     {{ typeahead.field('committee_id', 'Committee Name or ID') }}
     {{ text.field('loaner_name', 'Loaner name') }}
-    {{ date.field('incurred_date', 'Incurred date', dates, id_suffix='_raw') }}
+    {{ date.field('incurred_date', 'Incurred date', id_suffix='_raw') }}
     {{ range.amount('payment_to_date', 'Payment to date') }}
     {{ range.amount('amount', 'Original loan amount') }}
  </div>

--- a/openfecwebapp/templates/partials/reports-filter.html
+++ b/openfecwebapp/templates/partials/reports-filter.html
@@ -19,7 +19,7 @@ Filter reports
 {% block efiling_filters %}
   <div class="filters__inner">
     {{ typeahead.field('committee_id', 'Committee name or ID', id_suffix='raw') }}
-    {{ date.field('receipt_date', 'Receipt date', dates, id_suffix='raw') }}
+    {{ date.field('receipt_date', 'Receipt date', id_suffix='raw') }}
   </div>
 {% endblock %}
 
@@ -68,9 +68,9 @@ Filter reports
   <div class="accordion__content">
     {{ years.cycles('cycle', 'Years')  }}
     {% if table_context['form_type'] == 'pac-party' %}
-      {{ date.partition_field('receipt_date', 'Receipt date', dates, show_tooltip=False) }}
+      {{ date.partition_field('receipt_date', 'Receipt date', show_tooltip=False) }}
     {% else %}
-      {{ date.field('receipt_date', 'Receipt date', dates ) }}
+      {{ date.field('receipt_date', 'Receipt date' ) }}
     {% endif %}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Report type</button>

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -141,6 +141,7 @@ var candidates = [
   {data: 'party_full', className: 'min-tablet hide-panel'},
   {data: 'state', className: 'min-desktop hide-panel column--state'},
   {data: 'district', className: 'min-desktop hide-panel column--small'},
+  {data: 'first_filing_date', orderable: true, className: 'min-desktop hide-panel column--small'},
   modalTriggerColumn
 ];
 
@@ -172,6 +173,7 @@ var committees = [
   {data: 'treasurer_name', className: 'min-desktop hide-panel'},
   {data: 'committee_type_full', className: 'min-tablet hide-panel'},
   {data: 'designation_full', className: 'min-tablet hide-panel'},
+  {data: 'first_filing_date', orderable: true, className: 'min-desktop hide-panel column--small'},
   modalTriggerColumn
 ];
 

--- a/static/js/pages/candidates.js
+++ b/static/js/pages/candidates.js
@@ -13,6 +13,7 @@ $(document).ready(function() {
     title: 'Candidate',
     path: ['candidates'],
     columns: columns.candidates,
+    order: [[6, 'desc']],
     useFilters: true,
     useExport: true,
     rowCallback: tables.modalRenderRow,

--- a/static/js/pages/committees.js
+++ b/static/js/pages/committees.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
     columns: columns.committees,
     useFilters: true,
     useExport: true,
-    order: [[0, 'asc']],
+    order: [[4, 'desc']],
     rowCallback: tables.modalRenderRow,
     callbacks: {
       afterRender: tables.modalRenderFactory(committeesTemplate)


### PR DESCRIPTION
This implements the front-end changes to take advantage of the API data provided in https://github.com/18F/openFEC/pull/2550

- Adds state, office and party filters to /filings
- Adds a filter for "first filing date" to candidate and committee pages, along with a column for this and makes it so that these pages sort reverse-chronological on that field so that users see the most recent new candidates and committees by default


Resolves https://github.com/18F/openFEC/issues/2378