### PR TITLE
Adding cms_url to manifests

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -4,6 +4,7 @@ host: fec-dev-web
 services:
   - fec-creds-dev
 env:
+  FEC_CMS_URL: https://fec-dev-proxy.app.cloud.gov
   FEC_WEB_API_URL: https://fec-dev-api.app.cloud.gov
   FEC_WEB_DEBUG: true
   FEC_WEB_ENVIRONMENT: dev

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -5,6 +5,7 @@ instances: 4
 services:
   - fec-creds-prod
 env:
+  FEC_CMS_URL: https://www.fec.gov
   FEC_WEB_API_URL: https://api.open.fec.gov/
   FEC_WEB_CACHE: true
   FEC_WEB_ENVIRONMENT: prod

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -4,6 +4,7 @@ host: fec-stage-web
 services:
   - fec-creds-stage
 env:
+  FEC_CMS_URL: https://fec-stage-proxy.app.cloud.gov
   FEC_WEB_API_URL: https://api-stage.open.fec.gov/
   FEC_WEB_DEBUG: true
   FEC_WEB_ENVIRONMENT: stage


### PR DESCRIPTION
The issue with the "Home" link in the breadcrumbs not linking to the home page (https://github.com/18F/openFEC-web-app/issues/2244) appears to be due to a missing `FEC_CMS_URL` env variable. This adds it to the manifests for all three environments.

Resolves https://github.com/18F/openFEC-web-app/issues/2244