### PR TITLE
Add missing CSS files to candidate and committee pages

### DIFF
--- a/static/styles/entity.scss
+++ b/static/styles/entity.scss
@@ -5,6 +5,8 @@
 @import "fec-style/scss/components/candidate-page";
 @import "fec-style/scss/components/data-container";
 @import "fec-style/scss/components/datatables";
+@import "fec-style/scss/components/datatable-panel";
+@import "fec-style/scss/components/downloads";
 @import "fec-style/scss/components/table-styles";
 @import "fec-style/scss/components/results-info";
 @import "fec-style/scss/components/callouts";


### PR DESCRIPTION
The committee pages were missing styles for the data table panel and download widget. This adds them.