### PR TITLE
Add Alabama to 2018 senate class

### DIFF
--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -630,13 +630,15 @@ IE_FORMATTER = OrderedDict([
 ])
 
 SENATE_CLASSES = {
-    '1': ['AL', 'AZ', 'CA', 'CT', 'DE', 'FL', 'HI', 'IN', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NJ', 'NM', 'NY', 'ND', 'OH', 'PA', 'RI', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'],
+    '1': ['AZ', 'CA', 'CT', 'DE', 'FL', 'HI', 'IN', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NJ', 'NM', 'NY', 'ND', 'OH', 'PA', 'RI', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'],
     '2': ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'MD', 'MO', 'NV', 'NH', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'SC', 'SD', 'UT', 'VT', 'WA', 'WI'],
-    '3': ['AL', 'AK', 'AR', 'CO', 'DE', 'GA', 'ID', 'IL', 'IA', 'KS', 'KY', 'LA', 'ME', 'MA', 'MI', 'MN', 'MS', 'MT', 'NE', 'NH', 'NJ', 'NM', 'NC', 'OK', 'OR', 'RI', 'SC', 'SD', 'TN', 'TX', 'VA', 'WV', 'WY']
+    '3': ['AL', 'AK', 'AR', 'CO', 'DE', 'GA', 'ID', 'IL', 'IA', 'KS', 'KY', 'LA', 'ME', 'MA', 'MI', 'MN', 'MS', 'MT', 'NE', 'NH', 'NJ', 'NM', 'NC', 'OK', 'OR', 'RI', 'SC', 'SD', 'TN', 'TX', 'VA', 'WV', 'WY'],
+    'special': ['AL']
 }
 
 NEXT_SENATE_ELECTIONS = {
     '1': 2018,
     '2': 2022,
-    '3': 2020
+    '3': 2020,
+    'special': 2018
 }

--- a/openfecwebapp/constants.py
+++ b/openfecwebapp/constants.py
@@ -630,7 +630,7 @@ IE_FORMATTER = OrderedDict([
 ])
 
 SENATE_CLASSES = {
-    '1': ['AZ', 'CA', 'CT', 'DE', 'FL', 'HI', 'IN', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NJ', 'NM', 'NY', 'ND', 'OH', 'PA', 'RI', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'],
+    '1': ['AL', 'AZ', 'CA', 'CT', 'DE', 'FL', 'HI', 'IN', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NJ', 'NM', 'NY', 'ND', 'OH', 'PA', 'RI', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'],
     '2': ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'MD', 'MO', 'NV', 'NH', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'SC', 'SD', 'UT', 'VT', 'WA', 'WI'],
     '3': ['AL', 'AK', 'AR', 'CO', 'DE', 'GA', 'ID', 'IL', 'IA', 'KS', 'KY', 'LA', 'ME', 'MA', 'MI', 'MN', 'MS', 'MT', 'NE', 'NH', 'NJ', 'NM', 'NC', 'OK', 'OR', 'RI', 'SC', 'SD', 'TN', 'TX', 'VA', 'WV', 'WY']
 }

--- a/openfecwebapp/templates/partials/candidates-filter.html
+++ b/openfecwebapp/templates/partials/candidates-filter.html
@@ -14,7 +14,7 @@
   {{ states.field('state') }}
   {% include 'partials/filters/districts.html' %}
   {% import 'macros/filters/date.html' as date %}
-  {{ date.field('first_filing_date', 'Date first filed statement of candidacy', '') }}
+  {{ date.field('first_file_date', 'Date first filed statement of candidacy', '') }}
   <div class="filter">
     <fieldset class="js-filter" data-filter="checkbox">
       <legend class="label">Candidate fundraising</legend>

--- a/openfecwebapp/templates/partials/committees-filter.html
+++ b/openfecwebapp/templates/partials/committees-filter.html
@@ -17,7 +17,7 @@
     {{ text.field('treasurer_name', 'Most recent treasurer') }}
     {% include 'partials/filters/parties.html' %}
     {{ states.field('state') }}
-    {{ date.field('first_filing_date', 'Date first filed statement of candidacy', '') }}
+    {{ date.field('first_file_date', 'Date first filed statement of candidacy', '') }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Committee type</button>
   <div class="accordion__content">

--- a/openfecwebapp/utils.py
+++ b/openfecwebapp/utils.py
@@ -202,7 +202,7 @@ def get_senate_cycles(senate_class):
 
 def get_state_senate_cycles(state):
     senate_cycles = []
-    for senate_class in [1, 2, 3]:
+    for senate_class in ['1', '2', '3', 'special']:
         if state.upper() in constants.SENATE_CLASSES[str(senate_class)]:
             senate_cycles += get_senate_cycles(senate_class)
     return senate_cycles

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "datatables.net": "1.10.10",
     "datatables.net-responsive": "2.0.1",
     "es6-weak-map": "2.0.1",
-    "fec-style": "14.2.0",
+    "fec-style": "14.2.1",
     "glossary-panel": "1.0.0",
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",

--- a/static/js/modules/columns.js
+++ b/static/js/modules/columns.js
@@ -141,7 +141,7 @@ var candidates = [
   {data: 'party_full', className: 'min-tablet hide-panel'},
   {data: 'state', className: 'min-desktop hide-panel column--state'},
   {data: 'district', className: 'min-desktop hide-panel column--small'},
-  {data: 'first_filing_date', orderable: true, className: 'min-desktop hide-panel column--small'},
+  {data: 'first_file_date', orderable: true, className: 'min-desktop hide-panel column--small'},
   modalTriggerColumn
 ];
 
@@ -173,7 +173,7 @@ var committees = [
   {data: 'treasurer_name', className: 'min-desktop hide-panel'},
   {data: 'committee_type_full', className: 'min-tablet hide-panel'},
   {data: 'designation_full', className: 'min-tablet hide-panel'},
-  {data: 'first_filing_date', orderable: true, className: 'min-desktop hide-panel column--small'},
+  {data: 'first_file_date', orderable: true, className: 'min-desktop hide-panel column--small'},
   modalTriggerColumn
 ];
 


### PR DESCRIPTION
Currently on staging, going to [Alabama Senate 2018](https://fec-stage-proxy.app.cloud.gov/data/elections/senate/AL/2018/), the cycle select shows 2021-2022, which is the date of the next election. 

![image](https://user-images.githubusercontent.com/1696495/29593330-8328beda-875e-11e7-9ec2-a94b8bb419cd.png)

This change adds Alabama to the 2018 Senate class.