### PR TITLE
[MERGE WITH GIT FLOW] Adding SeekPaginator to itemized tables on profile pages

### DIFF
--- a/static/js/pages/candidate-single.js
+++ b/static/js/pages/candidate-single.js
@@ -166,6 +166,7 @@ var individualContributionsColumns = [
     data: 'committee',
     className: 'all',
     orderable: false,
+    paginator: tables.SeekPaginator,
     render: function(data, type, row) {
       return columnHelpers.buildEntityLink(
         row.committee.name,

--- a/static/js/pages/committee-single.js
+++ b/static/js/pages/committee-single.js
@@ -421,6 +421,7 @@ $(document).ready(function() {
             order: [[2, 'desc']],
             useExport: true,
             singleEntityItemizedExport: true,
+            paginator: tables.SeekPaginator,
             hideEmptyOpts: {
               dataType: 'individual contributions',
               name: context.name,
@@ -464,6 +465,7 @@ $(document).ready(function() {
             order: [[3, 'desc']],
             useExport: true,
             singleEntityItemizedExport: true,
+            paginator: tables.SeekPaginator,
             hideEmptyOpts: {
               dataType: 'disbursements to committees',
               name: context.name,


### PR DESCRIPTION
This fixes some bugs where transaction tables on candidate and commitee pages wouldn't paginate correctly. This is because we have two types of paginators: the default is `OffsetPaginator` which uses `page=X` to page through. Schedule A and B tables use `SeekPaginator` which uses the `last_index` value to page through. 

To test, verify that the itemized tables on [this page](http://localhost:3000/committee/C00580100/?tab=spending) and [this page](http://localhost:3000/candidate/P80001571/?cycle=2020&tab=raising) can page through.