### PR TITLE
[MERGE WITH GITFLOW] Added legal-common.css to mur templates

### DIFF
--- a/openfecwebapp/templates/legal-archived-mur.html
+++ b/openfecwebapp/templates/legal-archived-mur.html
@@ -7,7 +7,7 @@
 {% block title %}MUR #{{ mur.no }}{% endblock %}
 
 {% block css %}
-<link rel=“stylesheet” href=“{{ asset_for(‘dist/styles/legal-common.css’) }}” />
+<link rel="stylesheet" href="{{ asset_for('dist/styles/legal-common.css') }}" />
 {% endblock %}
 
 {% block body %}

--- a/openfecwebapp/templates/legal-archived-mur.html
+++ b/openfecwebapp/templates/legal-archived-mur.html
@@ -6,6 +6,10 @@
 
 {% block title %}MUR #{{ mur.no }}{% endblock %}
 
+{% block css %}
+<link rel=“stylesheet” href=“{{ asset_for(‘dist/styles/legal-common.css’) }}” />
+{% endblock %}
+
 {% block body %}
 <header class="page-header slab slab--primary">
   {{ breadcrumb.breadcrumbs('MUR #%s' % (mur.no,), breadcrumb_links) }}

--- a/openfecwebapp/templates/legal-current-mur.html
+++ b/openfecwebapp/templates/legal-current-mur.html
@@ -4,6 +4,10 @@
 
 {% block title %}MUR #{{ mur.no }}{% endblock %}
 
+{% block css %}
+<link rel=“stylesheet” href=“{{ asset_for(‘dist/styles/legal-common.css’) }}” />
+{% endblock %}
+
 {% block body %}
 <header class="page-header slab slab--primary">
   {{ breadcrumb.breadcrumbs('MUR #%s' % (mur.no,), breadcrumb_links) }}

--- a/openfecwebapp/templates/legal-current-mur.html
+++ b/openfecwebapp/templates/legal-current-mur.html
@@ -5,7 +5,7 @@
 {% block title %}MUR #{{ mur.no }}{% endblock %}
 
 {% block css %}
-<link rel=“stylesheet” href=“{{ asset_for(‘dist/styles/legal-common.css’) }}” />
+<link rel="stylesheet" href="{{ asset_for('dist/styles/legal-common.css') }}" />
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
Fixing styling issues with MUR pages by adding this to MUR templates:
{% block css %}
<link rel=“stylesheet” href=“{{ asset_for(‘dist/styles/legal-common.css’) }}” />
{% endblock %} 