### PR TITLE
[MERGE WITH GIT FLOW] Fixing label on committee F1 filter

### DIFF
--- a/openfecwebapp/templates/partials/committees-filter.html
+++ b/openfecwebapp/templates/partials/committees-filter.html
@@ -17,7 +17,7 @@
     {{ text.field('treasurer_name', 'Most recent treasurer') }}
     {% include 'partials/filters/parties.html' %}
     {{ states.field('state') }}
-    {{ date.field('first_file_date', 'Date first filed statement of candidacy', '') }}
+    {{ date.field('first_file_date', 'Date first filed statement of organization', '') }}
   </div>
   <button type="button" class="js-accordion-trigger accordion__button">Committee type</button>
   <div class="accordion__content">


### PR DESCRIPTION
I just noticed that the "first filing date" filter on [the committees page](https://www.fec.gov/data/committees/?min_first_file_date=08%2F10%2F2017) is labelled incorrectly. It should be statement of organization, not statement of candidacy.