### PR TITLE
Add links to election pages from data landing

### DIFF
--- a/openfecwebapp/routes.py
+++ b/openfecwebapp/routes.py
@@ -46,7 +46,9 @@ def search():
             page='home',
             parent='data',
             dates=utils.date_ranges(),
-            top_candidates_raising = top_candidates_raising['results'] if top_candidates_raising else None,
+            top_candidates_raising=top_candidates_raising['results'] if top_candidates_raising else None,
+            first_of_year=datetime.date(datetime.date.today().year, 1, 1).strftime('%m/%d/%Y'),
+            last_of_year=datetime.date(datetime.date.today().year, 12, 31).strftime('%m/%d/%Y'),
             title='Campaign finance data')
 
 

--- a/openfecwebapp/templates/candidates-single.html
+++ b/openfecwebapp/templates/candidates-single.html
@@ -107,7 +107,9 @@
             </ul>
         </li>
         <li class="side-nav__item">
-          <a class="button button--cta u-margin--top t-left-aligned button--two-candidates u-full-width">Compare to<br>opposing candidates</a>
+          <a class="button button--cta u-margin--top t-left-aligned button--two-candidates u-full-width"
+             href="{{ election_url(context(), cycle)}}"
+          >Compare to<br>opposing candidates</a>
         </li>
       </ul>
     </nav>

--- a/openfecwebapp/templates/candidates-single.html
+++ b/openfecwebapp/templates/candidates-single.html
@@ -108,8 +108,7 @@
         </li>
         <li class="side-nav__item">
           <a class="button button--cta u-margin--top t-left-aligned button--two-candidates u-full-width"
-             href="{{ election_url(context(), cycle)}}"
-          >Compare to<br>opposing candidates</a>
+             href="{{ election_url(context(), cycle)}}">Compare to<br>opposing candidates</a>
         </li>
       </ul>
     </nav>

--- a/openfecwebapp/templates/elections.html
+++ b/openfecwebapp/templates/elections.html
@@ -75,12 +75,12 @@
           <div class="accordion--neutral js-accordion" data-accordion-prefix="election-lookup">
             <button class="js-accordion-trigger accordion__button">Find another election</button>
             <div class="accordion__content" aria-hidden="true">
-              <form action="{{ url_for('election_lookup')}}">
+              <form action="{{ url_for('election_page')}}" id="election-nav">
                 <div class="filter">
                   <label for="state" class="label">State</label>
                   <select id="state" name="state" class="u-full-width">
                     <option value="">Select state</option>
-                    {% for value, label in constants.states.items() %}
+                    {% for value, label in constants.election_states.items() %}
                     <option value="{{ value }}">{{ label }}</option>
                     {% endfor %}
                   </select>
@@ -89,11 +89,14 @@
                   <label for="district" class="label">District <span class="label__optional">(optional)</span></label>
                   <select id="district" name="district" aria-label="Select a district" class="select--alt u-full-width">
                     <option value="">Select district</option>
-                    {% for value in range(1, 100) %}
-                    {% with formatted = '{0:02d}'.format(value) %}
-                    <option value="{{ formatted }}">{{ formatted }}</option>
-                    {% endwith %}
-                    {% endfor %}
+                    <option value="S">Senate</option>
+                    <optgroup label="House">
+                      {% for value in range(1, 100) %}
+                      {% with formatted = '{0:02d}'.format(value) %}
+                      <option value="{{ formatted }}">{{ formatted }}</option>
+                      {% endwith %}
+                      {% endfor %}
+                    </optgroup>
                   </select>
                 </div>
                 <div class="filter">

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -102,9 +102,9 @@
         <div class="example--primary">
           <h4 class="example__title">Trending elections</h4>
           <ul class="t-sans">
