### PR TITLE
Extend efiling window + refactor

### DIFF
--- a/openfecwebapp/app.py
+++ b/openfecwebapp/app.py
@@ -147,7 +147,7 @@ app.jinja_env.globals.update({
     'series_group_has_data': series_group_has_data,
     'cycle_start': cycle_start,
     'cycle_end': cycle_end,
-    'two_days_ago': utils.two_days_ago(),
+    'efiling_window': utils.n_days_ago(constants.EFILING_WINDOW),
     'election_url': get_election_url,
     'constants': constants,
     'cycles': utils.get_cycles(),

--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -5,6 +5,7 @@ END_YEAR = 2018
 DEFAULT_TIME_PERIOD = 2018
 DEFAULT_PRESIDENTIAL_YEAR = 2016
 DISTRICT_MAP_CUTOFF = 2018 # The year we show district maps for on election pages
+EFILING_WINDOW = 3 # The number of days to show raw efilings on a committee page
 
 states = OrderedDict([
     ('AK', 'Alaska'),

--- a/openfecwebapp/templates/macros/entity-pages.html
+++ b/openfecwebapp/templates/macros/entity-pages.html
@@ -38,9 +38,9 @@
         </a>
       </div>
       <div class="tag__category">
-        <div class="tag__item">Filed on or after: {{two_days_ago}}</div>
+        <div class="tag__item">Filed on or after: {{efiling_window}}</div>
       </div>
-      <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="raw-filings" data-min-date="{{ two_days_ago }}" data-cycle="{{ cycle }}" data-committee="{{ committee_id }}">
+      <table class="data-table data-table--heading-borders data-table--entity u-margin--top" data-type="raw-filings" data-min-date="{{ efiling_window }}" data-cycle="{{ cycle }}" data-committee="{{ committee_id }}">
         <thead>
           <th scope="col">Document</th>
           <th scope="col">Coverage start date</th>

--- a/openfecwebapp/utils.py
+++ b/openfecwebapp/utils.py
@@ -207,7 +207,7 @@ def get_state_senate_cycles(state):
             senate_cycles += get_senate_cycles(senate_class)
     return senate_cycles
 
-def two_days_ago():
-    """Find the date two days ago"""
-    two_days_ago = datetime.datetime.today() - datetime.timedelta(days=2)
-    return two_days_ago.strftime('%m/%d/%y')
+def n_days_ago(n):
+    """Find the date n days ago"""
+    n_days_ago = datetime.datetime.today() - datetime.timedelta(days=n)
+    return n_days_ago.strftime('%m/%d/%y')

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -19,6 +19,7 @@ from werkzeug.utils import cached_property
 from openfecwebapp import config
 from openfecwebapp import api_caller
 from openfecwebapp import utils
+from openfecwebapp import constants
 
 
 def render_search_results(results, query):

--- a/openfecwebapp/views.py
+++ b/openfecwebapp/views.py
@@ -153,13 +153,13 @@ def render_committee(committee, candidates, cycle, redirect_to_previous):
                 )
 
     # If it's not a senate committee and we're in the current cycle
-    # check if there's any raw filings in the last two days
+    # check if there's any raw filings in the last few days, whatever EFILING_WINDOW is set to
     if committee['committee_type'] != 'S' and cycle == utils.current_cycle():
         raw_filings = api_caller._call_api(
             'efile', 'filings',
             cycle=cycle,
             committee_id=committee['committee_id'],
-            min_receipt_date=utils.two_days_ago()
+            min_receipt_date=utils.n_days_ago(constants.EFILING_WINDOW)
         )
         if len(raw_filings.get('results')) > 0:
             tmpl_vars['has_raw_filings'] = True

--- a/static/styles/elections.scss
+++ b/static/styles/elections.scss
@@ -9,7 +9,6 @@
 @import "fec-style/scss/components/filters";
 @import "fec-style/scss/components/search-controls";
 @import "fec-style/scss/components/search-results";
-@import "fec-style/scss/components/page-controls";
 @import "fec-style/scss/components/headings";
 @import "fec-style/scss/components/maps";
 @import "fec-style/scss/components/messages";


### PR DESCRIPTION
This extends the window for showing efilings on a committee page from two days to three, for all the [reasons laid out here](https://github.com/18F/openFEC-web-app/issues/2179). 

It also makes this a little easier to configure by making the previous `two_days_ago` filter into `n_days_ago` and then setting a constant for `EFILING_WINDOW`.

Resolves https://github.com/18F/openFEC-web-app/issues/2179