### PR TITLE
Use public API key for client-side calls

### DIFF
--- a/openfecwebapp/templates/layouts/main.html
+++ b/openfecwebapp/templates/layouts/main.html
@@ -18,7 +18,7 @@
     CMS_URL = '{{ cms_url }}',
     API_LOCATION = '{{ api_location }}';
     API_VERSION = '{{ api_version }}';
-    API_KEY = '{{ api_key }}';
+    API_KEY = '{{ api_key_public }}';
     DEFAULT_TIME_PERIOD = '{{ constants.DEFAULT_TIME_PERIOD }}';
     START_YEAR = '{{ constants.START_YEAR }}';
     END_YEAR = '{{ constants.END_YEAR }}';


### PR DESCRIPTION
We already have a public key in the env and already look it up in `config.py` so this just passes it through to the Javascript. 

Resolves https://github.com/18F/openFEC-web-app/issues/2234