-            <li><a href="">Georgia, congressional district 6 special election</a></li>
-            <li><a href="">Alabama senate special election</a></li>
-            <li><a href="">2016 US presidential election</a></li>
+            <li><a href="{{ url_for('elections', office="house", state="GA", district="6", cycle="2018") }}">Georgia, congressional district 6 special election</a></li>
+            <li><a href="{{ url_for('elections', office="senate", state="AL", cycle="2018") }}">Alabama senate special election</a></li>
+            <li><a href="{{ url_for('elections', office="president", cycle="2016") }}">2016 US presidential election</a></li>
           </ul>
         </div>
       </div>

--- a/openfecwebapp/templates/landing.html
+++ b/openfecwebapp/templates/landing.html
@@ -55,7 +55,7 @@
           <h4 class="example__title">Possible uses of this data:</h4>
           <ul class="t-sans">
             <li><a href="{{ url_for('individual_contributions', min_amount=2000) }}">All contributions over $2,000</a></li>
-            <li><a href="{{ url_for('individual_contributions', min_amount=2000) }}">All contributions in the last month</a></li>
+            <li><a href="{{ url_for('individual_contributions', min_date=first_of_year, max_date=last_of_year) }}">All contributions this year</a></li>
             <li><a href="{{ url_for('individual_contributions') }}">Browse all and apply custom filters</a></li>
           </ul>
         </div>

--- a/openfecwebapp/templates/partials/candidate/about-candidate.html
+++ b/openfecwebapp/templates/partials/candidate/about-candidate.html
@@ -66,7 +66,7 @@
               <img class="icon--complex" src="/static/img/i-elections--primary.svg" alt="Icon representing elections">
             </div>
             <div class="card__content">
-              View all candidates in the {{ election_year }} {{ constants.states[state] }} {% if office == 'P' %}Presidential{% else %}{{ office_full }}{% endif %}{% if office_full == 'House' %} district {{ district }}{% endif %} election
+              View all candidates in the {{ election_year }} {{ constants.states[state] }} {% if office == 'P' %}Presidential{% else %}{{ office_full }}{% endif %}{% if office_full == 'House' %} District {{ district|strip_zero_pad }}{% endif %} election
             </div>
           </a>
           {% endif %}

--- a/openfecwebapp/templates/partials/candidate/about-candidate.html
+++ b/openfecwebapp/templates/partials/candidate/about-candidate.html
@@ -61,7 +61,7 @@
       <div class="usa-width-one-fourth">
         <div class="card">
           {% if election_url(context(), cycle) %}
-          <a href="{{ election_url(context(), election_year) }}">
+          <a href="{{ election_url(context(), cycle) }}">
             <div class="card__image__container">
               <img class="icon--complex" src="/static/img/i-elections--primary.svg" alt="Icon representing elections">
             </div>

--- a/static/js/modules/election-form.js
+++ b/static/js/modules/election-form.js
@@ -88,7 +88,8 @@ ElectionForm.prototype.updateDistricts = function(state) {
  * @param {object} query - the query to pass to the URL
  */
 ElectionForm.prototype.getUrl = function(query) {
-  return helpers.buildUrl(['elections', 'search'], query);
+  var params = _.extend({}, {per_page: 100}, query);
+  return helpers.buildUrl(['elections', 'search'], params);
 };
 
 /**

--- a/static/js/modules/election-form.js
+++ b/static/js/modules/election-form.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var $ = require('jquery');
 var _ = require('underscore');
 var helpers = require('./helpers');
 var utils = require('./election-utils');
@@ -13,7 +14,14 @@ var districtTemplate = require('../../templates/districts.hbs');
  * Both the ElectionSearch and ElectionLookup inherit from this class
  * It handles all logic around showing districts for the district select
  */
-function ElectionForm() { }
+function ElectionForm(elm) {
+  this.$elm = $(elm);
+  this.$state = this.$elm.find('[name="state"]');
+  this.$district = this.$elm.find('[name="district"]').prop('disabled', true);
+  this.$submit = this.$elm.find('[type="submit"]');
+  this.showSenateOption = true;
+  this.$state.on('change', this.handleStateChange.bind(this));
+}
 
 /**
  * Identify if a select has an option matching a particular value

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -15,7 +15,7 @@ var tables = require('../modules/tables');
 var columnHelpers = require('../modules/column-helpers');
 var columns = require('../modules/columns');
 var helpers = require('../modules/helpers');
-var ElectionForm = require('../modules/election-form').ElectionForm;
+var electionForm = require('../modules/election-form');
 
 var comparisonTemplate = require('../../templates/comparison.hbs');
 var candidateStateMapTemplate = require('../../templates/candidateStateMap.hbs');
@@ -538,5 +538,5 @@ $(document).ready(function() {
 
   initSpendingTables();
 
-  new ElectionForm('#election-nav');
+  new electionForm.ElectionForm('#election-nav');
 });

--- a/static/js/pages/elections.js
+++ b/static/js/pages/elections.js
@@ -15,6 +15,7 @@ var tables = require('../modules/tables');
 var columnHelpers = require('../modules/column-helpers');
 var columns = require('../modules/columns');
 var helpers = require('../modules/helpers');
+var ElectionForm = require('../modules/election-form').ElectionForm;
 
 var comparisonTemplate = require('../../templates/comparison.hbs');
 var candidateStateMapTemplate = require('../../templates/candidateStateMap.hbs');
@@ -536,4 +537,6 @@ $(document).ready(function() {
   }
 
   initSpendingTables();
+
+  new ElectionForm('#election-nav');
 });

--- a/static/styles/elections.scss
+++ b/static/styles/elections.scss
@@ -9,7 +9,6 @@
 @import "fec-style/scss/components/filters";
 @import "fec-style/scss/components/search-controls";
 @import "fec-style/scss/components/search-results";
-@import "fec-style/scss/components/page-controls";
 @import "fec-style/scss/components/headings";
 @import "fec-style/scss/components/maps";
 @import "fec-style/scss/components/messages";

--- a/tests/unit/modules/election-search.js
+++ b/tests/unit/modules/election-search.js
@@ -160,7 +160,7 @@ describe('election search', function() {
       var call = $.ajax.getCall(0);
       var uri = URI(call.args[0].url);
       expect(uri.path()).to.equal('/v1/elections/search/');
-      expect(URI.parseQuery(uri.search())).to.deep.equal({api_key: '12345', cycle: '2016', zip: '19041'});
+      expect(URI.parseQuery(uri.search())).to.deep.equal({api_key: '12345', per_page: '100', cycle: '2016', zip: '19041'});
       expect(URI.parseQuery(window.location.search)).to.deep.equal({cycle: '2016', zip: '19041'});
       expect(this.el.draw).to.have.been.calledWith(this.response.results);
     });
@@ -174,7 +174,7 @@ describe('election search', function() {
       var call = $.ajax.getCall(0);
       var uri = URI(call.args[0].url);
       expect(uri.path()).to.equal('/v1/elections/search/');
-      expect(URI.parseQuery(uri.search())).to.deep.equal({api_key: '12345', cycle: '2016', zip: '19041'});
+      expect(URI.parseQuery(uri.search())).to.deep.equal({api_key: '12345', per_page: '100', cycle: '2016', zip: '19041'});
     });
 
     it('should skip search if missing params', function() {


### PR DESCRIPTION
I forgot to include actual links on this part of the data landing, so this adds them:

![image](https://user-images.githubusercontent.com/1696495/29281960-d0101d72-80d5-11e7-838b-916b29338ca7.png)

It also adds the correct link to the election page from candidate pages:
![image](https://user-images.githubusercontent.com/1696495/29292737-22cfb690-80fd-11e7-96da-c060c1e70614.png)

And updates the state + district selects on election pages to go to the page similar to how it works on the data landing page:
![image](https://user-images.githubusercontent.com/1696495/29292759-3b66489a-80fd-11e7-89f3-d10f3e956ef4.png)

And last, I fixed an issue where not all district results were showing up when doing a state search by adding `per_page=100` to API calls for the election lookup. Resolves https://github.com/18F/openFEC-web-app/issues/2256